### PR TITLE
Resolve glob expressions in backup sources

### DIFF
--- a/config/path.go
+++ b/config/path.go
@@ -106,7 +106,7 @@ func absolutePath(value string) string {
 func resolveGlob(sources []string) []string {
 	resolved := make([]string, 0, len(sources))
 	for _, source := range sources {
-		if strings.ContainsAny(source, "?*") {
+		if strings.ContainsAny(source, "?*[") {
 			if matches, err := filepath.Glob(source); err == nil {
 				resolved = append(resolved, matches...)
 			} else {

--- a/config/path.go
+++ b/config/path.go
@@ -31,6 +31,23 @@ func fixPaths(sources []string, callbacks ...pathFix) []string {
 	return fixed
 }
 
+// resolveGlob evaluates glob expressions in a slice of paths and returns a resolved slice
+func resolveGlob(sources []string) []string {
+	resolved := make([]string, 0, len(sources))
+	for _, source := range sources {
+		if strings.ContainsAny(source, "?*") {
+			if matches, err := filepath.Glob(source); err == nil {
+				resolved = append(resolved, matches...)
+			} else {
+				clog.Warningf("cannot evaluate glob expression '%s' : %v", source, err)
+			}
+		} else {
+			resolved = append(resolved, source)
+		}
+	}
+	return resolved
+}
+
 func expandEnv(value string) string {
 	if strings.Contains(value, "$") || strings.Contains(value, "%") {
 		value = os.ExpandEnv(value)

--- a/config/path_test.go
+++ b/config/path_test.go
@@ -2,7 +2,8 @@ package config
 
 import (
 	"os"
-	"path"
+	"os/user"
+	"path/filepath"
 	"runtime"
 	"testing"
 
@@ -18,6 +19,9 @@ func TestFixUnixPaths(t *testing.T) {
 	home, err := os.UserHomeDir()
 	require.NoError(t, err)
 
+	usr, err := user.Current()
+	require.NoError(t, err)
+
 	paths := []struct {
 		source   string
 		expected string
@@ -25,7 +29,9 @@ func TestFixUnixPaths(t *testing.T) {
 		{"", ""},
 		{"dir", "/prefix/dir"},
 		{"/dir", "/dir"},
-		{"~/dir", path.Join(home, "dir")},
+		{"~/dir", filepath.Join(home, "dir")},
+		{"~" + usr.Username + "/dir", filepath.Join(home, "dir")},
+		{"~" + usr.Username, home},
 		{"~", home},
 		{"~file", "/prefix/~file"},
 		{"$TEMP_TEST_DIR/dir", "/home/dir"},
@@ -60,7 +66,8 @@ func TestFixWindowsPaths(t *testing.T) {
 		{`dir`, `c:\prefix\dir`},
 		{`\dir`, `c:\prefix\dir`},
 		{`c:\dir`, `c:\dir`},
-		{`~\dir`, home + `\dir`},
+		{`~\dir`, filepath.Join(home, "dir")},
+		{`~/dir`, home + `/dir`},
 		{`~`, home},
 		{`~file`, `c:\prefix\~file`},
 		{`%TEMP_TEST_DIR%\dir`, `%TEMP_TEST_DIR%\dir`},

--- a/config/profile.go
+++ b/config/profile.go
@@ -121,7 +121,7 @@ func (p *Profile) SetRootPath(rootPath string) {
 
 		// Backup source is NOT relative to the configuration, but where the script was launched instead
 		if p.Backup.Source != nil && len(p.Backup.Source) > 0 {
-			p.Backup.Source = fixPaths(p.Backup.Source, expandEnv)
+			p.Backup.Source = fixPaths(p.Backup.Source, expandEnv, expandUserHome)
 			if !p.legacyArg {
 				p.Backup.Source = resolveGlob(p.Backup.Source)
 			}

--- a/config/profile.go
+++ b/config/profile.go
@@ -122,7 +122,9 @@ func (p *Profile) SetRootPath(rootPath string) {
 		// Backup source is NOT relative to the configuration, but where the script was launched instead
 		if p.Backup.Source != nil && len(p.Backup.Source) > 0 {
 			p.Backup.Source = fixPaths(p.Backup.Source, expandEnv)
-			p.Backup.Source = resolveGlob(p.Backup.Source)
+			if !p.legacyArg {
+				p.Backup.Source = resolveGlob(p.Backup.Source)
+			}
 		}
 
 		if p.Backup.Exclude != nil && len(p.Backup.Exclude) > 0 {

--- a/config/profile.go
+++ b/config/profile.go
@@ -122,6 +122,7 @@ func (p *Profile) SetRootPath(rootPath string) {
 		// Backup source is NOT relative to the configuration, but where the script was launched instead
 		if p.Backup.Source != nil && len(p.Backup.Source) > 0 {
 			p.Backup.Source = fixPaths(p.Backup.Source, expandEnv)
+			p.Backup.Source = resolveGlob(p.Backup.Source)
 		}
 
 		if p.Backup.Exclude != nil && len(p.Backup.Exclude) > 0 {

--- a/config/profile_test.go
+++ b/config/profile_test.go
@@ -332,6 +332,28 @@ host = %s
 	}
 }
 
+func TestResolveGlobSourcesInBackup(t *testing.T) {
+	root, err := filepath.Abs("/")
+	require.NoError(t, err)
+	root = filepath.ToSlash(root)
+	sourcePattern := filepath.ToSlash(root) + "/*"
+	testConfig := `
+[profile.backup]
+source = "` + sourcePattern + `"
+`
+	profile, err := getProfile("toml", testConfig, "profile")
+	require.NoError(t, err)
+	assert.NotNil(t, profile)
+
+	sources, err := filepath.Glob(sourcePattern)
+	require.NoError(t, err)
+
+	assert.Equal(t, []string{sourcePattern}, profile.Backup.Source)
+
+	profile.SetRootPath(root)
+	assert.Equal(t, sources, profile.Backup.Source)
+}
+
 func TestKeepPathInRetention(t *testing.T) {
 	assert := assert.New(t)
 	root, err := filepath.Abs("/")

--- a/config/profile_test.go
+++ b/config/profile_test.go
@@ -333,10 +333,9 @@ host = %s
 }
 
 func TestResolveGlobSourcesInBackup(t *testing.T) {
-	root, err := filepath.Abs("/")
+	examples, err := filepath.Abs("../examples")
 	require.NoError(t, err)
-	root = filepath.ToSlash(root)
-	sourcePattern := filepath.ToSlash(root) + "/*"
+	sourcePattern := filepath.ToSlash(filepath.Join(examples, "[a-p]*"))
 	testConfig := `
 [profile.backup]
 source = "` + sourcePattern + `"
@@ -347,10 +346,11 @@ source = "` + sourcePattern + `"
 
 	sources, err := filepath.Glob(sourcePattern)
 	require.NoError(t, err)
+	assert.Greater(t, len(sources), 5)
 
 	assert.Equal(t, []string{sourcePattern}, profile.Backup.Source)
 
-	profile.SetRootPath(root)
+	profile.SetRootPath(examples)
 	assert.Equal(t, sources, profile.Backup.Source)
 }
 

--- a/integration_test.go
+++ b/integration_test.go
@@ -78,7 +78,7 @@ func TestFromConfigFileToCommandLine(t *testing.T) {
 			[]string{"examples/integration*"},
 			`["backup" "--exclude" "examples/integration*" "--password-file" "examples/key" "--repo" "rest:http://user:password@localhost:8000/path" ` + globFiles + " " + globFiles + "]",
 			`["backup" "--exclude" "examples/integration*" "--password-file" "examples/key" "--repo" "rest:http://user:password@localhost:8000/path" ` + globFiles + " " + globFiles + "]",
-			`["backup" "--exclude" "examples/integration*" "--password-file" "examples\\key" "--repo" "rest:http://user:password@localhost:8000/path" "examples/integration*" "examples/integration*"]`,
+			`["backup" "--exclude" "examples/integration*" "--password-file" "examples\\key" "--repo" "rest:http://user:password@localhost:8000/path" "examples/integration*" ` + globFiles + "]",
 		},
 		{
 			"spaces",

--- a/integration_test.go
+++ b/integration_test.go
@@ -39,6 +39,7 @@ func TestFromConfigFileToCommandLine(t *testing.T) {
 
 	// we can use the same files to test a glob pattern
 	globFiles := "\"" + strings.Join(files, "\" \"") + "\""
+	globFilesOnWindows := strings.Replace(globFiles, `\`, `\\`, -1)
 
 	integrationData := []struct {
 		profileName       string
@@ -78,7 +79,7 @@ func TestFromConfigFileToCommandLine(t *testing.T) {
 			[]string{"examples/integration*"},
 			`["backup" "--exclude" "examples/integration*" "--password-file" "examples/key" "--repo" "rest:http://user:password@localhost:8000/path" ` + globFiles + " " + globFiles + "]",
 			`["backup" "--exclude" "examples/integration*" "--password-file" "examples/key" "--repo" "rest:http://user:password@localhost:8000/path" ` + globFiles + " " + globFiles + "]",
-			`["backup" "--exclude" "examples/integration*" "--password-file" "examples\\key" "--repo" "rest:http://user:password@localhost:8000/path" "examples/integration*" ` + globFiles + "]",
+			`["backup" "--exclude" "examples/integration*" "--password-file" "examples\\key" "--repo" "rest:http://user:password@localhost:8000/path" "examples/integration*" ` + globFilesOnWindows + "]",
 		},
 		{
 			"spaces",


### PR DESCRIPTION
Resolves glob expressions in `source` internally instead of relying on shell expansion. 
This fixes problems with `retention` and `path` where shell expansion doesn't work.

~~Marked as draft until #60 is merged, also misses a test at the moment.~~