### PR TITLE
Add version command

### DIFF
--- a/README.md
+++ b/README.md
@@ -566,6 +566,7 @@ resticprofile flags:
   -w, --wait            wait at the end until the user presses the enter key
 
 resticprofile own commands:
+   version       display version (run in vebose mode for detailed information)
    self-update   update resticprofile to latest version (does not update restic)
    profiles      display profile names from the configuration file
    show          show all the details of the current profile
@@ -605,6 +606,14 @@ restic can be memory hungry. I'm running a few servers with no swap (I know: it 
 For that matter I've introduced a parameter in the `global` section called `min-memory`. The **default value is 100MB**. You can disable it by using a value of `0`.
 
 It compares against `(total - used)` which is probably the best way to know how much memory is available (that is including the memory used for disk buffers/cache).
+
+## Version
+
+The `version` command displays resticprofile version. If run in vebose mode (using `--verbose` flag) additional information such as OS version or golang version or modules are displayed as well.
+
+```
+$ resticprofile --verbose version
+```
 
 ## Generating random keys
 

--- a/commands.go
+++ b/commands.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"os"
 	"runtime"
+	"runtime/debug"
 	"sort"
 	"strconv"
 	"strings"
@@ -30,6 +31,12 @@ type ownCommand struct {
 
 var (
 	ownCommands = []ownCommand{
+		{
+			name:              "version",
+			description:       "display version (run in vebose mode for detailed information)",
+			action:            displayVersion,
+			needConfiguration: false,
+		},
 		{
 			name:              "self-update",
 			description:       "update resticprofile to latest version (does not update restic)",
@@ -132,6 +139,33 @@ func runOwnCommand(configuration *config.Config, command string, flags commandLi
 func displayProfilesCommand(configuration *config.Config, _ commandLineFlags, _ []string) error {
 	displayProfiles(configuration)
 	displayGroups(configuration)
+	return nil
+}
+
+func displayVersion(_ *config.Config, flags commandLineFlags, _ []string) error {
+	fmt.Printf("resticprofile version %s commit %s.\n", version, commit)
+
+	if flags.verbose {
+		w := tabwriter.NewWriter(os.Stderr, 0, 0, 3, ' ', 0)
+		_, _ = fmt.Fprintf(w, "\n")
+		_, _ = fmt.Fprintf(w, "\t%s:\t%s\n", "home", "https://github.com/creativeprojects/resticprofile")
+		_, _ = fmt.Fprintf(w, "\t%s:\t%s\n", "os", runtime.GOOS)
+		_, _ = fmt.Fprintf(w, "\t%s:\t%s\n", "arch", runtime.GOARCH)
+		_, _ = fmt.Fprintf(w, "\t%s:\t%s\n", "version", version)
+		_, _ = fmt.Fprintf(w, "\t%s:\t%s\n", "commit", commit)
+		_, _ = fmt.Fprintf(w, "\t%s:\t%s\n", "compiled", date)
+		_, _ = fmt.Fprintf(w, "\t%s:\t%s\n", "by", builtBy)
+		_, _ = fmt.Fprintf(w, "\t%s:\t%s\n", "go version", runtime.Version())
+		_, _ = fmt.Fprintf(w, "\n")
+		_, _ = fmt.Fprintf(w, "\t%s:\n", "go modules")
+		bi, _ := debug.ReadBuildInfo()
+		for _, dep := range bi.Deps {
+			_, _ = fmt.Fprintf(w, "\t\t%s\t%s\n", dep.Path, dep.Version)
+		}
+		_, _ = fmt.Fprintf(w, "\n")
+
+		w.Flush()
+	}
 	return nil
 }
 


### PR DESCRIPTION
This patch adds a version command to display resticprofile version. If
this command is run with verbose flag, additional such as OS version,
golang version and modules are displayed.

Signed-off-by: Sébastien Gross <seb•ɑƬ•chezwam•ɖɵʈ•org>