### PR TITLE
Allow overriding "default-command" in profile

### DIFF
--- a/config/profile.go
+++ b/config/profile.go
@@ -35,6 +35,7 @@ type Profile struct {
 	PrometheusSaveToFile string                       `mapstructure:"prometheus-save-to-file"`
 	PrometheusPush       string                       `mapstructure:"prometheus-push"`
 	PrometheusLabels     map[string]string            `mapstructure:"prometheus-labels"`
+	DefaultCommand       string                       `mapstructure:"default-command"`
 	OtherFlags           map[string]interface{}       `mapstructure:",remain"`
 	Environment          map[string]ConfidentialValue `mapstructure:"env"`
 	Backup               *BackupSection               `mapstructure:"backup"`


### PR DESCRIPTION
Add "default-command" from `global` also to the profile sections.
This allows to create profiles (and group of such profiles) for special cases, e.g. like `check` or `prune`:
```yaml
groups:
  prune-all: ["prune-repo1", ...]

prune-repo1:
  inherit: "repo1"
  default-command: "prune"
  prune:
    schedule: "daily"
...
```

The example above can be run with `resticprofile -n prune-all`
