### PR TITLE
Added resticprofile flags --no-lock & --lock-wait

### DIFF
--- a/README.md
+++ b/README.md
@@ -388,6 +388,7 @@ source = [ "/" ]
 # if scheduled, will run every day at midnight
 schedule = "daily"
 schedule-permission = "system"
+schedule-lock-wait = "2h"
 # run this after a backup to share a repository between a user and root (via sudo)
 run-after = "chown -R $SUDO_USER $HOME/.cache/restic /backup"
 # ignore restic warnings (otherwise the backup is considered failed when restic couldn't read some files)
@@ -433,6 +434,7 @@ run-after = "sync"
 # if scheduled, will run every 30 minutes
 schedule = "*:0,30"
 schedule-permission = "user"
+schedule-lock-wait = "10m"
 
 # retention policy for profile src
 [src.retention]
@@ -589,7 +591,8 @@ A few environment variables will be set before running these commands:
 Additionally for the `run-after-fail` commands, these environment variables will also be available:
 - `ERROR` containing the latest error message
 - `ERROR_COMMANDLINE` containing the command line that failed
-- `RESTIC_STDERR` containing any message that restic sent to the standard error (stderr)
+- `ERROR_EXIT_CODE` containing the exit code of the command line that failed
+- `ERROR_STDERR` containing any message that the failed command sent to the standard error (stderr)
 
 ## run before and after order during a backup
 
@@ -645,16 +648,50 @@ For this profile, a lock will be set using the file `/tmp/resticprofile-profile-
 
 **Please note restic locks and resticprofile locks are completely independent**
 
-In some cases, you might want to override the resticprofile lock if the process died (or the machine rebooted) leaving a lockfile behind.
+## Stale locks
 
-For that matter, if you add the flag `force-inactive-lock` to your profile, resticprofile will check for the presence of a process with the PID indicated in the lockfile. If it can't find any, it will try to delete the lock and continue the operation (locking again, running profile and so on...)
+In some cases, resticprofile as well as restic may leave a lock behind if the process died (or the machine rebooted).
+
+For that matter, if you add the flag `force-inactive-lock` to your profile, resticprofile will detect and remove stale locks: 
+* **resticprofile locks**: Check for the presence of a process with the PID indicated in the lockfile. If it can't find any, it will try to delete the lock and continue the operation (locking again, running profile and so on...)
+* **restic locks**: Evaluate if a restic command failed on acquiring a lock. If the lock is older than `restic-stale-lock-age`, invoke `restic unlock` and retry the command that failed (can be disabled by setting `restic-stale-lock-age` to 0, default is 2h).
 
 ```yaml
+global:
+  restic-stale-lock-age: 2h
+
 src:
     lock: "/tmp/resticprofile-profile-src.lock"
     force-inactive-lock: true
 ```
 
+## Lock wait
+
+By default, restic and resticprofile fail when a lock cannot be acquired as another process is currently holding it.
+
+Depending on the use case (e.g. scheduled backups), it may be more appropriate to wait on another process to finish instead of failing immediately.
+
+For that matter, if you add the commandline flag `--lock-wait` or configure schedules with `schedule-lock-wait`, resticprofile will wait on other backup processes:
+* **resticprofile locks**: Retry acquiring the lockfile until it either succeeds (when the other resticprofile process released the lock) or fail as the lock-wait duration has passed without success.
+* **restic locks**: Evaluate if a restic command failed on acquiring a lock. If the lock is not considered stale, retry the restic command every `restic-lock-retry-after` (default 1 minute) until it acquired the lock, or fail as the lock-wait duration has passed.
+
+Note: The lock wait duration is cumulative. If various locks in one profile-run require lock wait, the total wait time may not exceed the duration that was specified. 
+
+## restic lock management
+
+resticprofile can retry restic commands that fail on acquiring a lock and can also ask restic to unlock stale locks. The behaviour is controlled by 2 settings inside the `global` section:
+
+```yaml
+global:
+  # Retry a restic command that failed on acquiring a lock every minute 
+  # (at least), for up to the time specified in "--lock-wait duration". 
+  restic-lock-retry-after: 1m
+  # Ask restic to unlock a stale lock when its age is more than 2 hours
+  # and the option "force-inactive-lock" is enabled in the profile.
+  restic-stale-lock-age: 2h
+```
+
+If restic lock management is not desired, it can be disabled by setting both values to 0.
 
 # Using resticprofile
 
@@ -756,10 +793,10 @@ There are not many options on the command line, most of the options are in the c
 * **[-q | --quiet]**: Force resticprofile and restic to be quiet (override any configuration from the profile)
 * **[-v | --verbose]**: Force resticprofile and restic to be verbose (override any configuration from the profile)
 * **[--no-ansi]**: Disable console colouring (to save output into a log file)
-* **[--no-lock]**: Disable local locks, neither create nor fail on a lock. This options only operates on resticprofile locks.
+* **[--no-lock]**: Disable resticprofile locks, neither create nor fail on a lock. restic locks are unaffected by this option.
 * **[--theme]**: Can be `light`, `dark` or `none`. The colours will adjust to a 
 light or dark terminal (none to disable colouring)
-* **[--lock-wait] duration**: Retry to acquire local (profile lock file) and repository locks (restic locks) for up to the specified amount of time before failing on a lock failure. 
+* **[--lock-wait] duration**: Retry to acquire resticprofile and restic locks for up to the specified amount of time before failing on a lock failure. 
 * **[-l | --log] log_file**: To write the logs in file instead of displaying on the console
 * **[-w | --wait]**: Wait at the very end of the execution for the user to press enter. This is only useful in Windows when resticprofile is started from explorer and the console window closes automatically at the end.
 * **[resticprofile OR restic command]**: Like snapshots, backup, check, prune, forget, mount, etc.
@@ -771,23 +808,6 @@ restic can be memory hungry. I'm running a few servers with no swap (I know: it 
 For that matter I've introduced a parameter in the `global` section called `min-memory`. The **default value is 100MB**. You can disable it by using a value of `0`.
 
 It compares against `(total - used)` which is probably the best way to know how much memory is available (that is including the memory used for disk buffers/cache).
-
-# Repository lock management
-
-restic uses repository locks to protect from concurrent modifications. Locks can be shared or exclusive depending on the operation and may become stale when a restic process dies. 
-resticprofile can retry restic commands when they fail on acquiring the lock they need and can also ask restic to unlock stale locks. The behaviour is controlled by 2 settings inside the `global` section:
-
-```yaml
-global:
-  # Retry a restic command that failed on acquiring a lock every minute (or more
-  # frequent), for up to the time specified in "--lock-wait duration". 
-  restic-lock-retry-after: 1m
-  # Ask restic to unlock a stale lock when its age is more than 2 hours
-  # and option "force-inactive-lock" is enabled in the profile.
-  restic-stale-lock-age: 2h
-```
-
-The global settings default to the values above when not specified. Set to 0 to disable repository lock management.
 
 # Version
 
@@ -875,22 +895,21 @@ schedule-lock-wait = "15m30s"
 
 * *empty*: resticprofile will try its best guess based on how you started it (with sudo or as a normal user) and fallback to `user`
 
-### schedule-log
-
-Allow to redirect all output from resticprofile and restic to a file
-
 ### schedule-lock-mode
 
 Starting from version 0.14.0, `schedule-lock-mode` accepts 3 values:
-- `default`: Wait on acquiring a lock (local and repository) when `schedule-lock-wait` is set, before failing a schedule.
-   Behaves like `fail` when `schedule-lock-wait` is `0` or not specified.
-- `fail`: A lock failure causes a schedule to abort immediately. 
-- `ignore`: Skip local locks (lock files defined in the profile).
-   Repository lock failures abort the schedule immediately.
+- `default`: Wait on acquiring a lock for the time duration set in `schedule-lock-wait`, before failing a schedule.
+   Behaves like `fail` when `schedule-lock-wait` is "0" or not specified.
+- `fail`: Any lock failure causes a schedule to abort immediately. 
+- `ignore`: Skip resticprofile locks. restic locks are not skipped and can abort the schedule.
 
 ### schedule-lock-wait
 
-Sets the amount of time to wait in the default `schedule-lock-mode` for a lock to become available.
+Sets the amount of time to wait for a resticprofile and restic lock to become available. Is only used when `schedule-lock-mode` is unset or `default`.
+
+### schedule-log
+
+Allow to redirect all output from resticprofile and restic to a file
 
 ### schedule-priority (systemd and launchd only)
 
@@ -961,15 +980,20 @@ default:
 
 self:
     inherit: default
+    retention:
+      after-backup: true
+      keep-within: 14d
     backup:
         source: "."
         schedule:
         - "Mon..Fri *:00,15,30,45" # every 15 minutes on weekdays
         - "Sat,Sun 0,12:00"        # twice a day on week-ends
         schedule-permission: user
-    retention:
+        schedule-lock-wait: 10m
+    prune:
         schedule: "sun 3:30"
         schedule-permission: user
+        schedule-lock-wait: 1h
 ```
 
 ## Scheduling commands
@@ -1127,9 +1151,11 @@ test1:
         source: ./
         schedule: "*:00,15,30,45"
         schedule-permission: user
+        schedule-lock-wait: 15m
     check:
         schedule: "*-*-1"
         schedule-permission: user
+        schedule-lock-wait: 15m
 
 ```
 
@@ -1824,6 +1850,8 @@ None of these flags are passed on the restic command line
 * **default-command**: string
 * **initialize**: true / false
 * **restic-binary**: string
+* **restic-lock-retry-after**: duration
+* **restic-stale-lock-age**: duration
 * **min-memory**: integer (MB)
 * **scheduler**: string (`crond` is the only non-default value)
 
@@ -1871,6 +1899,8 @@ Flags used by resticprofile only
 * **check-after**: true / false
 * **schedule**: string OR list of strings
 * **schedule-permission**: string (`user` or `system`)
+* **schedule-lock-mode**: string (`default`, `fail` or `ignore`) 
+* **schedule-lock-wait**: duration 
 * **schedule-log**: string
 * **extended-status**: true / false
 * **no-error-on-warning**: true / false
@@ -1903,6 +1933,8 @@ Flags used by resticprofile only
 * **after-backup**: true / false
 * **schedule**: string OR list of strings
 * **schedule-permission**: string (`user` or `system`)
+* **schedule-lock-mode**: string (`default`, `fail` or `ignore`)
+* **schedule-lock-wait**: duration
 * **schedule-log**: string
 
 Flags passed to the restic command line
@@ -1940,6 +1972,8 @@ Flags used by resticprofile only
 
 * **schedule**: string OR list of strings
 * **schedule-permission**: string (`user` or `system`)
+* **schedule-lock-mode**: string (`default`, `fail` or `ignore`)
+* **schedule-lock-wait**: duration
 * **schedule-log**: string
 
 Flags passed to the restic command line
@@ -1966,6 +2000,8 @@ Flags used by resticprofile only
 
 * **schedule**: string OR list of strings
 * **schedule-permission**: string (`user` or `system`)
+* **schedule-lock-mode**: string (`default`, `fail` or `ignore`)
+* **schedule-lock-wait**: duration
 * **schedule-log**: string
 
 Flags passed to the restic command line
@@ -1981,6 +2017,8 @@ Flags used by resticprofile only
 
 * **schedule**: string OR list of strings
 * **schedule-permission**: string (`user` or `system`)
+* **schedule-lock-mode**: string (`default`, `fail` or `ignore`)
+* **schedule-lock-wait**: duration
 * **schedule-log**: string
 
 `[profile.mount]`

--- a/config/config.go
+++ b/config/config.go
@@ -43,8 +43,14 @@ type Config struct {
 // For that matter, viper creates a slice of maps instead of a map for the other configuration file formats
 // This configOptionHCL deals with the slice to merge it into a single map
 var (
-	configOption    = viper.DecodeHook(nil)
-	configOptionHCL = viper.DecodeHook(sliceOfMapsToMapHookFunc())
+	configOption = viper.DecodeHook(mapstructure.ComposeDecodeHookFunc(
+		mapstructure.StringToTimeDurationHookFunc(),
+	))
+
+	configOptionHCL = viper.DecodeHook(mapstructure.ComposeDecodeHookFunc(
+		mapstructure.StringToTimeDurationHookFunc(),
+		sliceOfMapsToMapHookFunc(),
+	))
 )
 
 // newConfig instantiate a new Config object
@@ -212,7 +218,7 @@ func (c *Config) getCommandListHCL(sectionRawValue interface{}) []string {
 
 // GetGlobalSection returns the global configuration
 func (c *Config) GetGlobalSection() (*Global, error) {
-	global := newGlobal()
+	global := NewGlobal()
 	err := c.unmarshalKey(constants.SectionConfigurationGlobal, global)
 	if err != nil {
 		return nil, err

--- a/config/flag.go
+++ b/config/flag.go
@@ -53,10 +53,24 @@ func stringifyValueOf(value interface{}) ([]string, bool) {
 
 // stringifyValue returns a string representation of the value, and if it has any value at all
 func stringifyValue(value reflect.Value) ([]string, bool) {
+	// Check if the value can convert itself to String() (e.g. time.Duration)
+	stringer := fmt.Stringer(nil)
+	if value.CanInterface() {
+		vi := value.Interface()
+		if s, ok := vi.(fmt.Stringer); ok {
+			stringer = s
+		}
+	}
+
+	var stringVal string
 
 	switch value.Kind() {
 	case reflect.String:
-		stringVal := value.String()
+		if stringer != nil {
+			stringVal = stringer.String()
+		} else {
+			stringVal = value.String()
+		}
 		return []string{stringVal}, stringVal != ""
 
 	case reflect.Bool:
@@ -65,17 +79,29 @@ func stringifyValue(value reflect.Value) ([]string, bool) {
 
 	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
 		intVal := value.Int()
-		stringVal := strconv.FormatInt(intVal, 10)
+		if stringer != nil {
+			stringVal = stringer.String()
+		} else {
+			stringVal = strconv.FormatInt(intVal, 10)
+		}
 		return []string{stringVal}, intVal != 0
 
 	case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
 		intVal := value.Uint()
-		stringVal := strconv.FormatUint(intVal, 10)
+		if stringer != nil {
+			stringVal = stringer.String()
+		} else {
+			stringVal = strconv.FormatUint(intVal, 10)
+		}
 		return []string{stringVal}, intVal != 0
 
 	case reflect.Float32, reflect.Float64:
 		floatVal := value.Float()
-		stringVal := strconv.FormatFloat(floatVal, 'f', -1, 64)
+		if stringer != nil {
+			stringVal = stringer.String()
+		} else {
+			stringVal = strconv.FormatFloat(floatVal, 'f', -1, 64)
+		}
 		return []string{stringVal}, floatVal != 0
 
 	case reflect.Slice, reflect.Array:

--- a/config/global.go
+++ b/config/global.go
@@ -1,30 +1,36 @@
 package config
 
 import (
+	"time"
+
 	"github.com/creativeprojects/resticprofile/constants"
 )
 
 // Global holds the configuration from the global section
 type Global struct {
-	IONice         bool   `mapstructure:"ionice"`
-	IONiceClass    int    `mapstructure:"ionice-class"`
-	IONiceLevel    int    `mapstructure:"ionice-level"`
-	Nice           int    `mapstructure:"nice"`
-	Priority       string `mapstructure:"priority"`
-	DefaultCommand string `mapstructure:"default-command"`
-	Initialize     bool   `mapstructure:"initialize"`
-	ResticBinary   string `mapstructure:"restic-binary"`
-	MinMemory      uint64 `mapstructure:"min-memory"`
-	Scheduler      string `mapstructure:"scheduler"`
+	IONice              bool          `mapstructure:"ionice"`
+	IONiceClass         int           `mapstructure:"ionice-class"`
+	IONiceLevel         int           `mapstructure:"ionice-level"`
+	Nice                int           `mapstructure:"nice"`
+	Priority            string        `mapstructure:"priority"`
+	DefaultCommand      string        `mapstructure:"default-command"`
+	Initialize          bool          `mapstructure:"initialize"`
+	ResticBinary        string        `mapstructure:"restic-binary"`
+	ResticLockRetryTime time.Duration `mapstructure:"restic-lock-retry-time"`
+	ResticStaleLockAge  time.Duration `mapstructure:"restic-stale-lock-age"`
+	MinMemory           uint64        `mapstructure:"min-memory"`
+	Scheduler           string        `mapstructure:"scheduler"`
 }
 
-// newGlobal instantiates a new Global with default values
-func newGlobal() *Global {
+// NewGlobal instantiates a new Global with default values
+func NewGlobal() *Global {
 	return &Global{
-		IONice:         constants.DefaultIONiceFlag,
-		Nice:           constants.DefaultStandardNiceFlag,
-		DefaultCommand: constants.DefaultCommand,
-		ResticBinary:   constants.DefaultResticBinary,
-		MinMemory:      constants.DefaultMinMemory,
+		IONice:              constants.DefaultIONiceFlag,
+		Nice:                constants.DefaultStandardNiceFlag,
+		DefaultCommand:      constants.DefaultCommand,
+		ResticBinary:        constants.DefaultResticBinary,
+		ResticLockRetryTime: constants.DefaultResticLockRetryTime,
+		ResticStaleLockAge:  constants.DefaultResticStaleLockAge,
+		MinMemory:           constants.DefaultMinMemory,
 	}
 }

--- a/config/global.go
+++ b/config/global.go
@@ -8,29 +8,29 @@ import (
 
 // Global holds the configuration from the global section
 type Global struct {
-	IONice              bool          `mapstructure:"ionice"`
-	IONiceClass         int           `mapstructure:"ionice-class"`
-	IONiceLevel         int           `mapstructure:"ionice-level"`
-	Nice                int           `mapstructure:"nice"`
-	Priority            string        `mapstructure:"priority"`
-	DefaultCommand      string        `mapstructure:"default-command"`
-	Initialize          bool          `mapstructure:"initialize"`
-	ResticBinary        string        `mapstructure:"restic-binary"`
-	ResticLockRetryTime time.Duration `mapstructure:"restic-lock-retry-time"`
-	ResticStaleLockAge  time.Duration `mapstructure:"restic-stale-lock-age"`
-	MinMemory           uint64        `mapstructure:"min-memory"`
-	Scheduler           string        `mapstructure:"scheduler"`
+	IONice               bool          `mapstructure:"ionice"`
+	IONiceClass          int           `mapstructure:"ionice-class"`
+	IONiceLevel          int           `mapstructure:"ionice-level"`
+	Nice                 int           `mapstructure:"nice"`
+	Priority             string        `mapstructure:"priority"`
+	DefaultCommand       string        `mapstructure:"default-command"`
+	Initialize           bool          `mapstructure:"initialize"`
+	ResticBinary         string        `mapstructure:"restic-binary"`
+	ResticLockRetryAfter time.Duration `mapstructure:"restic-lock-retry-after"`
+	ResticStaleLockAge   time.Duration `mapstructure:"restic-stale-lock-age"`
+	MinMemory            uint64        `mapstructure:"min-memory"`
+	Scheduler            string        `mapstructure:"scheduler"`
 }
 
 // NewGlobal instantiates a new Global with default values
 func NewGlobal() *Global {
 	return &Global{
-		IONice:              constants.DefaultIONiceFlag,
-		Nice:                constants.DefaultStandardNiceFlag,
-		DefaultCommand:      constants.DefaultCommand,
-		ResticBinary:        constants.DefaultResticBinary,
-		ResticLockRetryTime: constants.DefaultResticLockRetryTime,
-		ResticStaleLockAge:  constants.DefaultResticStaleLockAge,
-		MinMemory:           constants.DefaultMinMemory,
+		IONice:               constants.DefaultIONiceFlag,
+		Nice:                 constants.DefaultStandardNiceFlag,
+		DefaultCommand:       constants.DefaultCommand,
+		ResticBinary:         constants.DefaultResticBinary,
+		ResticLockRetryAfter: constants.DefaultResticLockRetryAfter,
+		ResticStaleLockAge:   constants.DefaultResticStaleLockAge,
+		MinMemory:            constants.DefaultMinMemory,
 	}
 }

--- a/config/global_test.go
+++ b/config/global_test.go
@@ -3,6 +3,7 @@ package config
 import (
 	"bytes"
 	"testing"
+	"time"
 
 	"github.com/creativeprojects/resticprofile/constants"
 	"github.com/stretchr/testify/assert"
@@ -44,6 +45,8 @@ priority = "low"
 default-command = "version"
 initialize = true
 restic-binary = "/tmp/restic"
+restic-lock-retry-time = "2m30s"
+restic-stale-lock-age = "4h"
 `
 	global, err := getGlobalSection(configString)
 	if err != nil {
@@ -58,6 +61,8 @@ restic-binary = "/tmp/restic"
 	assert.Equal(t, "version", global.DefaultCommand)
 	assert.True(t, global.Initialize)
 	assert.Equal(t, "/tmp/restic", global.ResticBinary)
+	assert.Equal(t, 150*time.Second, global.ResticLockRetryTime)
+	assert.Equal(t, 4*time.Hour, global.ResticStaleLockAge)
 }
 
 func getGlobalSection(configString string) (*Global, error) {

--- a/config/global_test.go
+++ b/config/global_test.go
@@ -22,7 +22,7 @@ something = 1
 	assert.Equal(t, constants.DefaultIONiceFlag, global.IONice)
 	assert.Equal(t, constants.DefaultStandardNiceFlag, global.Nice)
 	assert.Equal(t, constants.DefaultResticBinary, global.ResticBinary)
-	assert.Equal(t, constants.DefaultResticLockRetryTime, global.ResticLockRetryTime)
+	assert.Equal(t, constants.DefaultResticLockRetryAfter, global.ResticLockRetryAfter)
 	assert.Equal(t, constants.DefaultResticStaleLockAge, global.ResticStaleLockAge)
 	assert.Equal(t, uint64(constants.DefaultMinMemory), global.MinMemory)
 	assert.False(t, global.Initialize)
@@ -51,7 +51,7 @@ priority = "low"
 default-command = "version"
 initialize = true
 restic-binary = "/tmp/restic"
-restic-lock-retry-time = "2m30s"
+restic-lock-retry-after = "2m30s"
 restic-stale-lock-age = "4h"
 `
 	global, err := getGlobalSection(configString)
@@ -67,7 +67,7 @@ restic-stale-lock-age = "4h"
 	assert.Equal(t, "version", global.DefaultCommand)
 	assert.True(t, global.Initialize)
 	assert.Equal(t, "/tmp/restic", global.ResticBinary)
-	assert.Equal(t, 150*time.Second, global.ResticLockRetryTime)
+	assert.Equal(t, 150*time.Second, global.ResticLockRetryAfter)
 	assert.Equal(t, 4*time.Hour, global.ResticStaleLockAge)
 }
 

--- a/config/global_test.go
+++ b/config/global_test.go
@@ -19,6 +19,12 @@ something = 1
 	}
 
 	assert.Equal(t, constants.DefaultCommand, global.DefaultCommand)
+	assert.Equal(t, constants.DefaultIONiceFlag, global.IONice)
+	assert.Equal(t, constants.DefaultStandardNiceFlag, global.Nice)
+	assert.Equal(t, constants.DefaultResticBinary, global.ResticBinary)
+	assert.Equal(t, constants.DefaultResticLockRetryTime, global.ResticLockRetryTime)
+	assert.Equal(t, constants.DefaultResticStaleLockAge, global.ResticStaleLockAge)
+	assert.Equal(t, uint64(constants.DefaultMinMemory), global.MinMemory)
 	assert.False(t, global.Initialize)
 }
 

--- a/config/profile.go
+++ b/config/profile.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	"reflect"
+	"time"
 
 	"github.com/creativeprojects/clog"
 	"github.com/creativeprojects/resticprofile/constants"
@@ -73,10 +74,12 @@ type OtherSectionWithSchedule struct {
 
 // ScheduleSection contains the parameters for scheduling a command (backup, check, forget, etc.)
 type ScheduleSection struct {
-	Schedule           []string `mapstructure:"schedule"`
-	SchedulePermission string   `mapstructure:"schedule-permission"`
-	ScheduleLog        string   `mapstructure:"schedule-log"`
-	SchedulePriority   string   `mapstructure:"schedule-priority"`
+	Schedule           []string      `mapstructure:"schedule"`
+	SchedulePermission string        `mapstructure:"schedule-permission"`
+	ScheduleLog        string        `mapstructure:"schedule-log"`
+	SchedulePriority   string        `mapstructure:"schedule-priority"`
+	ScheduleLockMode   string        `mapstructure:"schedule-lock-mode"`
+	ScheduleLockWait   time.Duration `mapstructure:"schedule-lock-wait"`
 }
 
 // NewProfile instantiates a new blank profile
@@ -260,6 +263,8 @@ func (p *Profile) Schedules() []*ScheduleConfig {
 				permission:  s.SchedulePermission,
 				environment: p.Environment,
 				logfile:     s.ScheduleLog,
+				lockMode:    s.ScheduleLockMode,
+				lockWait:    s.ScheduleLockWait,
 				priority:    s.SchedulePriority,
 				configfile:  p.config.configFile,
 			}

--- a/config/schedule.go
+++ b/config/schedule.go
@@ -10,14 +10,12 @@ import (
 type ScheduleLockMode int8
 
 const (
-	// ScheduleLockModeDefault waits on acquiring a lock (local and remote) for up to ScheduleConfig lockWait (duration), before failing a schedule.
+	// ScheduleLockModeDefault waits on acquiring a lock (local and repository) for up to ScheduleConfig lockWait (duration), before failing a schedule.
 	// With lockWait set to 0, ScheduleLockModeDefault and ScheduleLockModeFail behave the same.
 	ScheduleLockModeDefault = ScheduleLockMode(0)
 	// ScheduleLockModeFail fails immediately on a lock failure without waiting.
-	// This mode does not wait on `restic` remote locks but removes stale locks when `force-inactive-lock` is set to true.
 	ScheduleLockModeFail = ScheduleLockMode(1)
-	// ScheduleLockModeIgnore does not create or fail on resticprofile locks.
-	// This mode does not interfere with `restic` locks unless the profile configures restic specific lock flags.
+	// ScheduleLockModeIgnore does not create or fail on resticprofile locks. Repository locks cause an immediate failure.
 	ScheduleLockModeIgnore = ScheduleLockMode(2)
 )
 

--- a/config/schedule_test.go
+++ b/config/schedule_test.go
@@ -1,7 +1,9 @@
 package config
 
 import (
+	"github.com/creativeprojects/resticprofile/constants"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 )
@@ -20,6 +22,8 @@ func TestScheduleProperties(t *testing.T) {
 		jobDescription:   "job",
 		timerDescription: "timer",
 		logfile:          "log.txt",
+		lockMode:         "undefined",
+		lockWait:         1 * time.Minute,
 	}
 
 	assert.Equal(t, "config", schedule.Configfile())
@@ -35,6 +39,30 @@ func TestScheduleProperties(t *testing.T) {
 	assert.Equal(t, "dev", schedule.Environment()["test"])
 	assert.Equal(t, "background", schedule.Priority()) // default value
 	assert.Equal(t, "log.txt", schedule.Logfile())
+	assert.Equal(t, ScheduleLockModeDefault, schedule.LockMode())
+	assert.Equal(t, 60*time.Second, schedule.LockWait())
+}
+
+func TestLockModes(t *testing.T) {
+	tests := map[ScheduleLockMode]ScheduleConfig{
+		ScheduleLockModeDefault: {lockMode: ""},
+		ScheduleLockModeFail:    {lockMode: constants.ScheduleLockModeOptionFail},
+		ScheduleLockModeIgnore:  {lockMode: constants.ScheduleLockModeOptionIgnore},
+	}
+	for mode, config := range tests {
+		assert.Equal(t, mode, config.LockMode())
+	}
+}
+
+func TestLockWait(t *testing.T) {
+	tests := map[time.Duration]ScheduleConfig{
+		0:               {lockWait: 2 * time.Second}, // min lock wait is is >2 seconds
+		3 * time.Second: {lockWait: 3 * time.Second},
+		120 * time.Hour: {lockWait: 120 * time.Hour},
+	}
+	for mode, config := range tests {
+		assert.Equal(t, mode, config.LockWait())
+	}
 }
 
 func TestStandardPriority(t *testing.T) {

--- a/config/schedule_test.go
+++ b/config/schedule_test.go
@@ -1,10 +1,10 @@
 package config
 
 import (
-	"github.com/creativeprojects/resticprofile/constants"
 	"testing"
 	"time"
 
+	"github.com/creativeprojects/resticprofile/constants"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/config/show_test.go
+++ b/config/show_test.go
@@ -3,6 +3,7 @@ package config
 import (
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 )
@@ -24,6 +25,10 @@ type testPerson struct {
 	Name       string              `mapstructure:"name"`
 	IsValid    bool                `mapstructure:"valid"`
 	Properties map[string][]string `mapstructure:"properties"`
+}
+
+type testStringer struct {
+	Age time.Duration `mapstructure:"age"`
 }
 
 type testPointer struct {
@@ -70,6 +75,14 @@ func TestShowStruct(t *testing.T) {
 		{
 			input:  testEmbedded{EmbeddedStruct{Value: true}, 1},
 			output: " value:   true\n inline:  1\n",
+		},
+		{
+			input:  testStringer{Age: 2*time.Minute + 5*time.Second},
+			output: " age:  2m5s\n",
+		},
+		{
+			input:  testStringer{},
+			output: "",
 		},
 	}
 

--- a/constants/command.go
+++ b/constants/command.go
@@ -8,5 +8,6 @@ const (
 	CommandInit      = "init"
 	CommandPrune     = "prune"
 	CommandSnapshots = "snapshots"
+	CommandUnlock    = "unlock"
 	CommandMount     = "mount"
 )

--- a/constants/default.go
+++ b/constants/default.go
@@ -4,17 +4,17 @@ import "time"
 
 // Configuration defaults
 const (
-	DefaultConfigurationFile   = "profiles"
-	DefaultProfileName         = "default"
-	DefaultCommand             = "snapshots"
-	DefaultResticBinary        = "restic"
-	DefaultResticLockRetryTime = 60 * time.Second
-	DefaultResticStaleLockAge  = 2 * time.Hour
-	DefaultTheme               = "light"
-	DefaultIONiceFlag          = false
-	DefaultStandardNiceFlag    = 0
-	DefaultBackgroundNiceFlag  = 5
-	DefaultVerboseFlag         = false
-	DefaultQuietFlag           = false
-	DefaultMinMemory           = 100
+	DefaultConfigurationFile    = "profiles"
+	DefaultProfileName          = "default"
+	DefaultCommand              = "snapshots"
+	DefaultResticBinary         = "restic"
+	DefaultResticLockRetryAfter = 60 * time.Second
+	DefaultResticStaleLockAge   = 2 * time.Hour
+	DefaultTheme                = "light"
+	DefaultIONiceFlag           = false
+	DefaultStandardNiceFlag     = 0
+	DefaultBackgroundNiceFlag   = 5
+	DefaultVerboseFlag          = false
+	DefaultQuietFlag            = false
+	DefaultMinMemory            = 100
 )

--- a/constants/default.go
+++ b/constants/default.go
@@ -1,16 +1,20 @@
 package constants
 
+import "time"
+
 // Configuration defaults
 const (
-	DefaultConfigurationFile  = "profiles"
-	DefaultProfileName        = "default"
-	DefaultCommand            = "snapshots"
-	DefaultResticBinary       = "restic"
-	DefaultTheme              = "light"
-	DefaultIONiceFlag         = false
-	DefaultStandardNiceFlag   = 0
-	DefaultBackgroundNiceFlag = 5
-	DefaultVerboseFlag        = false
-	DefaultQuietFlag          = false
-	DefaultMinMemory          = 100
+	DefaultConfigurationFile   = "profiles"
+	DefaultProfileName         = "default"
+	DefaultCommand             = "snapshots"
+	DefaultResticBinary        = "restic"
+	DefaultResticLockRetryTime = 60 * time.Second
+	DefaultResticStaleLockAge  = 2 * time.Hour
+	DefaultTheme               = "light"
+	DefaultIONiceFlag          = false
+	DefaultStandardNiceFlag    = 0
+	DefaultBackgroundNiceFlag  = 5
+	DefaultVerboseFlag         = false
+	DefaultQuietFlag           = false
+	DefaultMinMemory           = 100
 )

--- a/constants/global.go
+++ b/constants/global.go
@@ -1,6 +1,9 @@
 package constants
 
-import "github.com/creativeprojects/resticprofile/priority"
+import (
+	"github.com/creativeprojects/resticprofile/priority"
+	"time"
+)
 
 // Scheduler type
 const (
@@ -20,4 +23,17 @@ var (
 		"high":       priority.High,
 		"highest":    priority.Highest,
 	}
+)
+
+// Limits for restic lock handling (stale locks and retry on lock failure)
+const (
+	MinResticLockRetryTime = 15 * time.Second
+	MaxResticLockRetryTime = 30 * time.Minute
+	MinResticStaleLockAge  = 1 * time.Hour
+)
+
+// Schedule lock mode config options
+const (
+	ScheduleLockModeOptionFail   = "fail"
+	ScheduleLockModeOptionIgnore = "ignore"
 )

--- a/constants/global.go
+++ b/constants/global.go
@@ -1,8 +1,9 @@
 package constants
 
 import (
-	"github.com/creativeprojects/resticprofile/priority"
 	"time"
+
+	"github.com/creativeprojects/resticprofile/priority"
 )
 
 // Scheduler type

--- a/flags.go
+++ b/flags.go
@@ -59,7 +59,7 @@ func loadFlags() (*pflag.FlagSet, commandLineFlags) {
 	flagset.StringVarP(&flags.logFile, "log", "l", "", "logs into a file instead of the console")
 	flagset.BoolVar(&flags.dryRun, "dry-run", false, "display the restic commands instead of running them")
 
-	flagset.BoolVar(&flags.noLock, "no-lock", false, "ignore any profile lock")
+	flagset.BoolVar(&flags.noLock, "no-lock", false, "skip profile lock file")
 	flagset.DurationVar(&flags.lockWait, "lock-wait", 0, "wait up to duration to acquire a lock (syntax \"1h5m30s\")")
 
 	flagset.BoolVar(&flags.noAnsi, "no-ansi", false, "disable ansi control characters (disable console colouring)")

--- a/flags.go
+++ b/flags.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"runtime"
+	"time"
 
 	"github.com/creativeprojects/resticprofile/constants"
 	"github.com/spf13/pflag"
@@ -19,6 +20,8 @@ type commandLineFlags struct {
 	name        string
 	logFile     string
 	dryRun      bool
+	noLock      bool
+	lockWait    time.Duration
 	noAnsi      bool
 	theme       string
 	resticArgs  []string
@@ -55,6 +58,9 @@ func loadFlags() (*pflag.FlagSet, commandLineFlags) {
 	flagset.StringVarP(&flags.name, "name", "n", constants.DefaultProfileName, "profile name")
 	flagset.StringVarP(&flags.logFile, "log", "l", "", "logs into a file instead of the console")
 	flagset.BoolVar(&flags.dryRun, "dry-run", false, "display the restic commands instead of running them")
+
+	flagset.BoolVar(&flags.noLock, "no-lock", false, "ignore any profile lock")
+	flagset.DurationVar(&flags.lockWait, "lock-wait", 0, "wait up to duration to acquire a lock (syntax \"1h5m30s\")")
 
 	flagset.BoolVar(&flags.noAnsi, "no-ansi", false, "disable ansi control characters (disable console colouring)")
 	flagset.StringVar(&flags.theme, "theme", constants.DefaultTheme, "console colouring theme (dark, light, none)")

--- a/main.go
+++ b/main.go
@@ -350,6 +350,8 @@ func runProfile(
 		sigChan,
 	)
 
+	wrapper.setGlobal(global)
+
 	if flags.noLock {
 		wrapper.ignoreLock()
 	} else if flags.lockWait > 0 {

--- a/main.go
+++ b/main.go
@@ -349,6 +349,13 @@ func runProfile(
 		resticArguments,
 		sigChan,
 	)
+
+	if flags.noLock {
+		wrapper.ignoreLock()
+	} else if flags.lockWait > 0 {
+		wrapper.maxWaitOnLock(flags.lockWait)
+	}
+
 	err = wrapper.runProfile()
 	if err != nil {
 		return err

--- a/schedule_jobs.go
+++ b/schedule_jobs.go
@@ -37,9 +37,19 @@ func scheduleJobs(schedulerType, profileName string, configs []*config.ScheduleC
 			"--name",
 			scheduleConfig.Title(),
 		}
+
 		if runtime.GOOS != "darwin" && scheduleConfig.Logfile() != "" {
 			args = append(args, "--log", scheduleConfig.Logfile())
 		}
+
+		if scheduleConfig.LockMode() == config.ScheduleLockModeDefault {
+			if scheduleConfig.LockWait() > 0 {
+				args = append(args, "--lock-wait", scheduleConfig.LockWait().String())
+			}
+		} else if scheduleConfig.LockMode() == config.ScheduleLockModeIgnore {
+			args = append(args, "--no-lock")
+		}
+
 		args = append(args, getResticCommand(scheduleConfig.SubTitle()))
 
 		scheduleConfig.SetCommand(wd, binary, args)

--- a/shell/analyser.go
+++ b/shell/analyser.go
@@ -17,7 +17,7 @@ type OutputAnalyser struct {
 	matches map[string][]string
 }
 
-var outputAnalyzerPatterns = map[string]*regexp.Regexp{
+var outputAnalyserPatterns = map[string]*regexp.Regexp{
 	"lock-failure,who":   regexp.MustCompile("unable to create lock.+already locked.+?by (.+)$"),
 	"lock-failure,age":   regexp.MustCompile("lock was created at.+\\(([^()]+)\\s+ago\\)"),
 	"lock-failure,stale": regexp.MustCompile("the\\W+unlock\\W+command can be used to remove stale locks"),
@@ -67,17 +67,17 @@ func (a OutputAnalyser) GetRemoteLockedBy() (string, bool) {
 	return "", false
 }
 
-func (a OutputAnalyser) AnalyzeStringLines(output string) OutputAnalysis {
-	return a.AnalyzeLines(strings.NewReader(output))
+func (a OutputAnalyser) AnalyseStringLines(output string) OutputAnalysis {
+	return a.AnalyseLines(strings.NewReader(output))
 }
 
-func (a OutputAnalyser) AnalyzeLines(output io.Reader) OutputAnalysis {
+func (a OutputAnalyser) AnalyseLines(output io.Reader) OutputAnalysis {
 	a.lock.Lock()
 	defer a.lock.Unlock()
 
 	scanner := bufio.NewScanner(output)
 	for scanner.Scan() {
-		a.analyzeLine(scanner.Text())
+		a.analyseLine(scanner.Text())
 	}
 
 	if err := scanner.Err(); err != nil {
@@ -87,8 +87,8 @@ func (a OutputAnalyser) AnalyzeLines(output io.Reader) OutputAnalysis {
 	return a
 }
 
-func (a OutputAnalyser) analyzeLine(line string) {
-	for name, pattern := range outputAnalyzerPatterns {
+func (a OutputAnalyser) analyseLine(line string) {
+	for name, pattern := range outputAnalyserPatterns {
 		match := pattern.FindStringSubmatch(line)
 		if match != nil {
 			a.matches[name] = match
@@ -99,5 +99,5 @@ func (a OutputAnalyser) analyzeLine(line string) {
 	}
 }
 
-// Ensure OutputAnalyzer implements OutputAnalysis
+// Ensure OutputAnalyser implements OutputAnalysis
 var _ = OutputAnalysis(NewOutputAnalyser())

--- a/shell/analyser_test.go
+++ b/shell/analyser_test.go
@@ -15,7 +15,7 @@ the 'unlock' command can be used to remove stale locks
 `
 
 func TestRemoteLockFailure(t *testing.T) {
-	analysis := NewOutputAnalyser().AnalyzeStringLines(ResticLockFailureOutput)
+	analysis := NewOutputAnalyser().AnalyseStringLines(ResticLockFailureOutput)
 
 	assert.Equal(t, true, analysis.ContainsRemoteLockFailure())
 

--- a/shell/analyzer.go
+++ b/shell/analyzer.go
@@ -1,0 +1,103 @@
+package shell
+
+import (
+	"bufio"
+	"io"
+	"regexp"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/creativeprojects/clog"
+)
+
+type OutputAnalyser struct {
+	lock    sync.Locker
+	counts  map[string]int
+	matches map[string][]string
+}
+
+var outputAnalyzerPatterns = map[string]*regexp.Regexp{
+	"lock-failure,who":   regexp.MustCompile("unable to create lock.+already locked.+?by (.+)$"),
+	"lock-failure,age":   regexp.MustCompile("lock was created at.+\\(([^()]+)\\s+ago\\)"),
+	"lock-failure,stale": regexp.MustCompile("the\\W+unlock\\W+command can be used to remove stale locks"),
+}
+
+func NewOutputAnalyser() *OutputAnalyser {
+	return &OutputAnalyser{
+		counts:  map[string]int{},
+		matches: map[string][]string{},
+		lock:    &sync.Mutex{},
+	}
+}
+
+func (a OutputAnalyser) ContainsRemoteLockFailure() bool {
+	a.lock.Lock()
+	defer a.lock.Unlock()
+
+	if count, ok := a.counts["lock-failure"]; ok {
+		return count >= 2
+	}
+	return false
+}
+
+func (a OutputAnalyser) GetRemoteLockedSince() (time.Duration, bool) {
+	a.lock.Lock()
+	defer a.lock.Unlock()
+
+	if m, ok := a.matches["lock-failure,age"]; ok && len(m) > 1 {
+		if lockAge, err := time.ParseDuration(m[1]); err == nil {
+			return lockAge.Truncate(time.Millisecond), true
+		} else {
+			clog.Warningf("Failed parsing restic lock age. Cause %s", err.Error())
+		}
+	}
+
+	return 0, false
+}
+
+func (a OutputAnalyser) GetRemoteLockedBy() (string, bool) {
+	a.lock.Lock()
+	defer a.lock.Unlock()
+
+	if m, ok := a.matches["lock-failure,who"]; ok && len(m) > 1 {
+		return m[1], true
+	}
+
+	return "", false
+}
+
+func (a OutputAnalyser) AnalyzeStringLines(output string) OutputAnalysis {
+	return a.AnalyzeLines(strings.NewReader(output))
+}
+
+func (a OutputAnalyser) AnalyzeLines(output io.Reader) OutputAnalysis {
+	a.lock.Lock()
+	defer a.lock.Unlock()
+
+	scanner := bufio.NewScanner(output)
+	for scanner.Scan() {
+		a.analyzeLine(scanner.Text())
+	}
+
+	if err := scanner.Err(); err != nil {
+		clog.Warningf("Failed analyzing all output lines. Cause %s", err.Error())
+	}
+
+	return a
+}
+
+func (a OutputAnalyser) analyzeLine(line string) {
+	for name, pattern := range outputAnalyzerPatterns {
+		match := pattern.FindStringSubmatch(line)
+		if match != nil {
+			a.matches[name] = match
+
+			baseName := strings.Split(name, ",")[0]
+			a.counts[baseName]++
+		}
+	}
+}
+
+// Ensure OutputAnalyzer implements OutputAnalysis
+var _ = OutputAnalysis(NewOutputAnalyser())

--- a/shell/analyzer_test.go
+++ b/shell/analyzer_test.go
@@ -1,0 +1,33 @@
+package shell
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+const ResticLockFailureOutput = `
+unable to create lock in backend: repository is already locked by PID 27153 on app-server-01 by root (UID 0, GID 0)
+lock was created at 2021-04-17 19:00:16 (1s727.5ms ago)
+storage ID 870530a4
+the 'unlock' command can be used to remove stale locks
+`
+
+func TestRemoteLockFailure(t *testing.T) {
+	analysis := NewOutputAnalyser().AnalyzeStringLines(ResticLockFailureOutput)
+
+	assert.Equal(t, true, analysis.ContainsRemoteLockFailure())
+
+	{
+		since, ok := analysis.GetRemoteLockedSince()
+		assert.Equal(t, true, ok)
+		assert.Equal(t, time.Second+(727*time.Millisecond), since)
+	}
+
+	{
+		name, ok := analysis.GetRemoteLockedBy()
+		assert.Equal(t, true, ok)
+		assert.Equal(t, "PID 27153 on app-server-01 by root (UID 0, GID 0)", name)
+	}
+}

--- a/shell/command.go
+++ b/shell/command.go
@@ -10,6 +10,8 @@ import (
 	"runtime"
 	"strings"
 	"time"
+
+	"github.com/creativeprojects/clog"
 )
 
 const (
@@ -133,9 +135,13 @@ func (c *Command) Run() (Summary, string, error) {
 		if stderrOutput == nil {
 			stderrOutput = os.Stderr
 		}
-		err = c.ScanStderr(stderr, stderrOutput, errors)
 
-		if e := cmd.Wait(); err == nil {
+		err = c.ScanStderr(stderr, stderrOutput, errors)
+		if err != nil {
+			clog.Errorf("failed reading stderr from command: %s ; Cause: %s", command, err.Error())
+		}
+
+		if e := cmd.Wait(); e != nil {
 			err = e
 		}
 	} else {

--- a/shell/command.go
+++ b/shell/command.go
@@ -65,8 +65,8 @@ func (c *Command) Run() (Summary, string, error) {
 	var err error
 	var stdout, stderr io.ReadCloser
 
-	analyzer := NewOutputAnalyser()
-	summary := Summary{OutputAnalysis: analyzer}
+	analyser := NewOutputAnalyser()
+	summary := Summary{OutputAnalysis: analyser}
 
 	command, args, err := c.getShellCommand()
 	if err != nil {
@@ -145,7 +145,7 @@ func (c *Command) Run() (Summary, string, error) {
 	// finish summary
 	summary.Duration = time.Since(start)
 	errorText := errors.String()
-	analyzer.AnalyzeStringLines(errorText)
+	analyser.AnalyseStringLines(errorText)
 
 	return summary, errorText, err
 }

--- a/shell/command_test.go
+++ b/shell/command_test.go
@@ -356,7 +356,7 @@ func TestResticCanCatchInterruptSignal(t *testing.T) {
 	// assert.Error(t, err)
 }
 
-func TestCanAnalyzeLockFailure(t *testing.T) {
+func TestCanAnalyseLockFailure(t *testing.T) {
 	file, err := ioutil.TempFile(".", "test-restic-lock-failure")
 	assert.NoError(t, err)
 	file.Write([]byte(ResticLockFailureOutput))

--- a/shell/summary.go
+++ b/shell/summary.go
@@ -14,4 +14,18 @@ type Summary struct {
 	FilesTotal      int
 	BytesAdded      uint64
 	BytesTotal      uint64
+	OutputAnalysis  OutputAnalysis
+}
+
+// OutputAnalysis of the profile run
+type OutputAnalysis interface {
+	// ContainsRemoteLockFailure returns true if the output indicates that remote locking failed.
+	ContainsRemoteLockFailure() bool
+
+	// GetRemoteLockedSince returns the time duration since the remote lock was created.
+	// If no remote lock is held or the time cannot be determined, the second parameter is false.
+	GetRemoteLockedSince() (time.Duration, bool)
+
+	// GetRemoteLockedBy returns who locked the remote lock, if available.
+	GetRemoteLockedBy() (string, bool)
 }

--- a/wrapper.go
+++ b/wrapper.go
@@ -54,7 +54,7 @@ func (c *commandError) ExitCode() (int, error) {
 	if exitError, ok := asExitError(c.err); ok {
 		return exitError.ExitCode(), nil
 	} else {
-		return 0, errors.New("not and exit error. Exit code not available")
+		return 0, errors.New("exit code not available")
 	}
 }
 

--- a/wrapper.go
+++ b/wrapper.go
@@ -642,10 +642,10 @@ func (r *resticWrapper) canRetryAfterRemoteLockFailure(output shell.OutputAnalys
 	}
 
 	// Check if we have time left to wait on a non-stale lock
-	retryDelay := r.global.ResticLockRetryTime
+	retryDelay := r.global.ResticLockRetryAfter
 
 	if r.lockWait != nil && retryDelay >= constants.MinResticLockRetryTime {
-		elapsedTime := time.Now().Sub(r.startTime)
+		elapsedTime := time.Since(r.startTime)
 		availableTime := *r.lockWait - elapsedTime + r.executionTime
 
 		if retryDelay > constants.MaxResticLockRetryTime {
@@ -763,7 +763,7 @@ func lockRun(lockFile string, force bool, lockWait *time.Duration, run func(setP
 				return fmt.Errorf("another process is already running this profile: %s", locker)
 
 			} else {
-				if time.Now().Sub(start) < *lockWait {
+				if time.Since(start) < *lockWait {
 					lockName := fmt.Sprintf("%s locked by %s", lockFile, locker)
 					lockWaitLogged = logLockWait(lockName, start, lockWaitLogged, *lockWait)
 

--- a/wrapper_test.go
+++ b/wrapper_test.go
@@ -433,7 +433,7 @@ func TestCanRetryAfterRemoteLockFailure(t *testing.T) {
 	profile.Repository = "my-repo"
 	wrapper := newResticWrapper(mockBinary, false, false, profile, "backup", nil, nil)
 	wrapper.startTime = time.Now()
-	wrapper.global.ResticLockRetryTime = 0 // disable remote lock retry
+	wrapper.global.ResticLockRetryAfter = 0 // disable remote lock retry
 
 	// No retry when no remote-lock failure
 	assert.False(t, mockOutput.ContainsRemoteLockFailure())
@@ -453,18 +453,18 @@ func TestCanRetryAfterRemoteLockFailure(t *testing.T) {
 
 	// No retry when no time left
 	wrapper.maxWaitOnLock(constants.MinResticLockRetryTime - time.Nanosecond)
-	wrapper.global.ResticLockRetryTime = constants.MinResticLockRetryTime // enable remote lock retry
+	wrapper.global.ResticLockRetryAfter = constants.MinResticLockRetryTime // enable remote lock retry
 	retry, sleep = wrapper.canRetryAfterRemoteLockFailure(mockOutput)
 	assert.False(t, retry)
 
-	// Retry is acceptable when there is enough remaining time for the delay (ResticLockRetryTime)
+	// Retry is acceptable when there is enough remaining time for the delay (ResticLockRetryAfter)
 	wrapper.maxWaitOnLock(constants.MinResticLockRetryTime + 50*time.Millisecond)
 	retry, sleep = wrapper.canRetryAfterRemoteLockFailure(mockOutput)
 	assert.True(t, retry)
 	assert.Equal(t, constants.MinResticLockRetryTime, sleep)
 
 	wrapper.maxWaitOnLock(constants.MaxResticLockRetryTime + 50*time.Millisecond)
-	wrapper.global.ResticLockRetryTime = 2 * constants.MaxResticLockRetryTime
+	wrapper.global.ResticLockRetryAfter = 2 * constants.MaxResticLockRetryTime
 	retry, sleep = wrapper.canRetryAfterRemoteLockFailure(mockOutput)
 	assert.True(t, retry)
 	assert.Equal(t, constants.MaxResticLockRetryTime, sleep)


### PR DESCRIPTION
This draft PR adds 2 resticprofile flags (and schedule & global configs) to control locking behaviour (profile locks & restic remote locks)

@creativeprojects, let me know whether this is acceptable. If so I'll test and document it. 
Currently I'm not using the built-in locking as I'm missing these 2 features.

Added flags:
* `--no-lock`: Ignores any defined locks. 
   Motivation: Not all tasks really need a lock, e.g. I usually run `resiticprofile --name $PROFILE_NAME unlock` as pre-run to ensure stale locks are removed. With profile locks this only works when locks can be ignored.

* `--lock-wait`: Wait up to the specified duration to acquire a lock before failing.
  Motivation: When triggering operations that should use a lock, one can't always avoid concurrency (e.g. in schedules that may take longer than expected). However it should be configurable whether concurrency will immediately cause a failure or only when some time passed and it didn't resolve.

Added schedule config:
* `schedule-lock-mode` (default | fail | ignore): Toggles wether to set `--lock-wait` (default) or `--no-lock` (ignore) flags.
* `schedule-lock-wait`: Toggles whether `default` sets `--lock-wait` to a duration.

Added global config:
* `restic-lock-retry-after`: Sets a delay for retrying restic commands that fail to acquire a repository lock. 0 disables handling remote lock failures.
* `restic-stale-lock-age`: Sets a lock age for detecting stale locks. Stale locks are not waited upon but `restic unlock` is tried once (when `force-inactive-lock` is also set in the profile). 0 disables stale lock handling.

Status
- [x] Implemented drafts
- [x] Test config changes
- [x] Test profile lock handling
- [x] Test restic lock handling