### PR TITLE
Add support for copy command

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,7 @@
 {
     "cSpell.words": [
+        "crond",
+        "ionice",
         "launchd",
         "restic",
         "resticprofile",

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ With resticprofile:
 * Get backup statistics in your status file
 * **[new for v0.14.0]** Automatically clear up [stale locks](#locks)
 * **[new for v0.15.0]** Export a **prometheus** file after a backup, or send the report to a push gateway automatically
-* **[new for v0.16.0]** Full support for the copy command (which scheduling)
+* **[new for v0.16.0]** Full support for the copy command (with scheduling)
 
 The configuration file accepts various formats:
 * [TOML](https://github.com/toml-lang/toml) : configuration file with extension _.toml_ and _.conf_ to keep compatibility with versions before 0.6.0
@@ -66,7 +66,8 @@ For the rest of the documentation, I'll be showing examples using different form
   * [Simple YAML configuration](#simple-yaml-configuration)
   * [More complex configuration in TOML](#more-complex-configuration-in-toml)
   * [TOML configuration example for Windows](#toml-configuration-example-for-windows)
-    * [Use stdin in configuration](#use-stdin-in-configuration)
+  * [Use stdin in configuration](#use-stdin-in-configuration)
+  * [Special case for the copy command section](#special-case-for-the-copy-command-section)
 * [Configuration paths](#configuration-paths)
   * [macOS X](#macos-x)
   * [Other unixes (Linux and BSD)](#other-unixes-linux-and-bsd)
@@ -213,7 +214,7 @@ Installation using Ansible is not supported out of the box yet, but since I'm us
 
 ## Installation from source
 
-You can download the source code and recompile it, it's actually very easy! all you need to have on your machine is:
+You can download the source code and compile it, it's actually very easy! all you need to have on your machine is:
 - `git`
 - [go compiler](https://golang.org/dl/)
 - `GNU Make` which is installed by default on many unix boxes. On debian based distributions (Ubuntu included) the package is called `build-essential`.
@@ -556,7 +557,7 @@ run-after = "echo All Done!"
 no-error-on-warning = true
 ```
 
-### Use stdin in configuration
+## Use stdin in configuration
 
 Simple example sending a file via stdin
 
@@ -571,6 +572,37 @@ stdin = true
 stdin-filename = "stdin-test"
 tag = [ 'stdin' ]
 
+```
+
+## Special case for the `copy` command section
+
+The copy command needs two repository (and quite likely 2 different set of keys). You can configure a `copy` section like this:
+
+```toml
+[default]
+initialize = false
+repository = "/backup/original"
+password-file = "key"
+
+    [default.copy]
+    initialize = true
+    repository = "/backup/copy"
+    password-file = "other_key"
+```
+
+You will note that the secondary repository doesn't need to have a `2` behind its flags (`repository2`, `password-file2`, etc.). It's because the flags are well separated in the configuration.
+
+Here's the same configuration in YAML format:
+
+```yaml
+default:
+    initialize: false
+    repository: "/backup/original"
+    password-file: key
+    copy:
+        initialize: true
+        repository: "/backup/copy"
+        password-file: other_key
 ```
 
 # Configuration paths
@@ -958,13 +990,14 @@ global:
 
 Each profile can be scheduled independently (groups are not available for scheduling yet).
 
-These 4 profile sections are accepting a schedule configuration:
+These 5 profile sections are accepting a schedule configuration:
 - backup
 - check
 - forget (version 0.11.0)
 - prune (version 0.11.0)
+- copy (version 0.16.0)
 
-which mean you can schedule `backup`, `forget`, `prune` and `check` independently (I recommend to use a local `lock` in this case).
+which mean you can schedule `backup`, `forget`, `prune`, `check` and `copy` independently (I recommend to use a local `lock` in this case).
 
 ## retention schedule is deprecated
 **Important**:
@@ -2076,6 +2109,7 @@ Flags passed to the restic command line
 * **password-file**: string
 * **quiet**: true / false
 * **repository**: string **(will be passed as 'repo' to the command line)**
+* **repository-file**: string
 * **tls-client-cert**: string
 * **verbose**: true / false OR integer
 
@@ -2223,6 +2257,24 @@ Flags passed to the restic command line
 * **path**: string OR list of strings
 * **snapshot-template**: string
 * **tag**: string OR list of strings
+
+`[profile.copy]`
+
+Flags used by resticprofile only
+
+* **initialize**: true / false
+
+
+Flags passed to the restic command line
+
+* **key-hint**: string
+* **password-command**: command
+* **password-file**: string
+* **path**: string OR list of strings
+* **repository**: repository
+* **repository-file**: string
+* **tag**: string OR list of strings
+
 
 # Appendix
 

--- a/README.md
+++ b/README.md
@@ -31,9 +31,10 @@ With resticprofile:
 * You can generate a simple status file to send to some monitoring software and make sure your backups are running fine 
 * You can use a template syntax in your configuration file
 * You can generate scheduled tasks using *crond*
-* **[new for v0.12.0]** Get backup statistics in your status file
+* Get backup statistics in your status file
 * **[new for v0.14.0]** Automatically clear up [stale locks](#locks)
 * **[new for v0.15.0]** Export a **prometheus** file after a backup, or send the report to a push gateway automatically
+* **[new for v0.16.0]** Full support for the copy command (which scheduling)
 
 The configuration file accepts various formats:
 * [TOML](https://github.com/toml-lang/toml) : configuration file with extension _.toml_ and _.conf_ to keep compatibility with versions before 0.6.0

--- a/config/confidential.go
+++ b/config/confidential.go
@@ -40,7 +40,7 @@ func (c *ConfidentialValue) hideSubmatches(pattern *regexp.Regexp) {
 		return
 	}
 
-	if matches := pattern.FindStringSubmatchIndex(c.confidential); matches != nil && len(matches) > 2 {
+	if matches := pattern.FindStringSubmatchIndex(c.confidential); len(matches) > 2 {
 		c.public = c.confidential
 
 		for i := len(matches) - 2; i > 1; i -= 2 {
@@ -121,11 +121,9 @@ func getAllConfidentialValues(profile *Profile) []*ConfidentialValue {
 }
 
 func convertToNonConfidential(confidentials []*ConfidentialValue, value string) string {
-	if confidentials != nil {
-		for _, c := range confidentials {
-			if c != nil && c.IsConfidential() && value == c.Value() {
-				return c.String()
-			}
+	for _, c := range confidentials {
+		if c != nil && c.IsConfidential() && value == c.Value() {
+			return c.String()
 		}
 	}
 	return value

--- a/config/profile_test.go
+++ b/config/profile_test.go
@@ -556,7 +556,7 @@ initialize = true
 	}
 
 	sections := NewProfile(nil, "").SchedulableCommands()
-	assert.Len(sections, 5)
+	assert.Len(sections, 6)
 
 	for _, command := range sections {
 		// Check that schedule is supported

--- a/config/profile_test.go
+++ b/config/profile_test.go
@@ -223,6 +223,8 @@ exclude-file = "exclude"
 files-from = "include"
 exclude = "exclude"
 iexclude = "iexclude"
+[profile.copy]
+password-file = "key"
 `
 	profile, err := getProfile("toml", testConfig, "profile")
 	if err != nil {
@@ -240,6 +242,7 @@ iexclude = "iexclude"
 	assert.ElementsMatch(t, []string{"/wd/include"}, profile.Backup.FilesFrom)
 	assert.ElementsMatch(t, []string{"exclude"}, profile.Backup.Exclude)
 	assert.ElementsMatch(t, []string{"iexclude"}, profile.Backup.Iexclude)
+	assert.Equal(t, "/wd/key", profile.Copy.PasswordFile)
 }
 
 func TestHostInProfile(t *testing.T) {
@@ -711,6 +714,8 @@ other-flag-forget = true
 other-flag-prune = true
 [profile.mount]
 other-flag-mount = true
+[profile.copy]
+other-flag-copy = true
 `},
 		{"json", `
 {
@@ -722,7 +727,8 @@ other-flag-mount = true
     "check": {"other-flag-check": true},
     "forget": {"other-flag-forget": true},
     "prune": {"other-flag-prune": true},
-    "mount": {"other-flag-mount": true}
+    "mount": {"other-flag-mount": true},
+    "copy": {"other-flag-copy": true}
   }
 }`},
 		{"yaml", `---
@@ -742,6 +748,8 @@ profile:
     other-flag-prune: true
   mount:
     other-flag-mount: true
+  copy:
+    other-flag-copy: true
 `},
 		{"hcl", `
 "profile" = {
@@ -767,6 +775,9 @@ profile:
 	mount = {
 		other-flag-mount = true
 	}
+	copy = {
+		other-flag-copy = true
+	}
 }
 `},
 	}
@@ -786,6 +797,7 @@ profile:
 			require.NotNil(t, profile.Mount)
 			require.NotNil(t, profile.Prune)
 			require.NotNil(t, profile.Snapshots)
+			require.NotNil(t, profile.Copy)
 
 			flags := profile.GetCommonFlags()
 			assert.Equal(t, 1, len(flags.ToMap()))
@@ -830,6 +842,12 @@ profile:
 			assert.Equal(t, 2, len(flags.ToMap()))
 			assert.ElementsMatch(t, []string{"1"}, flags.ToMap()["other-flag"])
 			_, found = flags.ToMap()["other-flag-mount"]
+			assert.True(t, found)
+
+			flags = profile.GetCommandFlags("copy")
+			assert.Equal(t, 2, len(flags.ToMap()))
+			assert.ElementsMatch(t, []string{"1"}, flags.ToMap()["other-flag"])
+			_, found = flags.ToMap()["other-flag-copy"]
 			assert.True(t, found)
 		})
 	}

--- a/constants/command.go
+++ b/constants/command.go
@@ -10,4 +10,5 @@ const (
 	CommandSnapshots = "snapshots"
 	CommandUnlock    = "unlock"
 	CommandMount     = "mount"
+	CommandCopy      = "copy"
 )

--- a/examples/dev.yaml
+++ b/examples/dev.yaml
@@ -115,6 +115,7 @@ self:
         schedule: "weekly"
         schedule-priority: standard
     copy:
+        initialize: true
         schedule:
           - "*:45"
 

--- a/examples/dev.yaml
+++ b/examples/dev.yaml
@@ -25,6 +25,9 @@ default:
     password-file: key
     repository: "/Volumes/RAMDisk/{{ .Profile.Name }}"
     lock: "/Volumes/RAMDisk/resticprofile-{{ .Profile.Name }}.lock"
+    copy:
+        password-file: key
+        repository: "/Volumes/RAMDisk/{{ .Profile.Name }}-copy"
 
 space:
     description: Repository contains space
@@ -105,12 +108,15 @@ self:
       - "echo restic stderr = ${RESTIC_STDERR}"
     check:
         schedule:
-          - "*:15,45"
+          - "*:15"
     retention:
         after-backup: true
     forget:
         schedule: "weekly"
         schedule-priority: standard
+    copy:
+        schedule:
+          - "*:45"
 
 prom:
     force-inactive-lock: true

--- a/main.go
+++ b/main.go
@@ -26,7 +26,7 @@ import (
 
 // These fields are populated by the goreleaser build
 var (
-	version = "0.15.0-dev"
+	version = "0.16.0-dev"
 	commit  = ""
 	date    = ""
 	builtBy = ""

--- a/shell/args.go
+++ b/shell/args.go
@@ -48,13 +48,18 @@ func (a *Args) Walk(callback func(name string, arg *Arg) *Arg) {
 
 // PromoteSecondaryToPrimary removes a "2" at the end of each flag
 func (a *Args) PromoteSecondaryToPrimary() {
-	newArgs := make(map[string][]Arg, len(a.args))
+	override := make(map[string][]Arg, len(a.args))
 	for name, args := range a.args {
-		name = strings.TrimSuffix(name, "2")
-		// TODO: make sure the promoted secondary value doesn't get overwritten by an original primary value
-		newArgs[name] = args
+		if strings.HasSuffix(name, "2") {
+			name = strings.TrimSuffix(name, "2")
+			override[name] = args
+		}
 	}
-	a.args = newArgs
+	// now override the original arguments, and delete any secondary one
+	for name, args := range override {
+		a.args[name] = args
+		delete(a.args, name+"2")
+	}
 }
 
 // SetLegacyArg is used to activate the legacy (broken) mode of sending arguments on the restic command line

--- a/shell/args.go
+++ b/shell/args.go
@@ -3,6 +3,7 @@ package shell
 import (
 	"fmt"
 	"sort"
+	"strings"
 )
 
 type Args struct {
@@ -43,6 +44,17 @@ func (a *Args) Walk(callback func(name string, arg *Arg) *Arg) {
 		processArgs(name, args)
 	}
 	processArgs("", a.more)
+}
+
+// PromoteSecondaryToPrimary removes a "2" at the end of each flag
+func (a *Args) PromoteSecondaryToPrimary() {
+	newArgs := make(map[string][]Arg, len(a.args))
+	for name, args := range a.args {
+		name = strings.TrimSuffix(name, "2")
+		// TODO: make sure the promoted secondary value doesn't get overwritten by an original primary value
+		newArgs[name] = args
+	}
+	a.args = newArgs
 }
 
 // SetLegacyArg is used to activate the legacy (broken) mode of sending arguments on the restic command line

--- a/shell/args_test.go
+++ b/shell/args_test.go
@@ -112,3 +112,20 @@ func TestConversionToArgs(t *testing.T) {
 	}
 	assert.Equal(t, expected, args.GetAll())
 }
+
+func TestPromoteSecondaryToPrimary(t *testing.T) {
+	args := NewArgs()
+	args.AddFlag("initialize", "true", ArgConfigEscape)
+	args.AddFlag("repo", "first", ArgConfigEscape)
+	args.AddFlag("password-file", "key1", ArgConfigEscape)
+	args.AddFlag("repo2", "second", ArgConfigEscape)
+	args.AddFlag("password-file2", "key2", ArgConfigEscape)
+
+	args.PromoteSecondaryToPrimary()
+	result := args.ToMap()
+	assert.Equal(t, map[string][]string{
+		"initialize":    {"true"},
+		"password-file": {"key2"},
+		"repo":          {"second"},
+	}, result)
+}

--- a/wrapper.go
+++ b/wrapper.go
@@ -257,7 +257,7 @@ func (r *resticWrapper) runInitializeCopy() error {
 	clog.Infof("profile '%s': initializing secondary repository (if not existing)", r.profile.Name)
 	args := r.profile.GetCommandFlags(constants.CommandCopy)
 	// the copy command adds a 2 behind each flag about the secondary repository
-	// but in the case of init, we want to promote the secondary repository as primary
+	// in the case of init, we want to promote the secondary repository as primary
 	args.PromoteSecondaryToPrimary()
 	rCommand := r.prepareCommand(constants.CommandInit, args)
 	// don't display any error


### PR DESCRIPTION
As requested in #72, this PR adds support for the `copy` command.

Here's an example of configuration:

```toml
[default]
initialize = false
repository = "/backup/original"
password-file = "key"

    [default.copy]
    initialize = true
    repository = "/backup/copy"
    password-file = "other_key"
```

You will note that the secondary repository doesn't need to have a `2` behind its flags (`repository2`, `password-file2`, etc.). It's because the flags are well separated in the configuration.

Here's the same configuration in YAML format:

```yaml
default:
    initialize: false
    repository: "/backup/original"
    password-file: key
    copy:
        initialize: true
        repository: "/backup/copy"
        password-file: other_key
```
