### PR TITLE
initial support for systemd

### DIFF
--- a/README.md
+++ b/README.md
@@ -660,3 +660,61 @@ stdin:
         - stdin
 
 ```
+
+## Using resticprofile and systemd
+
+systemd is a common service manager in use by many Linux distributions.
+resticprofile has the ability to autocreate systemd timer and service files.
+systemd can be used in place of cron to schedule backups.
+
+All systemd units are created under the user's systemd profile (~/.config/systemd/user).
+
+TODO: create system profiles
+
+### systemd calendars
+
+resticprofile uses systemd
+[OnCalendar](https://www.freedesktop.org/software/systemd/man/systemd.time.html#Calendar%20Events)
+format to schedule events.
+
+Testing systemd calendars can be done with the systemd-analyze application.
+systemd-analyze will display when the next trigger will happen:
+
+```
+$ systemd-analyze calendar 'daly'
+  Original form: daily
+Normalized form: *-*-* 00:00:00
+    Next elapse: Sat 2020-04-18 00:00:00 CDT
+       (in UTC): Sat 2020-04-18 05:00:00 UTC
+       From now: 10h left
+```
+
+### Configuring a systemd profile
+
+Running the following command will create a timer and systemd unit for the
+'configs' profile name within resticprofile. 
+
+```
+$ resticprofile -n configs systemd-unit daily
+2020/04/17 13:34:07 resticprofile 0.6.0 compiled with go1.14.2
+2020/04/17 13:34:07 Writing /home/<user>/.config/systemd/user/resticprofile-backup@configs.service
+2020/04/17 13:34:07 Writing /home/<user>/.config/systemd/user/resticprofile-backup@configs.timer
+```
+
+The service can be tested or run once with:
+
+```
+$ systemctl --user start resticprofile-backup@configs.service
+```
+
+Or, starting the timer will enable the schedule:
+```
+$ systemctl --user start resticprofile-backup@configs.timer
+```
+
+To persist the timer across reboots, replace `start` with enable:
+
+```
+$ systemctl --user enable resticprofile-backup@configs.timer
+```
+

--- a/constants/command.go
+++ b/constants/command.go
@@ -2,11 +2,12 @@ package constants
 
 // Commands
 const (
-	CommandBackup    = "backup"
-	CommandCheck     = "check"
-	CommandForget    = "forget"
-	CommandInit      = "init"
-	CommandPrune     = "prune"
-	CommandSnapshots = "snapshots"
-	CommandProfiles  = "profiles"
+	CommandBackup      = "backup"
+	CommandCheck       = "check"
+	CommandForget      = "forget"
+	CommandInit        = "init"
+	CommandPrune       = "prune"
+	CommandSnapshots   = "snapshots"
+	CommandProfiles    = "profiles"
+	CommandSystemdUnit = "systemd-unit"
 )

--- a/filesearch/filesearch.go
+++ b/filesearch/filesearch.go
@@ -7,6 +7,8 @@ import (
 	"path/filepath"
 	"runtime"
 	"strings"
+
+	"github.com/adrg/xdg"
 )
 
 var (
@@ -51,6 +53,13 @@ var (
 
 // FindConfigurationFile returns the path of the configuration file
 func FindConfigurationFile(configFile string) (string, error) {
+	xdgFilename, err := xdg.ConfigFile(filepath.Join("resticprofile", configFile))
+	if err == nil {
+		if fileExists(xdgFilename) {
+			return xdgFilename, nil
+		}
+	}
+
 	paths := getDefaultConfigurationLocations()
 	if home, err := os.UserHomeDir(); err == nil {
 		paths = append(paths, home)

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/creativeprojects/resticprofile
 go 1.13
 
 require (
+	github.com/adrg/xdg v0.2.1
 	github.com/blang/semver v3.5.1+incompatible
 	github.com/fatih/color v1.9.0
 	github.com/fsnotify/fsnotify v1.4.9 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,6 +1,8 @@
 cloud.google.com/go v0.26.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/OneOfOne/xxhash v1.2.2/go.mod h1:HSdplMjZKSmBqAxg5vPj2TmRDmfkzw+cTzAElWljhcU=
+github.com/adrg/xdg v0.2.1 h1:VSVdnH7cQ7V+B33qSJHTCRlNgra1607Q8PzEmnvb2Ic=
+github.com/adrg/xdg v0.2.1/go.mod h1:ZuOshBmzV4Ta+s23hdfFZnBsdzmoR3US0d7ErpqSbTQ=
 github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
 github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
 github.com/armon/consul-api v0.0.0-20180202201655-eb2c6b5be1b6/go.mod h1:grANhF5doyWs3UAsr3K4I6qtAmlQcZDesFNEHPZAzj8=

--- a/main.go
+++ b/main.go
@@ -17,6 +17,7 @@ import (
 	"github.com/creativeprojects/resticprofile/filesearch"
 	"github.com/creativeprojects/resticprofile/lock"
 	"github.com/creativeprojects/resticprofile/priority"
+	"github.com/creativeprojects/resticprofile/systemd"
 	"github.com/spf13/viper"
 )
 
@@ -105,6 +106,15 @@ func main() {
 	if resticCommand == constants.CommandProfiles {
 		displayProfiles()
 		displayGroups()
+		return
+	}
+	if resticCommand == constants.CommandSystemdUnit {
+		if len(resticArguments) != 1 {
+			clog.Error("OnCalendar argument required")
+			os.Exit(1)
+			return
+		}
+		systemd.Generate(flags.name, resticArguments[0])
 		return
 	}
 

--- a/systemd/generate.go
+++ b/systemd/generate.go
@@ -1,0 +1,83 @@
+package systemd
+
+import (
+	"bytes"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"os/user"
+	"path/filepath"
+	"text/template"
+
+	"github.com/creativeprojects/resticprofile/clog"
+)
+
+var systemdUnitBackupUnitTmpl = `[Unit]
+Description=resticprofile backup for {{ .Profile }}
+
+[Service]
+Type=oneshot
+ExecStart=resticprofile -n "{{ .Profile }}"
+`
+
+var systemdUnitBackupTimerTmpl = `[Unit]
+Description=backup timer of {{ .Profile }}
+
+[Timer]
+OnCalendar={{.OnCalendar}}
+Unit={{ .SystemdProfile }}
+Persistent=true
+
+[Install]
+WantedBy=timers.target
+`
+
+type TemplateInfo struct {
+	Profile        string
+	OnCalendar     string
+	SystemdProfile string
+}
+
+func Generate(profile, onCalendar string) error {
+	systemdProfile := fmt.Sprintf("resticprofile-backup@%s.service", profile)
+	timerProfile := fmt.Sprintf("resticprofile-backup@%s.timer", profile)
+
+	u, err := user.Current()
+	if err != nil {
+		return err
+	}
+
+	systemdUserDir := filepath.Join(u.HomeDir, ".config", "systemd", "user")
+	if err := os.MkdirAll(systemdUserDir, 0700); err != nil {
+		return err
+	}
+
+	info := TemplateInfo{
+		Profile:        profile,
+		SystemdProfile: systemdProfile,
+		OnCalendar:     onCalendar,
+	}
+
+	var data bytes.Buffer
+	unitTmpl := template.Must(template.New("systemd.unit").Parse(systemdUnitBackupUnitTmpl))
+	if err := unitTmpl.Execute(&data, info); err != nil {
+		return err
+	}
+	filePathName := filepath.Join(systemdUserDir, systemdProfile)
+	clog.Infof("Writing %v", filePathName)
+	if err := ioutil.WriteFile(filePathName, data.Bytes(), 0600); err != nil {
+		return err
+	}
+	data.Reset()
+
+	timerTmpl := template.Must(template.New("timer.unit").Parse(systemdUnitBackupTimerTmpl))
+	if err := timerTmpl.Execute(&data, info); err != nil {
+		return err
+	}
+	filePathName = filepath.Join(systemdUserDir, timerProfile)
+	clog.Infof("Writing %v", filePathName)
+	if err := ioutil.WriteFile(filePathName, data.Bytes(), 0600); err != nil {
+		return err
+	}
+	return nil
+}


### PR DESCRIPTION
Adds initial support for per profile systemd user files where a user can run `resticprofile -n configs systemd-unit daily`. This is super useful to allow for automation to 'install' everything needed to automate backups.

Adds:

```
resticprofile -n [profile] systemd-unit [OnCalendar setting]
```

The following snippet runs resticprofile then enables the systemd timer. The intention is to create 'user' systemd profiles. If you think this PR will get merged, the next step would be add system wide support.

```
resticprofile -n configs systemd-unit daily
systemctl --user enable resticprofile-backup@configs.timer
```

I added the xdg library to pull in ~/.config/resticprofile/profile.conf on linux (the library works on windows and OSX as well)... The entire logic in filesearch/filesearch.go could be simplified with the xdg library, but I left it as is to maintain backwards compatibility.