### PR TITLE
Support "run-finally" in backup-section & profile

### DIFF
--- a/README.md
+++ b/README.md
@@ -645,23 +645,28 @@ documents:
   run-before: "echo == run-before profile $PROFILE_NAME command $PROFILE_COMMAND"
   run-after: "echo == run-after profile $PROFILE_NAME command $PROFILE_COMMAND"
   run-after-fail: "echo == Error in profile $PROFILE_NAME command $PROFILE_COMMAND: $ERROR"
+  run-finally: "echo == run-finally $PROFILE_NAME command $PROFILE_COMMAND"
   backup:
     run-before: "echo === run-before backup profile $PROFILE_NAME command $PROFILE_COMMAND"
     run-after: "echo === run-after backup profile $PROFILE_NAME command $PROFILE_COMMAND"
+    run-finally: "echo == run-finally $PROFILE_NAME command $PROFILE_COMMAND"
     source: ~/Documents
 ```
 
-`run-before`, `run-after` and `run-after-fail` can be a string, or an array of strings if you need to run more than one command
+`run-before`, `run-after`, `run-after-fail` and `run-finally` can be a string, or an array of strings if you need to run more than one command
 
 A few environment variables will be set before running these commands:
 - `PROFILE_NAME`
 - `PROFILE_COMMAND`: backup, check, forget, etc.
 
-Additionally for the `run-after-fail` commands, these environment variables will also be available:
+Additionally, for the `run-after-fail` commands, these environment variables will also be available:
 - `ERROR` containing the latest error message
 - `ERROR_COMMANDLINE` containing the command line that failed
 - `ERROR_EXIT_CODE` containing the exit code of the command line that failed
 - `ERROR_STDERR` containing any message that the failed command sent to the standard error (stderr)
+
+The commands of `run-finally` get the environment of `run-after-fail` when `run-before`, `run-after` or `restic` failed. 
+Failures in `run-finally` are logged but do not influence environment or return code.
 
 ## run before and after order during a backup
 
@@ -671,6 +676,9 @@ The commands will be running in this order **during a backup**:
 - run the restic backup (with check and retention if configured) - if error, go to `run-after-fail`
 - `run-after` from the backup section - if error, go to `run-after-fail`
 - `run-after` from the profile - if error, go to `run-after-fail`
+- If error: `run-after-fail` from the profile - if error, go to `run-finally`
+- `run-finally` from the backup section - if error, log and continue with next
+- `run-finally` from the profile - if error, log and continue with next
 
 # Warnings from restic
 

--- a/config/profile.go
+++ b/config/profile.go
@@ -29,6 +29,7 @@ type Profile struct {
 	RunBefore            []string                     `mapstructure:"run-before"`
 	RunAfter             []string                     `mapstructure:"run-after"`
 	RunAfterFail         []string                     `mapstructure:"run-after-fail"`
+	RunFinally           []string                     `mapstructure:"run-finally"`
 	StatusFile           string                       `mapstructure:"status-file"`
 	PrometheusSaveToFile string                       `mapstructure:"prometheus-save-to-file"`
 	PrometheusPush       string                       `mapstructure:"prometheus-push"`
@@ -51,6 +52,7 @@ type BackupSection struct {
 	CheckAfter       bool                   `mapstructure:"check-after"`
 	RunBefore        []string               `mapstructure:"run-before"`
 	RunAfter         []string               `mapstructure:"run-after"`
+	RunFinally       []string               `mapstructure:"run-finally"`
 	UseStdin         bool                   `mapstructure:"stdin" argument:"stdin"`
 	Source           []string               `mapstructure:"source"`
 	Exclude          []string               `mapstructure:"exclude" argument:"exclude" argument-type:"no-glob"`


### PR DESCRIPTION
This PR adds a new post command `run-finally` that is meant to run always regardless of what happened before. 

The main purpose is to have a hook for resource cleanup, e.g. consider the following profile:

```yaml
default:
  backup:
    source: "/opt/*/_backup"
    run-before:
      - btrfs subvolume snapshot -r /opt/apps/ /opt/apps/_backup
      - btrfs subvolume snapshot -r /opt/services/ /opt/services/_backup
    run-finally:
      - btrfs subvolume delete /opt/apps/_backup
      - btrfs subvolume delete /opt/services/_backup
```

The current available hooks `run-after` and `run-after-fail` would require to add the cleanup calls twice and may leave snapshots behind if one of the calls has a non-zero exit code. Also `run-after-fail` is not available for backup (and doesn't have to be).

Note: I thought about calling it `run-after-all` and `run-always` but used `run-finally` as it describes the behaviour best. Commands in this list are run after any other commands and are are always started, even if there is a panic somewhere.