### PR TITLE
Optional: Allow disabling path in retention with 'false'

### DIFF
--- a/README.md
+++ b/README.md
@@ -477,8 +477,9 @@ keep-within = "3h"
 keep-tag = [ "forever" ]
 compact = false
 prune = false
-# if path is NOT specified, it will be copied from the 'backup' source
-# path = []
+# path can be a boolean ('true' meaning to copy source paths from 'backup') 
+# or a path or list of paths to use instead. Default is `true` if not specified.
+#path = []
 # the tags are NOT copied from the 'backup' command
 tag = [ "test", "dev" ]
 # host can be a boolean ('true' meaning current hostname) or a string to specify a different hostname
@@ -2106,7 +2107,7 @@ Flags passed to the restic command line
 * **keep-tag**: string OR list of strings
 * **host**: true / false OR string
 * **tag**: string OR list of strings
-* **path**: string OR list of strings
+* **path**: true / false, string OR list of strings
 * **compact**: true / false
 * **group-by**: string
 * **dry-run**: true / false

--- a/README.md
+++ b/README.md
@@ -480,8 +480,9 @@ prune = false
 # path can be a boolean ('true' meaning to copy source paths from 'backup') 
 # or a path or list of paths to use instead. Default is `true` if not specified.
 #path = []
-# the tags are NOT copied from the 'backup' command
-tag = [ "test", "dev" ]
+# tag can be a boolean ('true' meaning to copy tag set from 'backup') 
+# or a custom set of tags. Default is 'false', meaning that tags are NOT used.
+tag = true
 # host can be a boolean ('true' meaning current hostname) or a string to specify a different hostname
 host = true
 
@@ -2106,7 +2107,7 @@ Flags passed to the restic command line
 * **keep-within**: string
 * **keep-tag**: string OR list of strings
 * **host**: true / false OR string
-* **tag**: string OR list of strings
+* **tag**: true / false, string OR list of strings
 * **path**: true / false, string OR list of strings
 * **compact**: true / false
 * **group-by**: string

--- a/config/profile.go
+++ b/config/profile.go
@@ -219,9 +219,22 @@ func (p *Profile) GetRetentionFlags() *shell.Args {
 
 	flags := p.GetCommonFlags()
 	// Special case of retention: we do copy the "source" from "backup" as "path" if it hasn't been redefined in "retention"
-	if _, found := p.Retention.OtherFlags[constants.ParameterPath]; !found {
+	addSources := func() {
 		p.Retention.OtherFlags[constants.ParameterPath] = fixPaths(p.Backup.Source, absolutePath)
 	}
+
+	if value, found := p.Retention.OtherFlags[constants.ParameterPath]; found {
+		if add, isBoolean := value.(bool); isBoolean {
+			if add {
+				addSources()
+			} else {
+				delete(p.Retention.OtherFlags, constants.ParameterPath)
+			}
+		}
+	} else {
+		addSources()
+	}
+
 	flags = addOtherArgs(flags, p.Retention.OtherFlags)
 	return flags
 }

--- a/config/profile_test.go
+++ b/config/profile_test.go
@@ -401,7 +401,7 @@ path = false
 	}
 	assert.NotNil(profile)
 
-	flags := profile.GetRetentionFlags()
+	flags := profile.GetRetentionFlags().ToMap()
 	assert.NotNil(flags)
 	assert.NotContains(flags, "path")
 }

--- a/config/profile_test.go
+++ b/config/profile_test.go
@@ -383,6 +383,29 @@ path = "/"
 	assert.Equal([]string{"/"}, flags["path"])
 }
 
+func TestNoPathInRetention(t *testing.T) {
+	assert := assert.New(t)
+	testConfig := `
+[profile]
+initialize = true
+
+[profile.backup]
+source = "/some_other_path"
+
+[profile.retention]
+path = false
+`
+	profile, err := getProfile("toml", testConfig, "profile")
+	if err != nil {
+		t.Fatal(err)
+	}
+	assert.NotNil(profile)
+
+	flags := profile.GetRetentionFlags()
+	assert.NotNil(flags)
+	assert.NotContains(flags, "path")
+}
+
 func TestForgetCommandFlags(t *testing.T) {
 	testData := []testTemplate{
 		{"toml", `

--- a/config/profile_test.go
+++ b/config/profile_test.go
@@ -406,6 +406,62 @@ path = false
 	assert.NotContains(flags, "path")
 }
 
+func TestCopyTagInRetention(t *testing.T) {
+	assert := assert.New(t)
+	testConfig := `
+[profile.backup]
+tag = ["one", "two"]
+
+[profile.retention]
+tag = true
+`
+	profile, err := getProfile("toml", testConfig, "profile")
+	require.NoError(t, err)
+	assert.NotNil(profile)
+
+	flags := profile.GetRetentionFlags().ToMap()
+	assert.NotNil(flags)
+	assert.Contains(flags, "tag")
+	assert.Equal([]string{"one", "two"}, flags["tag"])
+}
+
+func TestReplaceTagInRetention(t *testing.T) {
+	assert := assert.New(t)
+	testConfig := `
+[profile.backup]
+tag = ["one", "two"]
+
+[profile.retention]
+tag = ["a", "b"]
+`
+	profile, err := getProfile("toml", testConfig, "profile")
+	require.NoError(t, err)
+	assert.NotNil(profile)
+
+	flags := profile.GetRetentionFlags().ToMap()
+	assert.NotNil(flags)
+	assert.Contains(flags, "tag")
+	assert.Equal([]string{"a", "b"}, flags["tag"])
+}
+
+func TestNoTagInRetention(t *testing.T) {
+	assert := assert.New(t)
+	testConfig := `
+[profile.backup]
+tag = ["one", "two"]
+
+[profile.retention]
+tag = false
+`
+	profile, err := getProfile("toml", testConfig, "profile")
+	require.NoError(t, err)
+	assert.NotNil(profile)
+
+	flags := profile.GetRetentionFlags().ToMap()
+	assert.NotNil(flags)
+	assert.NotContains(flags, "tag")
+}
+
 func TestForgetCommandFlags(t *testing.T) {
 	testData := []testTemplate{
 		{"toml", `

--- a/constants/parameter.go
+++ b/constants/parameter.go
@@ -13,5 +13,6 @@ const (
 	ParameterInherit        = "inherit"
 	ParameterHost           = "host"
 	ParameterPath           = "path"
+	ParameterTag            = "tag"
 	ParameterDescription    = "description"
 )


### PR DESCRIPTION
This change is really optional and more a question whether it makes the built-in behaviour of path copy clearer when it can be toggled explicitly.

Remaining questions for me are:
* Would it make sense to apply such a logic to all commands that support `path` as parameter? (Other command would then default to `false` to not change their behaviour)
* Would it make sense to treat `tags` in a similar way?