### PR TITLE
Fix args are multiplied when commands are retried

### DIFF
--- a/wrapper.go
+++ b/wrapper.go
@@ -207,6 +207,9 @@ func (r *resticWrapper) runProfile() error {
 }
 
 func (r *resticWrapper) prepareCommand(command string, args *shell.Args) shellCommandDefinition {
+	// Create local instance to allow modification
+	args = args.Clone()
+
 	if r.moreArgs != nil && len(r.moreArgs) > 0 {
 		args.AddArgs(r.moreArgs, shell.ArgCommandLineEscape)
 	}


### PR DESCRIPTION
Discovered that when commands are retried (e.g. `backup` with lock failure) the command line contains repeated arguments:
````
"/usr/bin/restic" "backup" ... "--repo" "rest:https://user:×××@repo/" \
"--tag" "etc" "--tag" "home" "/etc" "/home" "/root" "/etc" "/home" \
"/root" "/etc" "/home" "/root" "/etc" "/home" "/root" "/etc" "/home" ...
````

This PR fixes it :)