### PR TITLE
Escape `exclude` globs passed to `/sh`

### DIFF
--- a/config/path.go
+++ b/config/path.go
@@ -46,6 +46,13 @@ func unixSpaces(value string) string {
 	return value
 }
 
+func unixGlobs(value string) string {
+	if runtime.GOOS != "windows" {
+		value = strings.ReplaceAll(value, "*", `\*`)
+	}
+	return value
+}
+
 func absolutePrefix(prefix string) pathFix {
 	return func(value string) string {
 		if value == "" ||

--- a/config/path_test.go
+++ b/config/path_test.go
@@ -24,13 +24,14 @@ func TestFixUnixPaths(t *testing.T) {
 		{"~/dir", "~/dir"},
 		{"$TEMP_TEST_DIR/dir", "/home/dir"},
 		{"some file.txt", "prefix/some\\ file.txt"},
+		{"/**/.git", "/\\*\\*/.git"},
 	}
 
 	err := os.Setenv("TEMP_TEST_DIR", "/home")
 	require.NoError(t, err)
 
 	for _, testPath := range paths {
-		fixed := fixPath(testPath.source, expandEnv, absolutePrefix("prefix"), unixSpaces)
+		fixed := fixPath(testPath.source, expandEnv, absolutePrefix("prefix"), unixSpaces, unixGlobs)
 		assert.Equalf(t, testPath.expected, fixed, "source was '%s'", testPath.source)
 	}
 }

--- a/config/profile.go
+++ b/config/profile.go
@@ -42,6 +42,8 @@ type BackupSection struct {
 	RunAfter           []string               `mapstructure:"run-after"`
 	UseStdin           bool                   `mapstructure:"stdin" argument:"stdin"`
 	Source             []string               `mapstructure:"source"`
+	Exclude            []string               `mapstructure:"exclude" argument:"exclude"`
+	Iexclude           []string               `mapstructure:"iexclude" argument:"iexclude"`
 	ExcludeFile        []string               `mapstructure:"exclude-file" argument:"exclude-file"`
 	FilesFrom          []string               `mapstructure:"files-from" argument:"files-from"`
 	Schedule           []string               `mapstructure:"schedule"`
@@ -99,6 +101,14 @@ func (p *Profile) SetRootPath(rootPath string) {
 		// Backup source is NOT relative to the configuration, but where the script was launched instead
 		if p.Backup.Source != nil && len(p.Backup.Source) > 0 {
 			p.Backup.Source = fixPaths(p.Backup.Source, expandEnv, unixSpaces)
+		}
+
+		if p.Backup.Exclude != nil && len(p.Backup.Exclude) > 0 {
+			p.Backup.Exclude = fixPaths(p.Backup.Exclude, expandEnv, unixSpaces, unixGlobs)
+		}
+
+		if p.Backup.Iexclude != nil && len(p.Backup.Iexclude) > 0 {
+			p.Backup.Iexclude = fixPaths(p.Backup.Iexclude, expandEnv, unixSpaces, unixGlobs)
 		}
 	}
 }

--- a/shell/command_test.go
+++ b/shell/command_test.go
@@ -5,6 +5,7 @@ import (
 	"io/ioutil"
 	"os"
 	"os/signal"
+	"regexp"
 	"runtime"
 	"strings"
 	"syscall"
@@ -61,7 +62,7 @@ func TestShellCommandWithArguments(t *testing.T) {
 			`.`,
 		}, args)
 	} else {
-		assert.Equal(t, "/bin/sh", command)
+		assert.Regexp(t, regexp.MustCompile("(/usr)?/bin/sh"), command)
 		assert.Equal(t, []string{
 			"-c",
 			"/bin/restic -v --exclude-file \"excludes\" --repo \"/Volumes/RAMDisk\" backup .",
@@ -84,7 +85,7 @@ func TestShellCommand(t *testing.T) {
 			"/bin/restic -v --exclude-file \"excludes\" --repo \"/Volumes/RAMDisk\" backup .",
 		}, args)
 	} else {
-		assert.Equal(t, "/bin/sh", command)
+		assert.Regexp(t, regexp.MustCompile("(/usr)?/bin/sh"), command)
 		assert.Equal(t, []string{
 			"-c",
 			"/bin/restic -v --exclude-file \"excludes\" --repo \"/Volumes/RAMDisk\" backup .",


### PR DESCRIPTION
This prevents `sh` expansion of any globs set by `exclude` & `iexclude` and allows `restic` to apply its own globbing logic.

Fixes #15.