### PR TITLE
add Homebrew Tap

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -92,7 +92,7 @@ brews:
       - targz
     tap:
       owner: creativeprojects
-      name: "{{ .ProjectName }}"
+      name: "homebrew-{{{ .ProjectName }}"
     folder: Formula
     homepage: https://github.com/creativeprojects/{{ .ProjectName }}
     description: Configuration profiles for restic backup

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -87,3 +87,35 @@ dockers:
     dockerfile: build/Dockerfile
     extra_files:
     - build/restic
+
+
+brews:
+  - 
+    ids:
+      - targz
+    tap:
+      owner: creativeprojects
+      name: "{{ .ProjectName }}"
+    folder: Formula
+    homepage: https://github.com/creativeprojects/{{ .ProjectName }}
+    description: Configuration profiles for restic backup
+    license: "GPL-3.0-only"
+    custom_block: |
+      head "https://github.com/creativeprojects/{{ .ProjectName }}.git"
+    dependencies:
+      - name: restic
+    test: |
+      (testpath/"restic_repo").mkdir
+      (testpath/"password.txt").write("key")
+      (testpath/"profiles.yaml").write <<~EOS
+        default:
+          repository: "local:#{testpath}/restic_repo"
+          password-file: "password.txt"
+          initialize: true
+      EOS
+
+      (testpath/"testfile").write("This is a testfile")
+
+      system "#{bin}/resticprofile", "backup", "testfile"
+      system "#{bin}/resticprofile", "restore", "latest", "-t", "#{testpath}/restore"
+      assert compare_file "testfile", "#{testpath}/restore/testfile"

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -31,8 +31,6 @@ builds:
     ignore:
       - goos: darwin
         goarch: arm
-      - goos: darwin
-        goarch: arm64
       - goos: freebsd
         goarch: arm64
       - goos: windows
@@ -87,7 +85,6 @@ dockers:
     dockerfile: build/Dockerfile
     extra_files:
     - build/restic
-
 
 brews:
   - 


### PR DESCRIPTION
This MR adds instructions for GoReleaser to release a [Homebrew Tap](https://docs.brew.sh/Taps).

I don't think it's required to set a specific `$HOMEBREW_TAP_GITHUB_TOKEN` as long as the provided token is allowed to push to the repository.

Closes #44 