### PR TITLE
Supporting config `includes` (e.g. `profiles.d`)

### DIFF
--- a/README.md
+++ b/README.md
@@ -625,6 +625,24 @@ resticprofile will search for your configuration file in these folders:
 - c:\resticprofile\
 - %USERPROFILE%\
 
+# Includes
+
+The configuration may be split into multiple files by adding `includes = "glob-pattern"` to the main configuration file. 
+E.g. the following `profiles.conf` loads configurations from `conf.d` and `profiles.d`:
+```toml
+# Includes
+includes = ["conf.d/*.conf", "profiles.d/*.yaml", "profiles.d/*.toml"]
+
+# Defaults
+[global]
+initialize = true
+...
+```
+
+Included configuration files may use any supported format and settings are merged so that multiple files can extend the same profiles.
+The HCL format is special in that it cannot be mixed with other formats.
+
+Included files cannot include nested files and do not change the current configuration path.
 
 # Path resolution in configuration
 

--- a/README.md
+++ b/README.md
@@ -636,7 +636,6 @@ includes = ["conf.d/*.conf", "profiles.d/*.yaml", "profiles.d/*.toml"]
 # Defaults
 [global]
 initialize = true
-...
 ```
 
 Included configuration files may use any supported format and settings are merged so that multiple files can extend the same profiles.

--- a/config/config.go
+++ b/config/config.go
@@ -140,13 +140,10 @@ func (c *Config) getIncludes() []string {
 	var files []string
 
 	if c.IsSet(constants.SectionConfigurationIncludes) {
-		single := ""
-		list := []string{}
+		includes := make([]string, 0, 8)
 
-		if err := c.unmarshalKey(constants.SectionConfigurationIncludes, &list); err == nil {
-			files = append(files, list...)
-		} else if err = c.unmarshalKey(constants.SectionConfigurationIncludes, &single); err == nil {
-			files = append(files, single)
+		if err := c.unmarshalKey(constants.SectionConfigurationIncludes, &includes); err == nil {
+			files = append(files, includes...)
 		} else {
 			clog.Errorf("Failed parsing includes definition: %v", err)
 		}

--- a/config/config.go
+++ b/config/config.go
@@ -13,18 +13,20 @@ import (
 
 	"github.com/creativeprojects/clog"
 	"github.com/creativeprojects/resticprofile/constants"
+	"github.com/creativeprojects/resticprofile/filesearch"
 	"github.com/mitchellh/mapstructure"
 	"github.com/spf13/viper"
 )
 
 // Config wraps up a viper configuration object
 type Config struct {
-	keyDelim       string
-	format         string
-	configFile     string
-	viper          *viper.Viper
-	groups         map[string][]string
-	sourceTemplate *template.Template
+	keyDelim        string
+	format          string
+	configFile      string
+	includeFiles    []string
+	viper           *viper.Viper
+	groups          map[string][]string
+	sourceTemplates *template.Template
 }
 
 // This is where things are getting hairy:
@@ -64,81 +66,181 @@ func newConfig(format string) *Config {
 	}
 }
 
+func formatFromExtension(configFile string) string {
+	return strings.TrimPrefix(filepath.Ext(configFile), ".")
+}
+
 // LoadFile loads configuration from file
 // Leave format blank for auto-detection from the file extension
 func LoadFile(configFile, format string) (*Config, error) {
 	if format == "" {
-		// use file extension as format
-		format = strings.TrimPrefix(filepath.Ext(configFile), ".")
+		format = formatFromExtension(configFile)
 	}
-	file, err := os.Open(configFile)
-	if err != nil {
-		return nil, fmt.Errorf("cannot open configuration file for reading: %w", err)
-	}
+
 	c := newConfig(format)
 	c.configFile = configFile
-	// err = c.load(file)
-	err = c.loadTemplate(file)
+
+	readAndAdd := func(configFile string, replace bool) error {
+		clog.Debugf("Loading: %s", configFile)
+		file, err := os.Open(configFile)
+		if err != nil {
+			return fmt.Errorf("cannot open configuration file for reading: %w", err)
+		}
+		defer file.Close()
+
+		return c.addTemplate(file, configFile, replace)
+	}
+
+	// Load config file
+	err := readAndAdd(configFile, true)
 	if err != nil {
 		return c, err
 	}
-	return c, nil
+
+	// Load includes (if any).
+	var includes []string
+	if includes, err = filesearch.FindConfigurationIncludes(configFile, c.getIncludes()); err == nil {
+		for _, include := range includes {
+			format := formatFromExtension(include)
+
+			if format == "hcl" && c.format != "hcl" {
+				err = fmt.Errorf("hcl format (%s) cannot be used in includes from %s: %s", include, c.format, c.configFile)
+			} else if c.format == "hcl" && format != "hcl" {
+				err = fmt.Errorf("%s is in hcl format, includes must use the same format. Cannot load %s", c.configFile, include)
+			} else {
+				err = readAndAdd(include, false)
+				if err == nil {
+					c.includeFiles = append(c.includeFiles, include)
+				}
+			}
+
+			if err != nil {
+				break
+			}
+		}
+	}
+	if err == nil && c.includeFiles != nil {
+		err = c.loadTemplates()
+	}
+
+	return c, err
 }
 
 // Load configuration from reader
 func Load(input io.Reader, format string) (*Config, error) {
 	c := newConfig(format)
-	// err := c.load(input)
-	err := c.loadTemplate(input)
+	err := c.addTemplate(input, c.configFile, true)
 	if err != nil {
 		return c, err
 	}
 	return c, nil
 }
 
-func (c *Config) loadTemplate(input io.Reader) error {
+func (c *Config) getIncludes() []string {
+	var files []string
+
+	if c.IsSet(constants.SectionConfigurationIncludes) {
+		single := ""
+		list := []string{}
+
+		if err := c.unmarshalKey(constants.SectionConfigurationIncludes, &list); err == nil {
+			files = append(files, list...)
+		} else if err = c.unmarshalKey(constants.SectionConfigurationIncludes, &single); err == nil {
+			files = append(files, single)
+		} else {
+			clog.Errorf("Failed parsing includes definition: %v", err)
+		}
+	}
+
+	return files
+}
+
+func (c *Config) templateName(name string) string {
+	return "__config:" + name // prefixing name to avoid clash with named template defines
+}
+
+func (c *Config) addTemplate(input io.Reader, name string, replace bool) error {
 	inputString := &strings.Builder{}
 	_, err := io.Copy(inputString, input)
 	if err != nil {
 		return err
 	}
-	c.sourceTemplate, err = template.New(filepath.Base(c.configFile)).Parse(inputString.String())
+
+	var source *template.Template
+	if c.sourceTemplates == nil || replace {
+		source = template.New(c.templateName(name))
+		c.sourceTemplates = source
+	} else {
+		source = c.sourceTemplates.New(c.templateName(name))
+	}
+
+	_, err = source.Parse(inputString.String())
 	if err != nil {
 		return fmt.Errorf("cannot compile %w", err)
 	}
-	buffer := &bytes.Buffer{}
-	err = c.sourceTemplate.Execute(buffer, newTemplateData(c.configFile, "default"))
-	if err != nil {
-		return fmt.Errorf("cannot execute %w", err)
+
+	if replace {
+		err = c.loadTemplates()
 	}
-	traceConfig("default", buffer.String())
-	return c.load(buffer)
+	return err
 }
 
-func (c *Config) load(input io.Reader) error {
+func (c *Config) load(input io.Reader, format string, replace bool) error {
 	// For compatibility with the previous versions, a .conf file is TOML format
-	if c.format == "conf" {
-		c.format = "toml"
+	if format == "conf" {
+		format = "toml"
 	}
-	c.viper.SetConfigType(c.format)
-	err := c.viper.ReadConfig(input)
+	c.viper.SetConfigType(format)
+
+	var err error
+	if replace {
+		err = c.viper.ReadConfig(input)
+	} else {
+		err = c.viper.MergeConfig(input)
+	}
+
 	if err != nil {
-		return fmt.Errorf("cannot parse %s configuration: %w", c.format, err)
+		return fmt.Errorf("cannot parse %s configuration: %w", format, err)
 	}
 	return nil
 }
 
-func (c *Config) reloadTemplate(data TemplateData) error {
-	if c.sourceTemplate == nil {
+func (c *Config) loadTemplates() error {
+	return c.reloadTemplates(newTemplateData(c.configFile, "default"))
+}
+
+func (c *Config) reloadTemplates(data TemplateData) error {
+	if c.sourceTemplates == nil {
 		return errors.New("no available template to execute, please load it first")
 	}
+
 	buffer := &bytes.Buffer{}
-	err := c.sourceTemplate.Execute(buffer, data)
-	if err != nil {
-		return fmt.Errorf("cannot execute %w", err)
+	executeTemplate := func(name, format string, replace bool) error {
+		buffer.Reset()
+		err := c.sourceTemplates.ExecuteTemplate(buffer, c.templateName(name), data)
+		if err != nil {
+			return fmt.Errorf("cannot execute %w", err)
+		}
+
+		traceConfig(data.Profile.Name, name, replace, buffer.String())
+		return c.load(buffer, format, replace)
 	}
-	traceConfig(data.Profile.Name, buffer.String())
-	return c.load(buffer)
+
+	// Load main config file
+	var err error
+	err = executeTemplate(c.configFile, c.format, true)
+
+	// Load includes
+	if err == nil && c.includeFiles != nil {
+		for _, file := range c.includeFiles {
+			err = executeTemplate(file, formatFromExtension(file), false)
+			if err != nil {
+				break
+			}
+		}
+	}
+
+	return err
 }
 
 // IsSet checks if the key contains a value
@@ -296,8 +398,8 @@ func (c *Config) loadGroups() error {
 
 // GetProfile in configuration
 func (c *Config) GetProfile(profileKey string) (*Profile, error) {
-	if c.sourceTemplate != nil {
-		err := c.reloadTemplate(newTemplateData(c.configFile, profileKey))
+	if c.sourceTemplates != nil {
+		err := c.reloadTemplates(newTemplateData(c.configFile, profileKey))
 		if err != nil {
 			return nil, err
 		}
@@ -382,11 +484,14 @@ func sliceOfMapsToMapHookFunc() mapstructure.DecodeHookFunc {
 	}
 }
 
-func traceConfig(profileName, config string) {
+func traceConfig(profileName, name string, replace bool, config string) {
 	lines := strings.Split(config, "\n")
 	output := ""
 	for i := 0; i < len(lines); i++ {
 		output += fmt.Sprintf("%3d: %s\n", i+1, lines[i])
 	}
-	clog.Tracef("Resulting configuration for profile '%s':\n====================\n%s====================\n", profileName, output)
+	clog.Tracef("Resulting configuration for profile '%s' ('%s' / replace=%v):\n"+
+		"====================\n"+
+		"%s"+
+		"====================\n", profileName, name, replace, output)
 }

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -2,7 +2,10 @@ package config
 
 import (
 	"bytes"
+	"fmt"
+	"os"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -115,4 +118,123 @@ profile:
 			assert.Len(t, profile.RunAfter, 3)
 		})
 	}
+}
+
+func TestGetIncludes(t *testing.T) {
+	config, err := Load(bytes.NewBufferString(`includes=["i1", "i2"]`), "toml")
+	require.NoError(t, err)
+	assert.Equal(t, config.getIncludes(), []string{"i1", "i2"})
+
+	config, err = Load(bytes.NewBufferString(`includes="inc"`), "toml")
+	require.NoError(t, err)
+	assert.Equal(t, config.getIncludes(), []string{"inc"})
+
+	config, err = Load(bytes.NewBufferString(`
+[includes]
+x=0
+	`), "toml")
+	require.NoError(t, err)
+	assert.Nil(t, config.getIncludes())
+
+	config, err = Load(bytes.NewBufferString(`x=0`), "toml")
+	require.NoError(t, err)
+	assert.Nil(t, config.getIncludes())
+}
+
+func TestIncludes(t *testing.T) {
+	files := []string{}
+	cleanFiles := func() {
+		for _, file := range files {
+			os.Remove(file)
+		}
+		files = files[:0]
+	}
+	defer cleanFiles()
+
+	createFile := func(suffix, content string) string {
+		name := ""
+		file, err := os.CreateTemp("", "*-"+suffix)
+		if err == nil {
+			defer file.Close()
+			_, err = file.WriteString(content)
+			name = file.Name()
+			files = append(files, name)
+		}
+		require.NoError(t, err)
+		return name
+	}
+
+	mustLoadConfig := func(configFile string) *Config {
+		config, err := LoadFile(configFile, "")
+		require.NoError(t, err)
+		return config
+	}
+
+	testID := fmt.Sprintf("%d", time.Now().Unix())
+
+	t.Run("multiple-includes", func(t *testing.T) {
+		defer cleanFiles()
+		content := fmt.Sprintf(`includes=['*%[1]s.inc.toml','*%[1]s.inc.yaml','*%[1]s.inc.json']`, testID)
+
+		configFile := createFile("profiles.conf", content)
+		createFile("d-"+testID+".inc.toml", `[one]`)
+		createFile("o-"+testID+".inc.yaml", `two: {}`)
+		createFile("j-"+testID+".inc.json", `{"three":{}}`)
+
+		config := mustLoadConfig(configFile)
+		assert.True(t, config.IsSet("includes"))
+		assert.True(t, config.HasProfile("one"))
+		assert.True(t, config.HasProfile("two"))
+		assert.True(t, config.HasProfile("three"))
+	})
+
+	t.Run("overrides", func(t *testing.T) {
+		defer cleanFiles()
+
+		configFile := createFile("profiles.conf", `
+includes = "*`+testID+`.inc.toml"
+[default]
+repository = "default-repo"`)
+
+		createFile("override-"+testID+".inc.toml", `
+[default]
+repository = "overridden-repo"`)
+
+		config := mustLoadConfig(configFile)
+		assert.True(t, config.HasProfile("default"))
+
+		profile, err := config.GetProfile("default")
+		assert.NoError(t, err)
+		assert.Equal(t, NewConfidentialValue("overridden-repo"), profile.Repository)
+	})
+
+	t.Run("hcl-includes-only-hcl", func(t *testing.T) {
+		defer cleanFiles()
+
+		configFile := createFile("profiles.hcl", `includes = "*`+testID+`.inc.*"`)
+		createFile("pass-"+testID+".inc.hcl", `one { }`)
+
+		config := mustLoadConfig(configFile)
+		assert.True(t, config.HasProfile("one"))
+
+		createFile("fail-"+testID+".inc.toml", `[two]`)
+		_, err := LoadFile(configFile, "")
+		assert.Error(t, err)
+		assert.Regexp(t, ".+ is in hcl format, includes must use the same format", err.Error())
+	})
+
+	t.Run("non-hcl-include-no-hcl", func(t *testing.T) {
+		defer cleanFiles()
+
+		configFile := createFile("profiles.toml", `includes = "*`+testID+`.inc.*"`)
+		createFile("pass-"+testID+".inc.toml", `[one]`)
+
+		config := mustLoadConfig(configFile)
+		assert.True(t, config.HasProfile("one"))
+
+		createFile("fail-"+testID+".inc.hcl", `one { }`)
+		_, err := LoadFile(configFile, "")
+		assert.Error(t, err)
+		assert.Regexp(t, "hcl format .+ cannot be used in includes from toml", err.Error())
+	})
 }

--- a/constants/section.go
+++ b/constants/section.go
@@ -6,6 +6,7 @@ const (
 	SectionConfigurationRetention   = "retention"
 	SectionConfigurationEnvironment = "env"
 	SectionConfigurationGroups      = "groups"
+	SectionConfigurationIncludes    = "includes"
 
 	SectionDefinitionCommon = "common"
 	SectionDefinitionForget = "forget"

--- a/filesearch/filesearch.go
+++ b/filesearch/filesearch.go
@@ -6,6 +6,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"runtime"
+	"sort"
 	"strings"
 
 	"github.com/adrg/xdg"
@@ -153,7 +154,8 @@ func FindConfigurationIncludes(configFile string, includes []string) ([]string, 
 		if fileExists(include) {
 			addFile(include)
 		} else {
-			if matches, err := filepath.Glob(include); err == nil {
+			if matches, err := filepath.Glob(include); err == nil && matches != nil {
+				sort.Strings(matches)
 				for _, match := range matches {
 					addFile(match)
 				}

--- a/filesearch/filesearch.go
+++ b/filesearch/filesearch.go
@@ -128,15 +128,17 @@ func findConfigurationFileWithExtension(configFile string) string {
 // FindConfigurationIncludes finds includes (glob patterns) relative to the configuration file.
 func FindConfigurationIncludes(configFile string, includes []string) ([]string, error) {
 	if !filepath.IsAbs(configFile) {
-		if dir, err := os.Getwd(); err == nil {
-			configFile = filepath.Join(dir, configFile)
-		} else {
+		var err error
+		if configFile, err = filepath.Abs(configFile); err != nil {
 			return nil, err
 		}
 	}
 
+	configFile = filepath.FromSlash(filepath.Clean(configFile))
+
 	var files []string
 	addFile := func(file string) {
+		file = filepath.FromSlash(filepath.Clean(file))
 		if file != configFile {
 			files = append(files, file)
 		}


### PR DESCRIPTION
This PR adds support for splitting the profile configuration into multiple config files that can be included from the main "profiles" config file (glob expressions are supported for `conf.d` or `profiles.d` style configs).

The implementation allows to mix any supported config file format and merges things together. HCL format is special in that it doesn't support mixing with other formats.

Example `profiles.toml`:
````toml
##
# Loading config overrides from "conf.d" and profiles from "profiles.d":
includes = [
  'conf.d/*.conf',
  'profiles.d/*.toml',
  'profiles.d/*.yaml',
]

##
# Defaults
[default]
repository = "/backup"
password-file = "{{.ConfigDir}}/backup.password"
````