### PR TITLE
add Hostname pre-defined variable to template resolver

### DIFF
--- a/README.md
+++ b/README.md
@@ -1438,6 +1438,7 @@ The list of pre-defined variables is:
 - **.Now** ([time.Time](https://golang.org/pkg/time/) object)
 - **.CurrentDir** (string)
 - **.ConfigDir** (string)
+- **.Hostname** (string)
 - **.Env.{NAME}** (string)
 
 Environment variables are accessible using `.Env.` followed by the name of the environment variable.

--- a/config/template.go
+++ b/config/template.go
@@ -13,6 +13,7 @@ type TemplateData struct {
 	Now        time.Time
 	CurrentDir string
 	ConfigDir  string
+	Hostname   string
 	Env        map[string]string
 }
 
@@ -27,6 +28,10 @@ func newTemplateData(configFile, profileName string) TemplateData {
 	configDir := filepath.Dir(configFile)
 	if !filepath.IsAbs(configDir) {
 		configDir = filepath.Join(currentDir, configDir)
+	}
+	hostname, err := os.Hostname()
+	if err != nil {
+		hostname = "localhost"
 	}
 	env := make(map[string]string, len(os.Environ()))
 	for _, envValue := range os.Environ() {
@@ -43,6 +48,7 @@ func newTemplateData(configFile, profileName string) TemplateData {
 		Now:        time.Now(),
 		ConfigDir:  configDir,
 		CurrentDir: currentDir,
+		Hostname:   hostname,
 		Env:        env,
 	}
 }


### PR DESCRIPTION
One use case for that could be :

```
global:
  default-command: snapshots
  initialize: false
  scheduler: crond

default:
  repository: s3:http://my.local.minio/{{ .Hostname }}-{{ .Profile.Name }}
  password-file: {{ .ConfigDir }}/{{ .Hostname }}.key

(...)

home-src:
  inherit: default

  backup:
    source:
    - {{ .Env.HOME }}/src

```

Then, running `resticprofile --name home-src` would use different buckets (and keys) if running the same profile on different machines.