### PR TITLE
Added `{{.TempDir}}` to TemplateData

### DIFF
--- a/config/template.go
+++ b/config/template.go
@@ -13,6 +13,7 @@ type TemplateData struct {
 	Now        time.Time
 	CurrentDir string
 	ConfigDir  string
+	TempDir    string
 	Hostname   string
 	Env        map[string]string
 }
@@ -48,6 +49,7 @@ func newTemplateData(configFile, profileName string) TemplateData {
 		Now:        time.Now(),
 		ConfigDir:  configDir,
 		CurrentDir: currentDir,
+		TempDir:    os.TempDir(),
 		Hostname:   hostname,
 		Env:        env,
 	}


### PR DESCRIPTION
Allows to use `{{.TempDir}}` in the profile, e.g. for lock or status file paths. 

Using `os.TempDir()` is more reliable than {{.Env.TMPDIR}} which might not be defined.