### PR TITLE
Feature: Hide confidential values in output

### DIFF
--- a/command_error.go
+++ b/command_error.go
@@ -26,8 +26,9 @@ func (c *commandError) Error() string {
 
 func (c *commandError) Commandline() string {
 	args := ""
-	if c.scd.args != nil && len(c.scd.args) > 0 {
-		args = fmt.Sprintf(" \"%s\"", strings.Join(c.scd.args, "\" \""))
+	argsList := c.scd.publicArgs
+	if argsList != nil && len(argsList) > 0 {
+		args = fmt.Sprintf(" \"%s\"", strings.Join(argsList, "\" \""))
 	}
 	return fmt.Sprintf("\"%s\"%s", c.scd.command, args)
 }

--- a/config/confidential.go
+++ b/config/confidential.go
@@ -1,0 +1,132 @@
+package config
+
+import (
+	"reflect"
+	"regexp"
+)
+
+const ConfidentialReplacement = "***"
+
+// ConfidentialValue is a string value with a public and a confidential representation
+type ConfidentialValue struct {
+	public, confidential string
+}
+
+func (c ConfidentialValue) Value() string {
+	return c.confidential
+}
+
+func (c ConfidentialValue) String() string {
+	return c.public
+}
+
+func (c *ConfidentialValue) IsConfidential() bool {
+	return c.public != c.confidential
+}
+
+// hideValue hides the entire value in the public representation
+func (c *ConfidentialValue) hideValue() {
+	if c.IsConfidential() {
+		return
+	}
+	c.public = ConfidentialReplacement
+}
+
+// hideSubmatches hides all occurrences of submatches in the public representation
+func (c *ConfidentialValue) hideSubmatches(pattern *regexp.Regexp) {
+	if c.IsConfidential() {
+		return
+	}
+
+	if matches := pattern.FindStringSubmatchIndex(c.confidential); matches != nil && len(matches) > 2 {
+		c.public = c.confidential
+
+		for i := len(matches) - 2; i > 1; i -= 2 {
+			start := matches[i]
+			end := matches[i+1]
+
+			c.public = c.public[0:start] + ConfidentialReplacement + c.public[end:]
+		}
+	}
+}
+
+func NewConfidentialValue(value string) ConfidentialValue {
+	return ConfidentialValue{public: value, confidential: value}
+}
+
+// confidentialValueDecoder implements parsing config parsing for ConfidentialValue
+func confidentialValueDecoder() func(from reflect.Type, to reflect.Type, data interface{}) (interface{}, error) {
+	confidentialValueType := reflect.TypeOf(ConfidentialValue{})
+
+	return func(from reflect.Type, to reflect.Type, data interface{}) (interface{}, error) {
+		if to != confidentialValueType {
+			return data, nil
+		}
+
+		// Source type may be boolean, numeric or string
+		values, isset := stringifyValue(reflect.ValueOf(data))
+		if len(values) == 0 {
+			if isset {
+				values = []string{"1"}
+			} else {
+				values = []string{"0"}
+			}
+		}
+
+		return NewConfidentialValue(values[0]), nil
+	}
+}
+
+// See https://restic.readthedocs.io/en/latest/030_preparing_a_new_repo.html
+var (
+	urlConfidentialPart = regexp.MustCompile("[:/][^:/@]+?:([^:@]+?)@[^:/@]+?") // user:pass@host
+	urlEnvKeys          = regexp.MustCompile("(?i)^.+(_AUTH|_URL)$")
+	hiddenEnvKeys       = regexp.MustCompile("(?i)^(.+_KEY|.+_TOKEN|.*PASSWORD.*|.*SECRET.*)$")
+)
+
+// ProcessConfidentialValues hides confidential parts inside the specified Profile.
+func ProcessConfidentialValues(profile *Profile) {
+	if profile == nil {
+		return
+	}
+
+	// Handle the repo URL
+	profile.Repository.hideSubmatches(urlConfidentialPart)
+
+	// Handle env variables
+	for name, value := range profile.Environment {
+		if hiddenEnvKeys.MatchString(name) {
+			value.hideValue()
+			profile.Environment[name] = value
+		} else if urlEnvKeys.MatchString(name) {
+			value.hideSubmatches(urlConfidentialPart)
+			profile.Environment[name] = value
+		}
+	}
+}
+
+// GetNonConfidentialValues returns a new list with confidential values being replaced with their public representation
+func GetNonConfidentialValues(profile *Profile, values []string) []string {
+	if profile == nil {
+		return values
+	}
+
+	confidentials := []*ConfidentialValue{&profile.Repository}
+	for _, value := range profile.Environment {
+		confidentials = append(confidentials, &value)
+	}
+
+	target := make([]string, len(values))
+
+	for i := len(values) - 1; i >= 0; i-- {
+		target[i] = values[i]
+
+		for _, c := range confidentials {
+			if c.IsConfidential() && target[i] == c.Value() {
+				target[i] = c.String()
+			}
+		}
+	}
+
+	return target
+}

--- a/config/confidential_test.go
+++ b/config/confidential_test.go
@@ -3,6 +3,7 @@ package config
 import (
 	"bytes"
 	"fmt"
+	"reflect"
 	"regexp"
 	"strings"
 	"testing"
@@ -35,6 +36,26 @@ func TestConfidentialHideSubmatch(t *testing.T) {
 
 	expected := fmt.Sprintf("some-%s-with-%s-parts", ConfidentialReplacement, ConfidentialReplacement)
 	assert.Equal(t, expected, value.String())
+}
+
+func TestFmtStringDoesntLeakConfidentialValues(t *testing.T) {
+	value := NewConfidentialValue("secret")
+	value.hideValue()
+
+	assert.Equal(t, ConfidentialReplacement, fmt.Sprintf("%s", value))
+	assert.Equal(t, ConfidentialReplacement, fmt.Sprintf("%v", value))
+	assert.Equal(t, ConfidentialReplacement, value.String())
+	assert.Equal(t, "secret", value.Value())
+}
+
+func TestStringifyPassesConfidentialValues(t *testing.T) {
+	value := NewConfidentialValue("secret")
+	value.hideValue()
+
+	v1, _ := stringifyValue(reflect.ValueOf(value))
+	v2, _ := stringifyConfidentialValue(reflect.ValueOf(value))
+	assert.Equal(t, []string{ConfidentialReplacement}, v1)
+	assert.Equal(t, []string{"secret"}, v2)
 }
 
 func TestConfidentialURLs(t *testing.T) {

--- a/config/confidential_test.go
+++ b/config/confidential_test.go
@@ -1,0 +1,192 @@
+package config
+
+import (
+	"bytes"
+	"fmt"
+	"regexp"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+var defaultUrl = "local:user:pass@host"
+var defaultUrlReplaced = fmt.Sprintf("local:user:%s@host", ConfidentialReplacement)
+
+func TestConfidentialHideAll(t *testing.T) {
+	value := NewConfidentialValue("val")
+
+	assert.Equal(t, value.String(), value.Value())
+	assert.Equal(t, "val", value.String())
+
+	value.hideValue()
+	assert.Equal(t, "val", value.Value())
+	assert.Equal(t, ConfidentialReplacement, value.String())
+}
+
+func TestConfidentialHideSubmatch(t *testing.T) {
+	value := NewConfidentialValue("some-vAl-with-sEcRet-parts")
+
+	assert.Equal(t, value.String(), value.Value())
+	assert.Equal(t, "some-vAl-with-sEcRet-parts", value.String())
+
+	value.hideSubmatches(regexp.MustCompile("(?i).+(val).+(secret).+"))
+	assert.Equal(t, "some-vAl-with-sEcRet-parts", value.Value())
+
+	expected := fmt.Sprintf("some-%s-with-%s-parts", ConfidentialReplacement, ConfidentialReplacement)
+	assert.Equal(t, expected, value.String())
+}
+
+func TestConfidentialURLs(t *testing.T) {
+	// https://restic.readthedocs.io/en/latest/030_preparing_a_new_repo.html
+	urls := map[string]string{
+		"local:some/path":                                      "-",
+		"sftp:user@host:/srv/restic-repo":                      "-",
+		"sftp://user@[::1]:2222//srv/restic-repo":              "-",
+		"sftp:restic-backup-host:/srv/restic-repo":             "-",
+		"rest:http://host:8000/":                               "-",
+		"rest:https://user:1234fdfASDasfwY.-+;@host:8000/":     fmt.Sprintf("rest:https://user:%s@host:8000/", ConfidentialReplacement),
+		"rest:https://user:35%3Asad%C3%B6p%C3%9F@host:8000/":   fmt.Sprintf("rest:https://user:%s@host:8000/", ConfidentialReplacement),
+		"rest:https://user:pass@host:8000/f/":                  fmt.Sprintf("rest:https://user:%s@host:8000/f/", ConfidentialReplacement),
+		"s3:s3.amazonaws.com/bucket_name":                      "-",
+		"s3:https://<WASABI-SERVICE-URL>/<WASABI-BUCKET-NAME>": "-",
+		"swift:container_name:/path":                           "-",
+		"azure:foo:/":                                          "-",
+		"gs:foo:/":                                             "-",
+		"rclone:b2prod:yggdrasil/foo/bar/baz":                  "-",
+	}
+
+	for url, expected := range urls {
+		testConfig := fmt.Sprintf(`
+[profile]
+repository = "%s"
+`, url)
+
+		profile, err := getProfile("toml", testConfig, "profile")
+		assert.Nil(t, err)
+		assert.NotNil(t, profile)
+
+		if expected == "-" {
+			expected = url
+		}
+		assert.Equal(t, expected, profile.Repository.String())
+		assert.Equal(t, url, profile.Repository.Value())
+	}
+}
+
+func TestConfidentialEnvironment(t *testing.T) {
+	// https://restic.readthedocs.io/en/latest/030_preparing_a_new_repo.html
+	vars := map[string]string{
+		"MY_VALUE": "-",
+		"MY_KEY":   "*",
+		"PASSWORD": "*",
+		"MY_URL":   "<url>",
+		// AWS, MinIO, Wasabi, Alibaba Cloud
+		"AWS_ACCESS_KEY_ID":     "-",
+		"AWS_SECRET_ACCESS_KEY": "*",
+		"AWS_DEFAULT_REGION":    "-",
+		// OpenStack Swift
+		"ST_AUTH":                          "<url>",
+		"ST_USER":                          "-",
+		"ST_KEY":                           "*",
+		"OS_AUTH_URL":                      "<url>",
+		"OS_REGION_NAME":                   "-",
+		"OS_USERNAME":                      "-",
+		"OS_PASSWORD":                      "*",
+		"OS_TENANT_ID":                     "-",
+		"OS_TENANT_NAME":                   "-",
+		"OS_USER_ID":                       "-",
+		"OS_USER_DOMAIN_NAME":              "-",
+		"OS_USER_DOMAIN_ID":                "-",
+		"OS_PROJECT_NAME":                  "-",
+		"OS_PROJECT_DOMAIN_NAME":           "-",
+		"OS_PROJECT_DOMAIN_ID":             "-",
+		"OS_TRUST_ID":                      "-",
+		"OS_APPLICATION_CREDENTIAL_ID":     "-",
+		"OS_APPLICATION_CREDENTIAL_NAME":   "-",
+		"OS_APPLICATION_CREDENTIAL_SECRET": "*",
+		"OS_STORAGE_URL":                   "<url>",
+		"OS_AUTH_TOKEN":                    "*",
+		"SWIFT_DEFAULT_CONTAINER_POLICY":   "-",
+		// Backblaze B2
+		"B2_ACCOUNT_ID":  "-",
+		"B2_ACCOUNT_KEY": "*",
+		// Microsoft Azure Blob Storage
+		"AZURE_ACCOUNT_NAME": "-",
+		"AZURE_ACCOUNT_KEY":  "*",
+		// Google Cloud Storage
+		"GOOGLE_PROJECT_ID":              "-",
+		"GOOGLE_APPLICATION_CREDENTIALS": "-",
+		"GOOGLE_ACCESS_TOKEN":            "*",
+	}
+
+	for name, expected := range vars {
+		testConfig := fmt.Sprintf(`
+[profile.env]
+%s = "%s"
+`, name, defaultUrl)
+
+		profile, err := getProfile("toml", testConfig, "profile")
+		assert.Nil(t, err)
+		assert.NotNil(t, profile)
+
+		switch expected {
+		case "<url>":
+			expected = defaultUrlReplaced
+		case "*":
+			expected = ConfidentialReplacement
+		default:
+			expected = defaultUrl
+		}
+
+		name = strings.ToLower(name)
+		env := profile.Environment[name]
+		assert.Equal(t, expected, env.String())
+		assert.Equal(t, defaultUrl, env.Value())
+	}
+}
+
+func TestShowConfigHidesConfidentialValues(t *testing.T) {
+	testConfig := `
+profile:
+  repository: "local:user:pass@host"
+  env:
+    MY_VALUE: "val"
+    MY_URL: "local:user:pass@host"
+    MY_KEY: 1234
+    MY_TOKEN: false
+    MY_PASSWORD: "otherval"
+`
+	profile, err := getProfile("yaml", testConfig, "profile")
+	assert.Nil(t, err)
+	assert.NotNil(t, profile)
+
+	buffer := &bytes.Buffer{}
+	assert.Nil(t, ShowStruct(buffer, profile, "p"))
+
+	result := regexp.MustCompile("\\s+").ReplaceAllString(buffer.String(), " ")
+	result = strings.TrimSpace(result)
+
+	assert.Contains(t, result, "my_value: val")
+	assert.Contains(t, result, "my_url: "+defaultUrlReplaced)
+	assert.Contains(t, result, "my_key: "+ConfidentialReplacement)
+	assert.Contains(t, result, "my_token: "+ConfidentialReplacement)
+	assert.Contains(t, result, "my_password: "+ConfidentialReplacement)
+	assert.Contains(t, result, "repository: "+defaultUrlReplaced)
+}
+
+func TestGetNonConfidentialValues(t *testing.T) {
+	testConfig := `
+profile:
+  verbose: false
+  repository: "local:user:pass@host"
+  env:
+    MY_PASSWORD: "otherval"
+`
+	profile, err := getProfile("yaml", testConfig, "profile")
+	assert.Nil(t, err)
+	assert.NotNil(t, profile)
+
+	result := GetNonConfidentialValues(profile, []string{"a", defaultUrl, "b", "otherval", "c"})
+	assert.Equal(t, []string{"a", defaultUrlReplaced, "b", ConfidentialReplacement, "c"}, result)
+}

--- a/config/config.go
+++ b/config/config.go
@@ -45,10 +45,12 @@ type Config struct {
 var (
 	configOption = viper.DecodeHook(mapstructure.ComposeDecodeHookFunc(
 		mapstructure.StringToTimeDurationHookFunc(),
+		confidentialValueDecoder(),
 	))
 
 	configOptionHCL = viper.DecodeHook(mapstructure.ComposeDecodeHookFunc(
 		mapstructure.StringToTimeDurationHookFunc(),
+		confidentialValueDecoder(),
 		sliceOfMapsToMapHookFunc(),
 	))
 )
@@ -305,6 +307,7 @@ func (c *Config) getProfile(profileKey string) (*Profile, error) {
 	if err != nil {
 		return nil, err
 	}
+
 	if profile.Inherit != "" {
 		inherit := profile.Inherit
 		// Load inherited profile
@@ -323,6 +326,10 @@ func (c *Config) getProfile(profileKey string) (*Profile, error) {
 		// make sure it has the right name
 		profile.Name = profileKey
 	}
+
+	// Hide confidential values (keys, passwords) from the public representation
+	ProcessConfidentialValues(profile)
+
 	return profile, nil
 }
 

--- a/config/profile.go
+++ b/config/profile.go
@@ -12,34 +12,34 @@ import (
 type Profile struct {
 	config               *Config
 	Name                 string
-	Description          string                    `mapstructure:"description"`
-	Quiet                bool                      `mapstructure:"quiet" argument:"quiet"`
-	Verbose              bool                      `mapstructure:"verbose" argument:"verbose"`
-	Repository           string                    `mapstructure:"repository" argument:"repo"`
-	PasswordFile         string                    `mapstructure:"password-file" argument:"password-file"`
-	CacheDir             string                    `mapstructure:"cache-dir" argument:"cache-dir"`
-	CACert               string                    `mapstructure:"cacert" argument:"cacert"`
-	TLSClientCert        string                    `mapstructure:"tls-client-cert" argument:"tls-client-cert"`
-	Initialize           bool                      `mapstructure:"initialize"`
-	Inherit              string                    `mapstructure:"inherit"`
-	Lock                 string                    `mapstructure:"lock"`
-	ForceLock            bool                      `mapstructure:"force-inactive-lock"`
-	RunBefore            []string                  `mapstructure:"run-before"`
-	RunAfter             []string                  `mapstructure:"run-after"`
-	RunAfterFail         []string                  `mapstructure:"run-after-fail"`
-	StatusFile           string                    `mapstructure:"status-file"`
-	PrometheusSaveToFile string                    `mapstructure:"prometheus-save-to-file"`
-	PrometheusPush       string                    `mapstructure:"prometheus-push"`
-	PrometheusLabels     map[string]string         `mapstructure:"prometheus-labels"`
-	OtherFlags           map[string]interface{}    `mapstructure:",remain"`
-	Environment          map[string]string         `mapstructure:"env"`
-	Backup               *BackupSection            `mapstructure:"backup"`
-	Retention            *RetentionSection         `mapstructure:"retention"`
-	Check                *OtherSectionWithSchedule `mapstructure:"check"`
-	Prune                *OtherSectionWithSchedule `mapstructure:"prune"`
-	Snapshots            map[string]interface{}    `mapstructure:"snapshots"`
-	Forget               *OtherSectionWithSchedule `mapstructure:"forget"`
-	Mount                map[string]interface{}    `mapstructure:"mount"`
+	Description          string                       `mapstructure:"description"`
+	Quiet                bool                         `mapstructure:"quiet" argument:"quiet"`
+	Verbose              bool                         `mapstructure:"verbose" argument:"verbose"`
+	Repository           ConfidentialValue            `mapstructure:"repository" argument:"repo"`
+	PasswordFile         string                       `mapstructure:"password-file" argument:"password-file"`
+	CacheDir             string                       `mapstructure:"cache-dir" argument:"cache-dir"`
+	CACert               string                       `mapstructure:"cacert" argument:"cacert"`
+	TLSClientCert        string                       `mapstructure:"tls-client-cert" argument:"tls-client-cert"`
+	Initialize           bool                         `mapstructure:"initialize"`
+	Inherit              string                       `mapstructure:"inherit"`
+	Lock                 string                       `mapstructure:"lock"`
+	ForceLock            bool                         `mapstructure:"force-inactive-lock"`
+	RunBefore            []string                     `mapstructure:"run-before"`
+	RunAfter             []string                     `mapstructure:"run-after"`
+	RunAfterFail         []string                     `mapstructure:"run-after-fail"`
+	StatusFile           string                       `mapstructure:"status-file"`
+	PrometheusSaveToFile string                       `mapstructure:"prometheus-save-to-file"`
+	PrometheusPush       string                       `mapstructure:"prometheus-push"`
+	PrometheusLabels     map[string]string            `mapstructure:"prometheus-labels"`
+	OtherFlags           map[string]interface{}       `mapstructure:",remain"`
+	Environment          map[string]ConfidentialValue `mapstructure:"env"`
+	Backup               *BackupSection               `mapstructure:"backup"`
+	Retention            *RetentionSection            `mapstructure:"retention"`
+	Check                *OtherSectionWithSchedule    `mapstructure:"check"`
+	Prune                *OtherSectionWithSchedule    `mapstructure:"prune"`
+	Snapshots            map[string]interface{}       `mapstructure:"snapshots"`
+	Forget               *OtherSectionWithSchedule    `mapstructure:"forget"`
+	Mount                map[string]interface{}       `mapstructure:"mount"`
 }
 
 // BackupSection contains the specific configuration to the 'backup' command
@@ -260,12 +260,17 @@ func (p *Profile) Schedules() []*ScheduleConfig {
 
 	for name, section := range sections {
 		if s := getScheduleSection(section); s != nil && s.Schedule != nil && len(s.Schedule) > 0 {
+			env := map[string]string{}
+			for key, value := range p.Environment {
+				env[key] = value.Value()
+			}
+
 			config := &ScheduleConfig{
 				profileName: p.Name,
 				commandName: name,
 				schedules:   s.Schedule,
 				permission:  s.SchedulePermission,
-				environment: p.Environment,
+				environment: env,
 				logfile:     s.ScheduleLog,
 				lockMode:    s.ScheduleLockMode,
 				lockWait:    s.ScheduleLockWait,

--- a/config/profile_test.go
+++ b/config/profile_test.go
@@ -133,7 +133,7 @@ quiet = false
 	}
 	assert.NotNil(t, profile)
 	assert.Equal(t, "profile", profile.Name)
-	assert.Equal(t, "parent", profile.Repository)
+	assert.Equal(t, "parent", profile.Repository.String())
 	assert.Equal(t, true, profile.Initialize)
 	assert.Equal(t, int64(1), profile.OtherFlags["first-value"])
 	assert.Equal(t, int64(2), profile.OtherFlags["second-value"])

--- a/config/show.go
+++ b/config/show.go
@@ -51,18 +51,23 @@ func showSubStruct(orig interface{}, stack []string, display *Display) error {
 				continue
 			}
 			if valueOf.Field(i).Kind() == reflect.Struct {
-				var err error
-				if key == ",squash" {
-					// display on the same level
-					err = showSubStruct(valueOf.Field(i).Interface(), stack, display)
+				fieldIf := valueOf.Field(i).Interface()
+				if _, ok := fieldIf.(fmt.Stringer); ok {
+					// Pass as is. The struct has its own String() implementation
 				} else {
-					// start of a new struct
-					err = showSubStruct(valueOf.Field(i).Interface(), append(stack, key), display)
+					var err error
+					if key == ",squash" {
+						// display on the same level
+						err = showSubStruct(fieldIf, stack, display)
+					} else {
+						// start of a new struct
+						err = showSubStruct(fieldIf, append(stack, key), display)
+					}
+					if err != nil {
+						return err
+					}
+					continue
 				}
-				if err != nil {
-					return err
-				}
-				continue
 			}
 			if valueOf.Field(i).Kind() == reflect.Map {
 				if valueOf.Field(i).Len() == 0 {

--- a/config/template_test.go
+++ b/config/template_test.go
@@ -234,7 +234,7 @@ repository = "/mnt/backup"
 	require.NoError(t, err)
 	require.NotEmpty(t, profile)
 
-	assert.Equal(t, "/mnt/backup", profile.Repository)
+	assert.Equal(t, "/mnt/backup", profile.Repository.String())
 }
 
 func TestNestedTemplate(t *testing.T) {

--- a/shell_command.go
+++ b/shell_command.go
@@ -13,6 +13,7 @@ import (
 type shellCommandDefinition struct {
 	command    string
 	args       []string
+	publicArgs []string
 	env        []string
 	useStdin   bool
 	stdout     io.Writer
@@ -29,15 +30,16 @@ func newShellCommand(command string, args, env []string, dryRun bool, sigChan ch
 		env = make([]string, 0)
 	}
 	return shellCommandDefinition{
-		command:  command,
-		args:     args,
-		env:      env,
-		useStdin: false,
-		stdout:   os.Stdout,
-		stderr:   os.Stderr,
-		dryRun:   dryRun,
-		sigChan:  sigChan,
-		setPID:   setPID,
+		command:    command,
+		args:       args,
+		publicArgs: args,
+		env:        env,
+		useStdin:   false,
+		stdout:     os.Stdout,
+		stderr:     os.Stderr,
+		dryRun:     dryRun,
+		sigChan:    sigChan,
+		setPID:     setPID,
 	}
 }
 
@@ -46,7 +48,7 @@ func runShellCommand(command shellCommandDefinition) (progress.Summary, string, 
 	var err error
 
 	if command.dryRun {
-		clog.Infof("dry-run: %s %s", command.command, strings.Join(command.args, " "))
+		clog.Infof("dry-run: %s %s", command.command, strings.Join(command.publicArgs, " "))
 		return progress.Summary{}, "", nil
 	}
 

--- a/wrapper_test.go
+++ b/wrapper_test.go
@@ -43,8 +43,8 @@ func TestGetEmptyEnvironment(t *testing.T) {
 
 func TestGetSingleEnvironment(t *testing.T) {
 	profile := config.NewProfile(nil, "name")
-	profile.Environment = map[string]string{
-		"User": "me",
+	profile.Environment = map[string]config.ConfidentialValue{
+		"User": config.NewConfidentialValue("me"),
 	}
 	wrapper := newResticWrapper("restic", false, profile, "test", nil, nil)
 	env := wrapper.getEnvironment()
@@ -53,9 +53,9 @@ func TestGetSingleEnvironment(t *testing.T) {
 
 func TestGetMultipleEnvironment(t *testing.T) {
 	profile := config.NewProfile(nil, "name")
-	profile.Environment = map[string]string{
-		"User":     "me",
-		"Password": "secret",
+	profile.Environment = map[string]config.ConfidentialValue{
+		"User":     config.NewConfidentialValue("me"),
+		"Password": config.NewConfidentialValue("secret"),
 	}
 	wrapper := newResticWrapper("restic", false, profile, "test", nil, nil)
 	env := wrapper.getEnvironment()
@@ -381,7 +381,7 @@ func TestCanRetryAfterRemoteStaleLockFailure(t *testing.T) {
 	mockOutput := &mockOutputAnalysis{lockWho: "TestCanRetryAfterRemoteStaleLockFailure"}
 
 	profile := config.NewProfile(&config.Config{}, "name")
-	profile.Repository = "my-repo"
+	profile.Repository = config.NewConfidentialValue("my-repo")
 	profile.ForceLock = true
 	wrapper := newResticWrapper(mockBinary, false, profile, "backup", nil, nil)
 	wrapper.startTime = time.Now()
@@ -430,7 +430,7 @@ func TestCanRetryAfterRemoteLockFailure(t *testing.T) {
 	mockOutput := &mockOutputAnalysis{}
 
 	profile := config.NewProfile(&config.Config{}, "name")
-	profile.Repository = "my-repo"
+	profile.Repository = config.NewConfidentialValue("my-repo")
 	wrapper := newResticWrapper(mockBinary, false, profile, "backup", nil, nil)
 	wrapper.startTime = time.Now()
 	wrapper.global.ResticLockRetryAfter = 0 // disable remote lock retry


### PR DESCRIPTION
This PR wraps possibly confidential config values so that they have a public (non-confidential) and an internal value. 
The internal value is passed to `restic` while the public value is used in logging and profile output (`resticprofile show`)

**Motivation**:
* When using a rest server, basic auth credentials are usually part of the repo-url.
* In most other cases keys, tokens or passwords are part of the environment.
* Secrets may appear in the log output, when printing the profile and in error messages sent with a script like ["resticprofile-send-error.sh"](https://github.com/creativeprojects/resticprofile/tree/master/contrib/systemd)

 @creativeprojects  Let me know what you think. It probably has to wait for #57 as there will be conflicts on the same files.

**When the PR is applied, the output changes**:
```
➜ ./resticprofile --name=p3 show     
2021/08/04 19:46:42 using configuration file: profiles.yaml
p3:
    repository:     rest:https://user:***@remotehost
    password-file:  test-repo.key
    initialize:     true
    status-file:    test-repo-status.json

    env:
        my_secret_key:  ***

➜ ./resticprofile --name=p3 --dry-run                       
2021/08/04 19:46:52 using configuration file: profiles.yaml
2021/08/04 19:46:52 profile 'p3': initializing repository (if not existing)
2021/08/04 19:46:52 dry-run: /usr/local/bin/restic init --password-file test-repo.key --repo rest:https://user:***@remotehost
2021/08/04 19:46:52 profile 'p3': starting 'snapshots'
2021/08/04 19:46:52 dry-run: /usr/local/bin/restic snapshots --password-file test-repo.key --repo rest:https://user:***@remotehost
2021/08/04 19:46:52 profile 'p3': finished 'snapshots'
```