### PR TITLE
Enhanced "unschedule" to remove all possible jobs

### DIFF
--- a/config/profile.go
+++ b/config/profile.go
@@ -228,6 +228,16 @@ func (p *Profile) GetBackupSource() []string {
 	return p.Backup.Source
 }
 
+// SchedulableCommands returns all command names that could have a schedule
+func (p *Profile) SchedulableCommands() []string {
+	sections := p.allSchedulableSections()
+	commands := make([]string, 0, len(sections))
+	for name := range sections {
+		commands = append(commands, name)
+	}
+	return commands
+}
+
 // Schedules returns a slice of ScheduleConfig that satisfy the schedule.Config interface
 func (p *Profile) Schedules() []*ScheduleConfig {
 	// All SectionWithSchedule (backup, check, prune, etc)

--- a/config/profile_test.go
+++ b/config/profile_test.go
@@ -418,10 +418,10 @@ initialize = true
 		return fmt.Sprintf(config, command, schedule)
 	}
 
-	sections := NewProfile(nil, "").allSchedulableSections()
+	sections := NewProfile(nil, "").SchedulableCommands()
 	assert.Len(sections, 5)
 
-	for command, _ := range sections {
+	for _, command := range sections {
 		// Check that schedule is supported
 		profile, err := getProfile("toml", testConfig(command, true), "profile")
 		if err != nil {

--- a/schedule/job.go
+++ b/schedule/job.go
@@ -44,7 +44,7 @@ var ErrorJobCanBeRemovedOnly = errors.New("job can be removed only")
 // Accessible checks if the current user is permitted to access the job
 func (j *Job) Accessible() bool {
 	permission, _ := j.detectSchedulePermission()
-	return !j.checkPermission(permission)
+	return j.checkPermission(permission)
 }
 
 // Create a new job

--- a/schedule/job.go
+++ b/schedule/job.go
@@ -1,5 +1,7 @@
 package schedule
 
+import "errors"
+
 //
 // Schedule: common code for all systems
 //
@@ -24,8 +26,10 @@ type Config interface {
 
 // SchedulerJob interface
 type SchedulerJob interface {
+	Accessible() bool
 	Create() error
 	Remove() error
+	RemoveOnly() bool
 	Status() error
 }
 
@@ -35,8 +39,20 @@ type Job struct {
 	scheduler string
 }
 
+var ErrorJobCanBeRemovedOnly = errors.New("job can be removed only")
+
+// Accessible checks if the current user is permitted to access the job
+func (j *Job) Accessible() bool {
+	permission, _ := j.detectSchedulePermission()
+	return !j.checkPermission(permission)
+}
+
 // Create a new job
 func (j *Job) Create() error {
+	if j.RemoveOnly() {
+		return ErrorJobCanBeRemovedOnly
+	}
+
 	schedules, err := j.loadSchedules(j.config.SubTitle(), j.config.Schedules())
 	if err != nil {
 		return err
@@ -59,8 +75,17 @@ func (j *Job) Remove() error {
 	return nil
 }
 
+// RemoveOnly returns true if this job can be removed only
+func (j *Job) RemoveOnly() bool {
+	return isRemoveOnlyConfig(j.config)
+}
+
 // Status of a job
 func (j *Job) Status() error {
+	if j.RemoveOnly() {
+		return ErrorJobCanBeRemovedOnly
+	}
+
 	_, err := j.loadSchedules(j.config.SubTitle(), j.config.Schedules())
 	if err != nil {
 		return err

--- a/schedule/removeonly.go
+++ b/schedule/removeonly.go
@@ -1,0 +1,34 @@
+package schedule
+
+// RemoveOnlyConfig implements Config for jobs that are Job.RemoveOnly()
+type RemoveOnlyConfig struct {
+	title, subTitle string
+}
+
+func (r *RemoveOnlyConfig) Title() string                  { return r.title }
+func (r *RemoveOnlyConfig) SubTitle() string               { return r.subTitle }
+func (r *RemoveOnlyConfig) JobDescription() string         { return "" }
+func (r *RemoveOnlyConfig) TimerDescription() string       { return "" }
+func (r *RemoveOnlyConfig) Schedules() []string            { return []string{} }
+func (r *RemoveOnlyConfig) Permission() string             { return "" }
+func (r *RemoveOnlyConfig) WorkingDirectory() string       { return "" }
+func (r *RemoveOnlyConfig) Command() string                { return "" }
+func (r *RemoveOnlyConfig) Arguments() []string            { return []string{} }
+func (r *RemoveOnlyConfig) Environment() map[string]string { return map[string]string{} }
+func (r *RemoveOnlyConfig) Priority() string               { return "" }
+func (r *RemoveOnlyConfig) Logfile() string                { return "" }
+func (r *RemoveOnlyConfig) Configfile() string             { return "" }
+func (r *RemoveOnlyConfig) GetFlag(string) (string, bool)  { return "", false }
+
+func isRemoveOnlyConfig(config Config) bool {
+	_, ok := config.(*RemoveOnlyConfig)
+	return ok
+}
+
+// NewRemoveOnlyConfig creates a job config that may be used to call Job.Remove() on a scheduled job
+func NewRemoveOnlyConfig(profileName, commandName string) Config {
+	return &RemoveOnlyConfig{
+		title:    profileName,
+		subTitle: commandName,
+	}
+}

--- a/schedule/removeonly_test.go
+++ b/schedule/removeonly_test.go
@@ -1,0 +1,56 @@
+package schedule
+
+import (
+	"github.com/creativeprojects/resticprofile/config"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNewRemoveOnlyConfig(t *testing.T) {
+	c := NewRemoveOnlyConfig("profile", "command")
+
+	assert.Equal(t, "profile", c.Title())
+	assert.Equal(t, "command", c.SubTitle())
+	assert.Equal(t, "", c.JobDescription())
+	assert.Equal(t, "", c.TimerDescription())
+	assert.Empty(t, c.Schedules())
+	assert.Equal(t, "", c.Permission())
+	assert.Equal(t, "", c.WorkingDirectory())
+	assert.Equal(t, "", c.Command())
+	assert.Empty(t, c.Arguments())
+	assert.Empty(t, c.Environment())
+	assert.Equal(t, "", c.Priority())
+	assert.Equal(t, "", c.Logfile())
+	assert.Equal(t, "", c.Configfile())
+	{
+		flag, found := c.GetFlag("")
+		assert.Equal(t, "", flag)
+		assert.False(t, found)
+	}
+}
+
+func TestDetectRemoveOnlyConfig(t *testing.T) {
+	assertRemoveOnly := func(expected bool, config Config) {
+		assert.Equal(t, expected, isRemoveOnlyConfig(config))
+	}
+
+	assertRemoveOnly(true, NewRemoveOnlyConfig("", ""))
+	assertRemoveOnly(false, nil)
+	assertRemoveOnly(false, &config.ScheduleConfig{})
+}
+
+func TestRemoveOnlyJob(t *testing.T) {
+	profile := "non-existent"
+	scheduler := NewScheduler("", profile)
+	defer scheduler.Close()
+
+	config := NewRemoveOnlyConfig(profile, "check")
+	job := scheduler.NewJob(config)
+
+	assert.Equal(t, ErrorJobCanBeRemovedOnly, job.Create())
+	assert.Equal(t, ErrorJobCanBeRemovedOnly, job.Status())
+	assert.True(t, job.Accessible())
+	assert.True(t, job.RemoveOnly())
+	assert.NotEqual(t, ErrorJobCanBeRemovedOnly, job.Remove())
+}

--- a/schedule/schedule_unix.go
+++ b/schedule/schedule_unix.go
@@ -46,7 +46,13 @@ func (j *Job) createJob(schedules []*calendar.Event) error {
 
 // removeJob is disabling the systemd unit and deleting the timer and service files
 func (j *Job) removeJob() error {
-	permission := j.getSchedulePermission()
+	var permission string
+	if j.RemoveOnly() {
+		permission, _ = j.detectSchedulePermission() // silent call for possibly non-existent job
+	} else {
+		permission = j.getSchedulePermission()
+	}
+
 	ok := j.checkPermission(permission)
 	if !ok {
 		return errors.New("user is not allowed to remove a system job: please restart resticprofile as root (with sudo)")

--- a/schedule/schedule_windows.go
+++ b/schedule/schedule_windows.go
@@ -48,7 +48,7 @@ var _ Scheduler = &Schedule{}
 func (j *Job) createJob(schedules []*calendar.Event) error {
 	// default permission will be system
 	permission := schtasks.SystemAccount
-	if j.config.Permission() == constants.SchedulePermissionUser {
+	if p, _ := j.detectSchedulePermission(); p == constants.SchedulePermissionUser {
 		permission = schtasks.UserAccount
 	}
 	err := schtasks.Create(j.config, schedules, permission)
@@ -80,4 +80,23 @@ func (j *Job) displayStatus(command string) error {
 		return err
 	}
 	return nil
+}
+
+// detectSchedulePermission returns the permission defined from the configuration,
+// or the best guess considering the current user permission.
+// unsafe specifies whether a guess may lead to a too broad or too narrow file access permission.
+//
+// This method is for Windows only
+func (j *Job) detectSchedulePermission() (permission string, unsafe bool) {
+	if j.config.Permission() == constants.SchedulePermissionUser {
+		return constants.SchedulePermissionUser, false
+	}
+	return constants.SchedulePermissionSystem, false
+}
+
+// checkPermission returns true if the user is allowed to access the job.
+//
+// This method is for Windows only
+func (j *Job) checkPermission(permission string) bool {
+	return true
 }


### PR DESCRIPTION
This change ensures that schedules that are no longer defined in the config will still attempted to be removed from the os scheduler. It addresses one part of #27 to remove all schedules for one profile.

Notes:
* ~~Currently this is a first draft without any testing as basis for discussing the general direction.~~
* The implementation tries to be as generic as possible to support all os schedulers.
* There is no dependency on OS schedulers to list registered jobs and as a consequence, renamed profiles may still leave scheduled jobs behind. A fix for this may be added in a separate PR.
