### PR TITLE
Update non-confidential values to support shell.Args

### DIFF
--- a/shell/arg.go
+++ b/shell/arg.go
@@ -44,6 +44,14 @@ func (a Arg) HasValue() bool {
 	return a.raw != ""
 }
 
+func (a Arg) Value() string {
+	return a.raw
+}
+
+func (a Arg) Type() ArgType {
+	return a.argType
+}
+
 func (a Arg) String() string {
 	if runtime.GOOS == "windows" {
 		return a.raw

--- a/shell/args.go
+++ b/shell/args.go
@@ -18,6 +18,33 @@ func NewArgs() *Args {
 	}
 }
 
+func (a *Args) Clone() *Args {
+	clone := NewArgs()
+	for name, args := range a.args {
+		if args != nil {
+			args = append(make([]Arg, 0, len(args)), args...)
+		}
+		clone.args[name] = args
+	}
+	clone.more = append(clone.more, a.more...)
+	clone.legacy = a.legacy
+	return clone
+}
+
+func (a *Args) Walk(callback func(name string, arg *Arg) *Arg) {
+	processArgs := func(name string, args []Arg) {
+		for i, arg := range args {
+			if newArg := callback(name, &arg); newArg != nil && newArg != &arg {
+				args[i] = *newArg
+			}
+		}
+	}
+	for name, args := range a.args {
+		processArgs(name, args)
+	}
+	processArgs("", a.more)
+}
+
 // SetLegacyArg is used to activate the legacy (broken) mode of sending arguments on the restic command line
 func (a *Args) SetLegacyArg(legacy bool) *Args {
 	a.legacy = legacy

--- a/shell/args_test.go
+++ b/shell/args_test.go
@@ -26,6 +26,42 @@ func TestConversionToArgsNoFlag(t *testing.T) {
 	assert.Equal(t, []string{"one", "two", "three"}, args.GetAll())
 }
 
+func TestClone(t *testing.T) {
+	args := NewArgs()
+	args.AddFlag("x", "y", ArgConfigEscape)
+	args.AddArg("more", ArgConfigEscape)
+	args.SetLegacyArg(true)
+
+	clone := args.Clone()
+	assert.Equal(t, args.GetAll(), clone.GetAll())
+	assert.Equal(t, args.ToMap(), clone.ToMap())
+	assert.Equal(t, args.legacy, clone.legacy)
+
+	assert.NotSame(t, args, clone)
+	assert.NotSame(t, args.args, clone.args)
+	assert.NotSame(t, args.args["x"], clone.args["x"])
+	assert.NotSame(t, args.more, clone.more)
+}
+
+func TestWalk(t *testing.T) {
+	args := NewArgs()
+	args.AddFlag("x", "y", ArgConfigEscape)
+	args.AddArg("more", ArgConfigEscape)
+
+	var walked []string
+	args.Walk(func(name string, arg *Arg) *Arg {
+		walked = append(walked, arg.Value())
+		if name == "x" {
+			a := NewArg("newY", arg.Type())
+			arg = &a
+		}
+		return arg
+	})
+
+	assert.Equal(t, []string{"y", "more"}, walked)
+	assert.Equal(t, []string{"--x", "newY", "more"}, args.GetAll())
+}
+
 func TestConversionToArgs(t *testing.T) {
 	args := NewArgs()
 	args.AddFlags("aaa", []string{"simple", "with space", "with\"quote"}, ArgConfigEscape)

--- a/wrapper.go
+++ b/wrapper.go
@@ -208,7 +208,7 @@ func (r *resticWrapper) prepareCommand(command string, args *shell.Args) shellCo
 	arguments := append([]string{command}, args.GetAll()...)
 
 	// Create non-confidential arguments list for logging
-	publicArguments := config.GetNonConfidentialValues(r.profile, arguments)
+	publicArguments := append([]string{command}, config.GetNonConfidentialArgs(r.profile, args).GetAll()...)
 
 	env := append(os.Environ(), r.getEnvironment()...)
 


### PR DESCRIPTION
Updates non-confidential value handling to work properly after #60 when confidential values (e.g. `repository`) are escaped. 

The implementation operates on `Arg.raw` values and creates a clone of `*shell.Args` instead of processing a formatted and escaped arguments list that may not match original config values after escaping.