### PR TITLE
Added prune as supported, schedulable command

### DIFF
--- a/README.md
+++ b/README.md
@@ -1770,6 +1770,14 @@ Flags passed to the restic command line
 * **read-data-subset**: string
 * **with-cache**: true / false
 
+`[profile.prune]`
+
+Flags used by resticprofile only
+
+* **schedule**: string OR list of strings
+* **schedule-permission**: string (`user` or `system`)
+* **schedule-log**: string
+
 `[profile.mount]`
 
 Flags passed to the restic command line

--- a/config/show.go
+++ b/config/show.go
@@ -57,9 +57,15 @@ func showSubStruct(outputWriter io.Writer, orig interface{}, prefix string) erro
 				continue
 			}
 			if valueOf.Field(i).Kind() == reflect.Struct {
-				// start of a new struct
-				fmt.Fprintf(buffer, "%s%s:\n", prefix, key)
-				err := showSubStruct(buffer, valueOf.Field(i).Interface(), prefix)
+				var err error
+				if key == ",squash" {
+					p := prefix[0 : len(prefix)-len(templateIndent)]
+					err = showSubStruct(tabWriter, valueOf.Field(i).Interface(), p)
+				} else {
+					// start of a new struct
+					fmt.Fprintf(buffer, "%s%s:\n", prefix, key)
+					err = showSubStruct(buffer, valueOf.Field(i).Interface(), prefix)
+				}
 				if err != nil {
 					return err
 				}

--- a/config/show_test.go
+++ b/config/show_test.go
@@ -30,6 +30,15 @@ type testPointer struct {
 	IsValid bool `mapstructure:"valid"`
 }
 
+type testEmbedded struct {
+	EmbeddedStruct `mapstructure:",squash"`
+	InlineValue    int `mapstructure:"inline"`
+}
+
+type EmbeddedStruct struct {
+	Value bool `mapstructure:"value"`
+}
+
 func TestShowStruct(t *testing.T) {
 	testData := []showStructData{
 		{
@@ -57,6 +66,10 @@ func TestShowStruct(t *testing.T) {
 		{
 			input:  testObject{Id: 11, Name: "test", Map: map[string][]string{"left": {"over"}}},
 			output: " person:\n\n id: 11\n name:  test\n left:  over\n\n",
+		},
+		{
+			input:  testEmbedded{EmbeddedStruct{Value: true}, 1},
+			output: " value:  true\n\n inline:  1\n\n",
 		},
 	}
 

--- a/schedule/schedule.go
+++ b/schedule/schedule.go
@@ -5,11 +5,12 @@ import (
 )
 
 var (
-	// ScheduledSections are the command that can be scheduled (backup, retention, check)
+	// ScheduledSections are the command that can be scheduled (backup, retention, check, prune)
 	ScheduledSections = []string{
 		constants.CommandBackup,
 		constants.SectionConfigurationRetention,
 		constants.CommandCheck,
+		constants.CommandPrune,
 	}
 )
 


### PR DESCRIPTION
Fixes #22 

Implementation Notes:
* `profiles_test` & `show` was checked in with forced CRLF (other files were not). 
  The diff (without ignored whitespace) is larger than it should. Needs to be clarified if CRLF should be forced.
* I've consolidated schedule options since #23 may need one more schedulable section.
* All schedulable sections print with one newline in `show`. Needs to be clarified if this should be fixed.

~~Marked as WIP since I only tested it via `profiles_test` and on my mac so far.~~

Tested in regular backup schedule and via unit and manual tests.