### PR TITLE
Add run flag to to be able to have profile and job name as one argument

### DIFF
--- a/README.md
+++ b/README.md
@@ -943,7 +943,7 @@ There are not many options on the command line, most of the options are in the c
 * **[-f | --format] configuration_format**: Specify the configuration file format: `toml`, `yaml`, `json` or `hcl`
 * **[-n | --name] profile_name**: Profile section to use from the configuration file.
   You can also use `[profile_name].[command]` syntax instead, this will only work if `-n` is not set.
-  Bot using `-n [profile_name] [command]` and `[profile_name].[command]` are supported.
+  Using `-n [profile_name] [command]` or `[profile_name].[command]` both select profile and command and are technically equivalent.
 * **[--dry-run]**: Doesn't run the restic command but display the command line instead
 * **[-q | --quiet]**: Force resticprofile and restic to be quiet (override any configuration from the profile)
 * **[-v | --verbose]**: Force resticprofile and restic to be verbose (override any configuration from the profile)

--- a/README.md
+++ b/README.md
@@ -871,11 +871,19 @@ Backup root & src profiles (using _full-backup_ group shown earlier)
 ```
 $ resticprofile --name "full-backup" backup
 ```
+or
+```
+$ resticprofile full-backup.backup
+```
 
 Assuming the _stdin_ profile from the configuration file shown before, the command to send a mysqldump to the backup is as simple as:
 
 ```
 $ mysqldump --all-databases | resticprofile --name stdin backup
+```
+or
+```
+$ mysqldump --all-databases | resticprofile stdin.backup
 ```
 
 Mount the default profile (_default_) in /mnt/restic:
@@ -890,8 +898,8 @@ Display quick help
 $ resticprofile --help
 
 Usage of resticprofile:
-	resticprofile [resticprofile flags] [restic command] [restic flags]
-	resticprofile [resticprofile flags] [resticprofile command] [command specific flags]
+	resticprofile [resticprofile flags] [profile name.][restic command] [restic flags]
+	resticprofile [resticprofile flags] [profile name.][resticprofile command] [command specific flags]
 
 resticprofile flags:
   -c, --config string        configuration file (default "profiles")
@@ -933,7 +941,9 @@ There are not many options on the command line, most of the options are in the c
 * **[-h]**: Display quick help
 * **[-c | --config] configuration_file**: Specify a configuration file other than the default
 * **[-f | --format] configuration_format**: Specify the configuration file format: `toml`, `yaml`, `json` or `hcl`
-* **[-n | --name] profile_name**: Profile section to use from the configuration file
+* **[-n | --name] profile_name**: Profile section to use from the configuration file.
+  You can also use `[profile_name].[command]` syntax instead, this will only work if `-n` is not set.
+  Bot using `-n [profile_name] [command]` and `[profile_name].[command]` are supported.
 * **[--dry-run]**: Doesn't run the restic command but display the command line instead
 * **[-q | --quiet]**: Force resticprofile and restic to be quiet (override any configuration from the profile)
 * **[-v | --verbose]**: Force resticprofile and restic to be verbose (override any configuration from the profile)

--- a/codecov.yml
+++ b/codecov.yml
@@ -3,7 +3,6 @@ ignore:
   - lock/test/
   - priority/check/
   - deprecation.go
-  - flags.go
   - logger.go
   - systemd.go
   - update.go

--- a/flags.go
+++ b/flags.go
@@ -40,8 +40,8 @@ func loadFlags(args []string) (*pflag.FlagSet, commandLineFlags, error) {
 
 	flagset.Usage = func() {
 		fmt.Println("\nUsage of resticprofile:")
-		fmt.Println("\tresticprofile [resticprofile flags] [restic command] [restic flags]")
-		fmt.Println("\tresticprofile [resticprofile flags] [resticprofile command] [command specific flags]")
+		fmt.Println("\tresticprofile [resticprofile flags] [profile name.][restic command] [restic flags]")
+		fmt.Println("\tresticprofile [resticprofile flags] [profile name.][resticprofile command] [command specific flags]")
 		fmt.Println("\nresticprofile flags:")
 		flagset.PrintDefaults()
 		fmt.Println("\nresticprofile own commands:")
@@ -94,13 +94,13 @@ func loadFlags(args []string) (*pflag.FlagSet, commandLineFlags, error) {
 	flags.resticArgs = flagset.Args()
 
 	// if there are no further arguments, no further parsing is needed
-	if (len(flags.resticArgs) == 0) {
+	if len(flags.resticArgs) == 0 {
 		return flagset, flags, err
 	}
 
 	// parse first postitional argument as <profile>.<command> if the profile was not set via name
 	nameFlag := flagset.Lookup("name")
-	if ((nameFlag == nil || !nameFlag.Changed) && strings.Contains(flags.resticArgs[0] , ".")) {
+	if (nameFlag == nil || !nameFlag.Changed) && strings.Contains(flags.resticArgs[0] , ".") {
 		// split first argument at `.`
 		profileAndCommand := strings.Split(flags.resticArgs[0], ".")
 		// last element will be used as restic command
@@ -109,7 +109,7 @@ func loadFlags(args []string) (*pflag.FlagSet, commandLineFlags, error) {
 		profile := strings.Join(profileAndCommand[0:len(profileAndCommand)-1], ".")
 
 		// set command
-		if (len(command) == 0) {
+		if len(command) == 0 {
 			// take default command by removing it from resticArgs
 			flags.resticArgs = flags.resticArgs[1:]
 		} else {
@@ -117,7 +117,7 @@ func loadFlags(args []string) (*pflag.FlagSet, commandLineFlags, error) {
 		}
 
 		// set profile
-		if (len(profile) == 0) {
+		if len(profile) == 0 {
 			profile = constants.DefaultProfileName
 		}
 		flags.name = profile

--- a/flags.go
+++ b/flags.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"runtime"
 	"time"
+	"strings"
 
 	"github.com/creativeprojects/resticprofile/constants"
 	"github.com/spf13/pflag"
@@ -30,6 +31,7 @@ type commandLineFlags struct {
 	isChild     bool
 	parentPort  int
 	noPriority  bool
+	run         string
 }
 
 // loadFlags loads command line flags (before any command)
@@ -90,6 +92,36 @@ func loadFlags(args []string) (*pflag.FlagSet, commandLineFlags, error) {
 
 	// remaining flags
 	flags.resticArgs = flagset.Args()
+
+	// if there are no further arguments, no further parsing is needed
+	if (len(flags.resticArgs) == 0) {
+		return flagset, flags, err
+	}
+
+	// parse first postitional argument as <profile>.<command> if the profile was not set via name
+	nameFlag := flagset.Lookup("name")
+	if ((nameFlag == nil || !nameFlag.Changed) && strings.Contains(flags.resticArgs[0] , ".")) {
+		// split first argument at `.`
+		profileAndCommand := strings.Split(flags.resticArgs[0], ".")
+		// last element will be used as restic command
+		command := profileAndCommand[len(profileAndCommand)-1]
+		// remaining elements will be stiched together with `.` and used as profile name
+		profile := strings.Join(profileAndCommand[0:len(profileAndCommand)-1], ".")
+
+		// set command
+		if (len(command) == 0) {
+			// take default command by removing it from resticArgs
+			flags.resticArgs = flags.resticArgs[1:]
+		} else {
+			flags.resticArgs[0] = command
+		}
+
+		// set profile
+		if (len(profile) == 0) {
+			profile = constants.DefaultProfileName
+		}
+		flags.name = profile
+	}
 
 	return flagset, flags, nil
 }

--- a/flags_test.go
+++ b/flags_test.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"github.com/creativeprojects/resticprofile/constants"
 )
 
 func TestUnknownShortFlag(t *testing.T) {
@@ -32,7 +33,89 @@ func TestHelpLongFlag(t *testing.T) {
 func TestBackupProfileName(t *testing.T) {
 	_, flags, err := loadFlags([]string{"-n", "profile1", "backup", "-v"})
 	require.NoError(t, err)
+	assert.Equal(t, flags.name, "profile1")
+	assert.False(t, flags.verbose)
+	assert.Equal(t, flags.resticArgs, []string{"backup", "-v"})
+}
+
+func TestProfileCommandWithProfileNamePrecedence(t *testing.T) {
+	_, flags, err := loadFlags([]string{"-n", "profile2", "-v", "some.command"})
+	require.NoError(t, err)
+	assert.Equal(t, flags.name, "profile2")
+	assert.True(t, flags.verbose)
+	assert.Equal(t, flags.resticArgs, []string{"some.command"})
+}
+
+func TestProfileCommandWithProfileNamePrecedenceWithDefaultProfile(t *testing.T) {
+	_, flags, err := loadFlags([]string{"-n", constants.DefaultProfileName, "-v", "some.other.command"})
+	require.NoError(t, err)
+	assert.Equal(t, flags.name, constants.DefaultProfileName)
+	assert.True(t, flags.verbose)
+	assert.Equal(t, flags.resticArgs, []string{"some.other.command"})
+}
+
+func TestProfileCommandWithResticVerbose(t *testing.T) {
+	_, flags, err := loadFlags([]string{"profile1.check", "--", "-v"})
+	require.NoError(t, err)
 	assert.False(t, flags.help)
 	assert.Equal(t, flags.name, "profile1")
-	assert.Equal(t, flags.resticArgs, []string{"backup", "-v"})
+	assert.False(t, flags.verbose)
+	assert.Equal(t, flags.resticArgs, []string{"check", "--", "-v"})
+}
+
+func TestProfileCommandWithResticprofileVerbose(t *testing.T) {
+	_, flags, err := loadFlags([]string{"-v", "pro.file1.backup"})
+	require.NoError(t, err)
+	assert.True(t, flags.verbose)
+	assert.Equal(t, flags.name, "pro.file1")
+	assert.Equal(t, flags.resticArgs, []string{"backup"})
+}
+
+func TestProfileCommandThreePart(t *testing.T) {
+	_, flags, err := loadFlags([]string{"bla.foo.backup"})
+	require.NoError(t, err)
+	assert.Equal(t, flags.name, "bla.foo")
+	assert.Equal(t, flags.resticArgs, []string{"backup"})
+}
+
+func TestProfileCommandTwoPartCommandMissing(t *testing.T) {
+	_, flags, err := loadFlags([]string{"bar."})
+	require.NoError(t, err)
+	assert.Equal(t, flags.name, "bar")
+	assert.Equal(t, flags.resticArgs, []string{})
+}
+
+func TestProfileCommandTwoPartProfileMissing(t *testing.T) {
+	_, flags, err := loadFlags([]string{".baz"})
+	require.NoError(t, err)
+	assert.Equal(t, flags.name, constants.DefaultProfileName)
+	assert.Equal(t, flags.resticArgs, []string{"baz"})
+}
+
+func TestProfileCommandTwoPartDotPrefix(t *testing.T) {
+	_, flags, err := loadFlags([]string{".baz.qux"})
+	require.NoError(t, err)
+	assert.Equal(t, flags.name, ".baz")
+	assert.Equal(t, flags.resticArgs, []string{"qux"})
+}
+
+func TestProfileCommandThreePartCommandMissing(t *testing.T) {
+	_, flags, err := loadFlags([]string{"quux.quuz."})
+	require.NoError(t, err)
+	assert.Equal(t, flags.name, "quux.quuz")
+	assert.Equal(t, flags.resticArgs, []string{})
+}
+
+func TestProfileCommandTwoPartDotPrefixCommandMissing(t *testing.T) {
+	_, flags, err := loadFlags([]string{".corge."})
+	require.NoError(t, err)
+	assert.Equal(t, flags.name, ".corge")
+	assert.Equal(t, flags.resticArgs, []string{})
+}
+
+func TestProfileCommandTwoPartProfileMissingCommandMissing(t *testing.T) {
+	_, flags, err := loadFlags([]string{"."})
+	require.NoError(t, err)
+	assert.Equal(t, flags.name, constants.DefaultProfileName)
+	assert.Equal(t, flags.resticArgs, []string{})
 }


### PR DESCRIPTION
This implements the idea from #52 to make it easy to write systemd unit templates that directly correspond to a defined resticprofile job.

* `--run` takes `<profile>.<job>`
* if there is another `.` is will be interpreted as part of the job name
* overrides `--name`
* `--` for extra `restic` parameters

I am not sure how to write tests for this. Could you give me some pointers how to do so and what should be tested for?