### PR TITLE
Summary from plain output when not run in terminal

### DIFF
--- a/README.md
+++ b/README.md
@@ -1391,9 +1391,17 @@ Here's an example of a generated file, where you can see that the last `check` f
 }
 ```
 
-## Extended status
+Note: In the backup section above you can see some fields like `files_new`, `files_total`, etc. This information is only available when resticprofile's output is either *not* sent to the terminal (e.g. redirected) or when you add the flag `extended-status` to your backup configuration.
+This is a technical limitation to ensure restic displays terminal output correctly. 
 
-On the previous example of a status file you can see some fields like `files_new`, `files_total`, etc. To be able to get this information from restic, you need to add the flag `extended-status` to your backup configuration.
+`extended-status` or stdout redirection is **not needed** for these fields:
+- success
+- time
+- error
+- stderr
+- duration
+
+## Extended status
 
 `extended-status` is **not set by default because it hides any output from restic**
 
@@ -1408,13 +1416,6 @@ profile:
           - "/**/.git/"
 
 ```
-
-`extended-status` is **not needed** for these fields:
-- success
-- time
-- error
-- stderr
-- duration
 
 # Variable expansion in configuration file
 

--- a/term/term.go
+++ b/term/term.go
@@ -72,6 +72,12 @@ func ReadLine() (string, error) {
 	return strings.TrimSpace(line), nil
 }
 
+// OsStdoutIsTerminal returns true as os.Stdout is a terminal session
+func OsStdoutIsTerminal() bool {
+	fd := int(os.Stdout.Fd())
+	return terminal.IsTerminal(fd)
+}
+
 // SetOutput changes the default output for the Print* functions
 func SetOutput(w io.Writer) {
 	terminalOutput = w

--- a/wrapper.go
+++ b/wrapper.go
@@ -308,13 +308,13 @@ func (r *resticWrapper) runCommand(command string) error {
 	for {
 		rCommand := r.prepareCommand(command, args)
 
-		if command == constants.CommandBackup && r.profile.StatusFile != "" {
-			if r.profile.Backup != nil && r.profile.Backup.ExtendedStatus {
+		if command == constants.CommandBackup && r.profile.StatusFile != "" && r.profile.Backup != nil {
+			if r.profile.Backup.ExtendedStatus {
 				rCommand.scanOutput = shell.ScanBackupJson
-				// } else {
-				// scan plain backup could have been a good idea,
-				// except restic detects its output is not a terminal and no longer displays the progress
-				// rCommand.scanOutput = shell.ScanBackupPlain
+			} else if !term.OsStdoutIsTerminal() {
+				// restic detects its output is not a terminal and no longer displays the progress.
+				// Scan plain output only if resticprofile is not run from a terminal (e.g. schedule)
+				rCommand.scanOutput = shell.ScanBackupPlain
 			}
 		}
 


### PR DESCRIPTION
Small enhancement: Allow to use _restic_ plain output to fill summary (and `status-file`) when `resticprofile` output is redirected (= not sent to terminal), since in this case there is no disadvantage of intercepting stdout.

The alternative of using `extended-status: true` is even more limited as it cuts all normal output, which can be problematic when one wants to inspect the logs later.