### PR TITLE
Shell completion

### DIFF
--- a/README.md
+++ b/README.md
@@ -251,7 +251,7 @@ $ make install
 
 Shell commandline completions are provided for `bash` and `zsh`. 
 
-To load completions in the shell (user) profile, use:
+To load completions in shell or profile, use:
 
 ```shell
 # bash
@@ -267,8 +267,6 @@ To install them permanently:
 $ resticprofile completion-script --bash > /etc/bash_completion.d/resticprofile
 $ chmod +x /etc/bash_completion.d/resticprofile
 ```
-
-Note: Check path, might be `/etc/...` or `/usr/local/etc/...`
 
 
 # Upgrade

--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ For the rest of the documentation, I'll be showing examples using different form
   * [Manual installation (Windows)](#manual-installation-windows)
   * [Ansible](#ansible)
   * [Installation from source](#installation-from-source)
+  * [Shell completion](#shell-completion)
 * [Upgrade](#upgrade)
 * [Using docker image](#using-docker-image)
   * [Container host name](#container-host-name)
@@ -244,6 +245,31 @@ To install the binary in your user path:
 ```
 $ make install
 ```
+
+
+## Shell completion
+
+Shell commandline completions are provided for `bash` and `zsh`. 
+
+To load completions in the shell (user) profile, use:
+
+```shell
+# bash
+eval "$(resticprofile completion-script --bash)"
+
+# zsh
+eval "$(resticprofile completion-script --zsh)"
+```
+
+To install them permanently:
+
+```
+$ resticprofile completion-script --bash > /etc/bash_completion.d/resticprofile
+$ chmod +x /etc/bash_completion.d/resticprofile
+```
+
+Note: Check path, might be `/etc/...` or `/usr/local/etc/...`
+
 
 # Upgrade
 

--- a/complete.go
+++ b/complete.go
@@ -1,0 +1,351 @@
+package main
+
+import (
+	"fmt"
+	"sort"
+	"strconv"
+	"strings"
+
+	"github.com/creativeprojects/resticprofile/config"
+	"github.com/creativeprojects/resticprofile/filesearch"
+	"github.com/spf13/pflag"
+)
+
+const (
+	RequestFileCompletion   = "__complete_file"
+	RequestResticCompletion = "__complete_restic"
+	ProfileCommandDelimiter = "."
+)
+
+// Completer provides context aware shell completions for the current commandline argument(s)
+type Completer struct {
+	flags       *pflag.FlagSet
+	flagsInArgs []*pflag.Flag
+	ownCommands []ownCommand
+	profiles    []string
+}
+
+func (c *Completer) init(args []string) {
+	c.flags, _, _ = loadFlags(args)
+	c.flagsInArgs = nil
+	c.ownCommands = getOwnCommands()
+	c.profiles = nil
+}
+
+func (c *Completer) formatFlag(flag *pflag.Flag, shorthand bool) string {
+	if shorthand {
+		return fmt.Sprintf("-%s", flag.Shorthand)
+	} else {
+		return fmt.Sprintf("--%s", flag.Name)
+	}
+}
+
+func (c *Completer) completeFlagSet(word string) (completions []string) {
+	c.flags.SortFlags = true
+	c.flags.VisitAll(func(flag *pflag.Flag) {
+		// Skip already specified flags
+		for _, f := range c.flagsInArgs {
+			if f.Name == flag.Name {
+				return
+			}
+		}
+
+		if flag.Hidden {
+			return
+		}
+
+		if len(word) == 0 {
+			completions = append(completions, c.formatFlag(flag, false))
+		} else {
+			names := []string{
+				c.formatFlag(flag, true),
+				c.formatFlag(flag, false),
+			}
+			completions = c.appendMatches(completions, word, names...)
+		}
+	})
+
+	return
+}
+
+func (c *Completer) completeFlagSetValue(flag *pflag.Flag, word string) (completions []string) {
+	var list []string
+
+	switch flag.Name {
+	case "name":
+		list = c.listProfileNames()
+
+	case "format":
+		list = []string{"toml", "json", "yaml", "hcl"}
+
+	case "theme":
+		list = []string{"dark", "light", "none"}
+
+	case "config":
+		fallthrough
+	case "log":
+		completions = []string{RequestFileCompletion}
+	}
+
+	completions = c.appendMatches(completions, word, list...)
+	return
+}
+
+func (c *Completer) listProfileNames() (list []string) {
+	if c.profiles == nil {
+		filename := ""
+		format := ""
+		if configFlag := c.flags.Lookup("config"); configFlag != nil {
+			filename = configFlag.Value.String()
+		}
+		if formatFlag := c.flags.Lookup("format"); formatFlag != nil {
+			format = formatFlag.Value.String()
+		}
+
+		if file, err := filesearch.FindConfigurationFile(filename); err == nil {
+			if conf, err := config.LoadFile(file, format); err == nil {
+				for name, _ := range conf.GetProfileSections() {
+					list = append(list, name)
+				}
+				for name, _ := range conf.GetProfileGroups() {
+					list = append(list, name)
+				}
+			}
+		}
+		if list == nil {
+			list = make([]string, 0)
+		}
+		sort.Strings(list)
+		c.profiles = list
+	} else {
+		list = c.profiles
+	}
+
+	return
+}
+
+func (c *Completer) completeProfileNamePrefixes(word string) (completions []string) {
+	for _, profile := range c.listProfileNames() {
+		completions = c.appendMatches(completions, word, profile+ProfileCommandDelimiter)
+	}
+	return
+}
+
+func (c *Completer) formatCommand(command ownCommand) string {
+	return command.name
+}
+
+func (c *Completer) completeOwnCommands(word string) (completions []string) {
+	for _, command := range c.ownCommands {
+		if command.hide || command.hideInCompletion {
+			continue
+		}
+		completions = c.appendMatches(completions, word, c.formatCommand(command))
+	}
+
+	if completions != nil {
+		sort.Strings(completions)
+	}
+	return
+}
+
+func (c *Completer) completeOwnCommandFlags(name, word string) (completions []string) {
+	commandFlagsInArgs := c.flags.Args()
+	sort.Strings(commandFlagsInArgs)
+
+	for _, command := range c.ownCommands {
+		if command.name == name {
+			for names, _ := range command.flags { // e.g. "-q, --quiet"
+				var flagNames []string
+
+				for _, flag := range strings.Split(names, ",") {
+					flag = strings.TrimSpace(flag)
+					flagNames = append(flagNames, flag)
+
+					// Remove this flag if already specified
+					if c.sortedListContains(commandFlagsInArgs, flag) {
+						flagNames = nil
+						break
+					}
+				}
+
+				if flagNames != nil {
+					completions = c.appendMatches(completions, word, flagNames...)
+				}
+			}
+
+			if completions != nil {
+				sort.Strings(completions)
+			}
+		}
+	}
+
+	return
+}
+
+func (c *Completer) appendMatches(completions []string, word string, list ...string) []string {
+	for _, item := range list {
+		if strings.HasPrefix(item, word) && item != "--" && len(item) > 1 {
+			completions = append(completions, item)
+		}
+	}
+	return completions
+}
+
+func (c *Completer) sortedListContains(list []string, word string) bool {
+	// expects list to be sorted in ascending order (will fail if not)
+	index := sort.SearchStrings(list, word)
+	return index < len(list) && list[index] == word
+}
+
+func (c *Completer) toCompletionsWithProfilePrefix(completions []string, profile string) (result []string) {
+	if c.sortedListContains(c.listProfileNames(), profile) {
+		prefix := profile + ProfileCommandDelimiter
+
+		for _, item := range completions {
+			supportsPrefix := item != prefix &&
+				!strings.HasPrefix(item, "-") &&
+				!strings.HasSuffix(item, ProfileCommandDelimiter) &&
+				item != RequestFileCompletion &&
+				!c.isOwnCommand(item, false)
+
+			if supportsPrefix {
+				result = append(result, prefix+item)
+			}
+		}
+	} else {
+		result = completions
+	}
+
+	return
+}
+
+func (c *Completer) isOwnCommand(command string, configurationLoaded bool) bool {
+	for _, commandDef := range c.ownCommands {
+		if commandDef.name == command && commandDef.needConfiguration == configurationLoaded {
+			return true
+		}
+	}
+	return false
+}
+
+// Complete returns shell completions for the specified commandline args.
+// Use "__POS:{FOLLOWING-ARG-INDEX}" if completions should not be provided for the last args element
+func (c *Completer) Complete(args []string) (completions []string) {
+	args = append([]string{}, args...)
+	c.init(args)
+
+	lookupFlag := func(word string) (flag *pflag.Flag) {
+		if strings.HasPrefix(word, "-") {
+			flagName := strings.Trim(word, "-")
+			flag = c.flags.Lookup(flagName)
+			if flag == nil && len(flagName) == 1 && !strings.HasPrefix(word, "--") {
+				flag = c.flags.ShorthandLookup(flagName)
+			}
+		}
+		return
+	}
+
+	flagRequiresValue := func(flag *pflag.Flag) bool {
+		return flag.Value.Type() != "bool"
+	}
+
+	isAnyOwnCommand := func(command string) bool {
+		return len(command) > 0 && (c.isOwnCommand(command, false) || c.isOwnCommand(command, true))
+	}
+
+	// Parse cursor position (specified as "__POS:{FOLLOWING-ARG-INDEX}")
+	for i, length := 0, len(args); i < length; i++ {
+		if strings.HasPrefix(args[i], "__POS:") {
+			if pos, err := strconv.Atoi(strings.Split(args[i], ":")[1]); err == nil && pos >= 0 && pos < length-i {
+				length = i + pos + 1
+				args = args[0:length]
+			}
+			args = append(args[0:i], args[i+1:]...)[0 : length-1]
+			break
+		}
+	}
+
+	// Parsing the CLI args and setup state
+	var currentFlag *pflag.Flag
+	inFlagSet := true
+	atCommand := false
+	word, commandName, profileName := "", "", ""
+
+	for _, arg := range args {
+		currentFlag = nil
+		atCommand = false
+
+		// Unknown command, delegate to restic completion
+		if !inFlagSet && !isAnyOwnCommand(commandName) {
+			completions = []string{RequestResticCompletion}
+			break
+		}
+
+		// Handle own flags and commands
+		if inFlagSet {
+			if strings.HasPrefix(arg, "-") {
+				if flag := lookupFlag(arg); flag != nil {
+					c.flagsInArgs = append(c.flagsInArgs, flag)
+				}
+			} else {
+				inFlagSet = false
+
+				if currentFlag = lookupFlag(word); currentFlag != nil {
+					inFlagSet = flagRequiresValue(currentFlag)
+				}
+
+				if !inFlagSet {
+					atCommand = true
+					commandName = arg
+					if pos := strings.LastIndex(commandName, ProfileCommandDelimiter); pos > -1 {
+						profileName, commandName = commandName[0:pos], commandName[pos+1:]
+						word = commandName
+						continue
+					}
+				}
+			}
+		}
+
+		word = arg
+	}
+
+	// Build completions
+	if completions == nil {
+		if inFlagSet {
+			// Test for exact flag match in current input
+			if f := lookupFlag(word); f != nil {
+				if flagRequiresValue(f) {
+					currentFlag = f
+				}
+				word = ""
+			}
+
+			if currentFlag == nil {
+				completions = c.completeFlagSet(word)
+				completions = append(completions, c.completeOwnCommands(word)...)
+				completions = append(completions, c.completeProfileNamePrefixes(word)...)
+			} else if len(c.flagsInArgs) > 0 {
+				completions = c.completeFlagSetValue(currentFlag, word)
+			}
+		} else if len(commandName) > 0 && isAnyOwnCommand(commandName) {
+			completions = c.completeOwnCommandFlags(commandName, word)
+		} else {
+			completions = c.completeOwnCommands(word)
+			completions = append(completions, c.completeProfileNamePrefixes(word)...)
+			completions = append(completions, RequestResticCompletion)
+		}
+	}
+
+	// Remove direct matches to avoid duplications
+	if len(completions) == 1 && completions[0] == word {
+		completions = nil
+	}
+
+	// Add command profile prefix when a valid profile name is specified
+	if len(profileName) > 0 && atCommand {
+		completions = c.toCompletionsWithProfilePrefix(completions, profileName)
+	}
+
+	return
+}

--- a/complete_test.go
+++ b/complete_test.go
@@ -1,0 +1,311 @@
+package main
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/spf13/pflag"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCompleter(t *testing.T) {
+	completer := &Completer{}
+	completer.init(nil)
+
+	newArgs := func(args ...string) (result []string) {
+		result = append(result, "--config", "examples/profiles.conf")
+		result = append(result, args...)
+		return
+	}
+
+	// Flags and flag values
+	t.Run("Flags", func(t *testing.T) {
+		flagSet, _, _ := loadFlags(nil)
+
+		hasFlags := false
+		flagSet.VisitAll(func(*pflag.Flag) {
+			hasFlags = true
+		})
+		require.True(t, hasFlags)
+
+		// Flags
+		t.Run("CompletesFlagSets", func(t *testing.T) {
+			flagCompletion := func(flag *pflag.Flag, includeShorthand bool) (names []string) {
+				if includeShorthand {
+					names = append(names, fmt.Sprintf("-%s", flag.Shorthand))
+				}
+				names = append(names, fmt.Sprintf("--%s", flag.Name))
+				return
+			}
+
+			t.Run("ReturnsAllFlagsExceptHidden", func(t *testing.T) {
+				var expected []string
+				flagSet.SortFlags = true
+				flagSet.VisitAll(func(flag *pflag.Flag) {
+					if !flag.Hidden {
+						expected = append(expected, flagCompletion(flag, false)...)
+					}
+				})
+				assert.Equal(t, expected, completer.completeFlagSet(""))
+			})
+
+			t.Run("ReturnsSpecificFlags", func(t *testing.T) {
+				flagSet.VisitAll(func(flag *pflag.Flag) {
+					expected := flagCompletion(flag, false)
+					if flag.Hidden {
+						expected = nil
+					}
+					assert.Equal(t, expected, completer.completeFlagSet(fmt.Sprintf("--%s", flag.Name)))
+
+					if len(flag.Shorthand) > 0 && !flag.Hidden {
+						expected = flagCompletion(flag, true)[0:1]
+						assert.Equal(t, expected, completer.completeFlagSet(fmt.Sprintf("-%s", flag.Shorthand)))
+					}
+				})
+			})
+
+			t.Run("RemovesAlreadySet", func(t *testing.T) {
+				flagSet.VisitAll(func(flag *pflag.Flag) {
+					completion := flagCompletion(flag, false)[0]
+					completer.Complete(nil)
+					if !flag.Hidden {
+						assert.Contains(t, completer.completeFlagSet(""), completion)
+					}
+					completer.Complete(newArgs(fmt.Sprintf("--%s", flag.Name)))
+					assert.NotContains(t, completer.completeFlagSet(""), completion)
+				})
+			})
+		})
+
+		// Flag values
+		t.Run("CompletesFlagValues", func(t *testing.T) {
+
+			t.Run("AllWithValues", func(t *testing.T) {
+				flagSet.VisitAll(func(flag *pflag.Flag) {
+					if flag.Hidden {
+						return
+					}
+
+					completions := completer.completeFlagSetValue(flag, "")
+					flagType := flag.Value.Type()
+					if flagType == "bool" || flagType == "duration" {
+						assert.Empty(t, completions, "Flag --%s", flag.Name)
+					} else {
+						assert.NotEmpty(t, completions, "Flag --%s", flag.Name)
+					}
+				})
+			})
+
+			testValues := func(flagName string, expected []string) func(t *testing.T) {
+				return func(t *testing.T) {
+					t.Run("ReturnsAllValues", func(t *testing.T) {
+						actual := completer.Complete(newArgs(fmt.Sprintf("--%s", flagName), ""))
+						assert.Equal(t, expected, actual)
+					})
+
+					t.Run("ReturnsSpecificValues", func(t *testing.T) {
+						for _, value := range expected {
+							actual := completer.completeFlagSetValue(flagSet.Lookup(flagName), value)
+							assert.Equal(t, []string{value}, actual)
+						}
+					})
+				}
+			}
+
+			t.Run("ConfigFlag", testValues("config", []string{RequestFileCompletion}))
+			t.Run("FormatFlag", testValues("format", []string{"toml", "json", "yaml", "hcl"}))
+			t.Run("LogFlag", testValues("log", []string{RequestFileCompletion}))
+			t.Run("ThemeFlag", testValues("theme", []string{"dark", "light", "none"}))
+
+			// Profiles from "examples/profiles.conf"
+			t.Run("NameFlag", testValues("name", []string{
+				"default", "full-backup", "linux", "no-cache", "root", "src", "stdin",
+			}))
+		})
+	})
+
+	// Profile completion
+	t.Run("Profiles", func(t *testing.T) {
+		// Profiles from "examples/dev.yaml"
+		profiles := []string{
+			"default", "documents", "dropbox", "escape", "full-backup", "home",
+			"nobackup", "prom", "root", "self", "space", "src", "stdin", "system",
+		}
+
+		t.Run("Loading", func(t *testing.T) {
+			t.Run("LoadsConfig", func(t *testing.T) {
+				completer.Complete(newArgs("--config", "examples/dev.yaml"))
+				assert.Equal(t, profiles, completer.listProfileNames())
+			})
+
+			t.Run("RespectsFormat", func(t *testing.T) {
+				completer.Complete(newArgs("--format", "toml", "--config", "examples/dev.yaml"))
+				assert.Equal(t, []string{}, completer.listProfileNames())
+				completer.Complete(newArgs("--format", "yaml", "--config", "examples/dev.yaml"))
+				assert.Equal(t, profiles, completer.listProfileNames())
+			})
+
+			t.Run("HandleNonExisting", func(t *testing.T) {
+				completer.Complete(newArgs("--config", "non-existing-profiles.yaml"))
+				assert.Equal(t, []string{}, completer.listProfileNames())
+			})
+		})
+
+		t.Run("CompletesPrefix", func(t *testing.T) {
+			t.Run("AllProfiles", func(t *testing.T) {
+				completions := completer.Complete(newArgs("--config", "examples/dev.yaml", ""))
+				for _, profile := range profiles {
+					assert.Contains(t, completions, fmt.Sprintf("%s.", profile))
+				}
+			})
+
+			t.Run("CommandsWithProfile", func(t *testing.T) {
+				var commands []string
+				for _, command := range getOwnCommands() {
+					if command.needConfiguration && !command.hide && !command.hideInCompletion {
+						commands = append(commands, command.name)
+					}
+				}
+
+				require.NotEmpty(t, commands)
+				sort.Strings(commands)
+
+				for _, profile := range profiles {
+					prefix := fmt.Sprintf("%s.", profile)
+					completions := completer.Complete(newArgs("--config", "examples/dev.yaml", prefix))
+
+					var expected []string
+					for _, commandName := range commands {
+						expected = append(expected, prefix+commandName)
+					}
+					expected = append(expected, prefix+RequestResticCompletion)
+
+					assert.Equal(t, expected, completions)
+				}
+			})
+		})
+	})
+
+	// Commands
+	t.Run("Commands", func(t *testing.T) {
+		var commands []string
+		commandValues := map[string][]string{}
+
+		for _, command := range getOwnCommands() {
+			if !command.hide && !command.hideInCompletion {
+				commands = append(commands, command.name)
+			}
+			for flag, _ := range command.flags {
+				for _, v := range strings.Split(flag, ",") {
+					commandValues[command.name] = append(commandValues[command.name], strings.TrimSpace(v))
+					sort.Strings(commandValues[command.name])
+				}
+			}
+		}
+
+		require.NotEmpty(t, commands)
+		sort.Strings(commands)
+
+		t.Run("CompletesCommands", func(t *testing.T) {
+			t.Run("AllVisibleCommands", func(t *testing.T) {
+				assert.Equal(t, commands, completer.completeOwnCommands(""))
+			})
+
+			t.Run("SpecificCommands", func(t *testing.T) {
+				for _, command := range commands {
+					assert.Equal(t, []string{command}, completer.completeOwnCommands(command))
+				}
+			})
+		})
+
+		t.Run("CompletesCommandFlags", func(t *testing.T) {
+			t.Run("AllFlags", func(t *testing.T) {
+				for _, command := range commands {
+					expected := commandValues[command]
+					assert.Equal(t, expected, completer.Complete(newArgs(command, "-")), "Command %s", command)
+				}
+			})
+
+			t.Run("SpecificFlags", func(t *testing.T) {
+				for _, command := range commands {
+					for _, flag := range commandValues[command] {
+						assert.Equal(t, []string{flag}, completer.completeOwnCommandFlags(command, flag), "Command %s", command)
+					}
+				}
+			})
+		})
+	})
+
+	// Static test table on Complete()
+	t.Run("Complete", func(t *testing.T) {
+		tests := []struct {
+			args     []string
+			expected []string
+		}{
+			// Can complete by prefix
+			{args: []string{"ful"}, expected: []string{"full-backup.", RequestResticCompletion}},
+			{args: []string{"sched"}, expected: []string{"schedule", RequestResticCompletion}},
+			{args: []string{"unsch"}, expected: []string{"unschedule", RequestResticCompletion}},
+			{args: []string{"--nam"}, expected: []string{"--name"}},
+			{args: []string{"--theme", "d"}, expected: []string{"dark"}},
+
+			// Can complete shorthand
+			{args: []string{"-c"}, expected: []string{RequestFileCompletion}},
+			{args: []string{"-l"}, expected: []string{RequestFileCompletion}},
+			{args: []string{"self-update", "-"}, expected: []string{"--quiet", "-q"}},
+			{args: []string{"self-update", "-q"}, expected: nil},
+
+			// Can completion commands after flags
+			{args: []string{"--verbose", "schedule", "-"}, expected: []string{"--all", "--no-start"}},
+			{args: []string{"--log", "file", "schedule", "-"}, expected: []string{"--all", "--no-start"}},
+
+			// Flags are returned only once
+			{args: []string{"--verb"}, expected: []string{"--verbose"}},
+			{args: []string{"--verb", "--verb"}, expected: []string{"--verbose"}},
+			{args: []string{"--verbose", "--verb"}, expected: nil},
+			{args: []string{"schedule", "-"}, expected: []string{"--all", "--no-start"}},
+			{args: []string{"schedule", "--all", "-"}, expected: []string{"--no-start"}},
+
+			// Exact command match returns nothing (no duplication)
+			{args: []string{"schedule"}, expected: nil},
+			{args: []string{"unschedule"}, expected: nil},
+
+			// Exact flag value match returns nothing (no duplication)
+			{args: []string{"--name", "full-backup"}, expected: nil},
+			{args: []string{"--theme", "light"}, expected: nil},
+			{args: []string{"status", "--all"}, expected: nil},
+
+			// Can set completion cursor position
+			{args: []string{"__POS:1", "--log", "out.log", "--verbose", "schedule", "-"}, expected: []string{RequestFileCompletion}},
+			{args: []string{"__POS:2", "--log", "out.log", "--verbose", "schedule", "-"}, expected: []string{RequestFileCompletion}},
+			{args: []string{"__POS:4", "--log", "out.log", "--verbose", "schedule", "-"}, expected: nil},
+			{args: []string{"__POS:5", "--log", "out.log", "--verbose", "schedule", "-"}, expected: []string{"--all", "--no-start"}},
+
+			// Unknown is delegated to restic
+			{args: []string{"unknown-cmd"}, expected: []string{RequestResticCompletion}},
+			{args: []string{"--verbose", "unknown-cmd"}, expected: []string{RequestResticCompletion}},
+			{args: []string{"--log", "file", "unknown-cmd"}, expected: []string{RequestResticCompletion}},
+			{args: []string{"--log", "file", "unknown-cmd", "--a-flag"}, expected: []string{RequestResticCompletion}},
+
+			// Adds profile prefixes (but only for existing profiles)
+			{args: []string{"unknown-profile.schedul"}, expected: []string{"schedule", RequestResticCompletion}},
+			{args: []string{"full-backup.schedul"}, expected: []string{"full-backup.schedule", "full-backup." + RequestResticCompletion}},
+			{args: []string{"full-backup.unknown-cmd"}, expected: []string{"full-backup." + RequestResticCompletion}},
+
+			// Regression: Flag value completion does not complete flags matching value names
+			{args: []string{"--log", "f"}, expected: []string{RequestFileCompletion}},
+			{args: []string{"--log", "theme"}, expected: []string{RequestFileCompletion}},
+		}
+
+		for index, test := range tests {
+			name := fmt.Sprintf("#%d [%s]", index, strings.Join(test.args, ","))
+			t.Run(name, func(t *testing.T) {
+				completions := completer.Complete(newArgs(test.args...))
+				assert.Equal(t, test.expected, completions)
+			})
+		}
+	})
+}

--- a/contrib/completion/bash-completion.sh
+++ b/contrib/completion/bash-completion.sh
@@ -6,7 +6,7 @@ function _resticprofile() {
   local resticprofile="${COMP_WORDS[0]}"
   COMP_WORDS[0]="__POS:${COMP_CWORD}"
 
-  # Get completions for resticprofile
+  # Get completions from resticprofile
   COMPREPLY=($("$resticprofile" complete "${COMP_WORDS[@]}"))
 
   # Handle completion requests (last item in result of prev command)
@@ -25,7 +25,7 @@ function _resticprofile() {
         local action="${COMPREPLY[-1]##*.}" # everything after last dot
         unset COMPREPLY[-1]
 
-        # Remove prefixes that restic doesn't understand (must remove all prefix.value, keep paths)
+        # Remove prefixes that restic doesn't understand (removes any [prefix.]value, keeps paths)
         for (( i=0 ; i<${#COMP_WORDS[@]} ; i++ )) ; do
           [[ "${COMP_WORDS[-1]}" =~ (.*/.*) ]] \
             || COMP_WORDS[$i]="${COMP_WORDS[$i]##*.}"
@@ -41,7 +41,7 @@ function _resticprofile() {
           done
         fi
 
-          # Add command prefix and append
+        # Add command prefix and append to completions
         if ((${#restic_values[@]})) ; then
           if [[ -n $prefix && "$prefix" != "$action" ]] ; then
             for (( i=0 ; i<${#restic_values[@]} ; i++ )) ; do
@@ -82,6 +82,15 @@ function __resticprofile_get_other_completions() {
 
     # determine completion function
     completion=$(complete -p "$1" 2>/dev/null | awk '{print $(NF-1)}')
+
+    # run _completion_loader only if necessary
+    [[ -n $completion ]] || declare -F _completion_loader &>/dev/null && {
+        # load completion
+        _completion_loader "$1"
+
+        # detect completion
+        completion=$(complete -p "$1" 2>/dev/null | awk '{print $(NF-1)}')
+    }
 
     # ensure completion was detected
     [[ -n $completion ]] || return 1

--- a/contrib/completion/bash-completion.sh
+++ b/contrib/completion/bash-completion.sh
@@ -1,0 +1,94 @@
+#!/usr/bin/env bash
+#
+# resticprofile bash completion script
+# Usage: source this script in your bash profile (or add to bash_completion.d)
+function _resticprofile() {
+  local resticprofile="${COMP_WORDS[0]}"
+  COMP_WORDS[0]="__POS:${COMP_CWORD}"
+
+  # Get completions for resticprofile
+  COMPREPLY=($("$resticprofile" complete "${COMP_WORDS[@]}"))
+
+  # Handle completion requests (last item in result of prev command)
+  if ((${#COMPREPLY[@]})) ; then
+    case "${COMPREPLY[-1]}" in
+      __complete_file)
+        unset COMPREPLY[-1]
+
+        local file="${COMP_WORDS[-1]}"
+        [[ "${file:0:1}" == "-" ]] && file=""
+        COMPREPLY+=($(compgen -f "$file"))
+      ;;
+
+      **__complete_restic)
+        local prefix="${COMPREPLY[-1]%.*}"  # everything before last dot
+        local action="${COMPREPLY[-1]##*.}" # everything after last dot
+        unset COMPREPLY[-1]
+
+        # Remove prefixes that restic doesn't understand (must remove all prefix.value, keep paths)
+        for (( i=0 ; i<${#COMP_WORDS[@]} ; i++ )) ; do
+          [[ "${COMP_WORDS[-1]}" =~ (.*/.*) ]] \
+            || COMP_WORDS[$i]="${COMP_WORDS[$i]##*.}"
+        done
+
+        # Get restic completions
+        local restic_values=($(__resticprofile_get_other_completions restic "${COMP_WORDS[@]}"))
+
+        # Remove any empty trailing values
+        if ((${#restic_values[@]})) ; then
+          while [[ "${restic_values[-1]}" =~ (^[\r\n\t ]+$) ]] ; do
+            unset restic_values[-1]
+          done
+        fi
+
+          # Add command prefix and append
+        if ((${#restic_values[@]})) ; then
+          if [[ -n $prefix && "$prefix" != "$action" ]] ; then
+            for (( i=0 ; i<${#restic_values[@]} ; i++ )) ; do
+              restic_values[$i]="${prefix}.${restic_values[$i]}"
+            done
+          fi
+
+          COMPREPLY+=("${restic_values[@]}")
+        fi
+      ;;
+    esac
+  fi
+}
+
+# Registering the completion
+complete -F _resticprofile resticprofile
+
+#
+# __resticprofile_get_other_completions
+# Author: Brian Beffa <brbsix@gmail.com>
+# Original source: https://brbsix.github.io/2015/11/29/accessing-tab-completion-programmatically-in-bash/
+# License: LGPLv3 (http://www.gnu.org/licenses/lgpl-3.0.txt)
+function __resticprofile_get_other_completions() {
+    local completion COMP_CWORD COMP_LINE COMP_POINT COMP_WORDS COMPREPLY=()
+
+    COMP_LINE=$*
+    COMP_POINT=${#COMP_LINE}
+
+    eval set -- "$@"
+
+    COMP_WORDS=("$@")
+
+    # add '' to COMP_WORDS if the last character of the command line is a space
+    [[ ${COMP_LINE[@]: -1} = ' ' ]] && COMP_WORDS+=('')
+
+    # index of the last word
+    COMP_CWORD=$(( ${#COMP_WORDS[@]} - 1 ))
+
+    # determine completion function
+    completion=$(complete -p "$1" 2>/dev/null | awk '{print $(NF-1)}')
+
+    # ensure completion was detected
+    [[ -n $completion ]] || return 1
+
+    # execute completion function
+    "$completion"
+
+    # print completions to stdout
+    printf '%s\n' "${COMPREPLY[@]}" | LC_ALL=C sort
+}

--- a/contrib/completion/bash-completion.sh
+++ b/contrib/completion/bash-completion.sh
@@ -9,7 +9,7 @@ function _resticprofile() {
   COMP_WORDS[0]="__POS:${COMP_CWORD}"
 
   # Get completions from resticprofile
-  COMPREPLY=($("$resticprofile" complete "${COMP_WORDS[@]}"))
+  COMPREPLY=($("$resticprofile" complete "bash:v1" "${COMP_WORDS[@]}"))
 
   # Handle completion requests (last item in result of prev command)
   if ((${#COMPREPLY[@]})) ; then

--- a/contrib/completion/zsh-completion.sh
+++ b/contrib/completion/zsh-completion.sh
@@ -8,7 +8,26 @@
 
 autoload -U +X compinit && compinit
 autoload -U +X bashcompinit && bashcompinit
-eval "$(resticprofile completion-script --bash)"
+
+# Continue only if bashcompinit succeeded
+declare -F complete &>/dev/null || exit 1
+
+# Load bash script
+__resticprofile_script=""
+
+if [[ -x "$(which resticprofile)" ]] ; then
+  __resticprofile_script="$(resticprofile completion-script --bash)"
+else
+  echo "resticprofile not found or not executable"
+  exit 1
+fi
+
+if echo "${__resticprofile_script}" | grep -q "__resticprofile_get_other_completions()" ; then
+  eval "${__resticprofile_script}"
+else
+  echo "resticprofile did not return a completion script"
+  exit 1
+fi
 
 #
 # Disable other completions for now

--- a/contrib/completion/zsh-completion.sh
+++ b/contrib/completion/zsh-completion.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env zsh
+#
+# resticprofile zsh completion script
+# Usage: source this script in your zsh profile (or add to zsh_completion.d)
+
+# TODO: This script redirects to the bash_completion script
+# TODO: A dedicated completion for zsh should be created instead
+
+autoload -U +X compinit && compinit
+autoload -U +X bashcompinit && bashcompinit
+eval "$(resticprofile completion-script --bash)"
+
+#
+# Disable other completions for now
+function __resticprofile_get_other_completions() {
+  return
+}


### PR DESCRIPTION
This PR provides shell completion (addressing #86) using a custom `complete` command operating on the data structures in resticprofile rather than auto-generating a complete script (like restic does) which would require more refactoring on resticprofile's internals.

Since `resticprofile` is a wrapper around `restic`, all unknown input is forwarded to shell completion of `restic` and both results are then merged.

**Setup**

```shell
resticprofile completion-script --bash > /etc/bash_completion.d/resticprofile
chmod +x /etc/bash_completion.d/resticprofile
source /etc/bash_completion.d/resticprofile
```

or

```shell
eval "$(resticprofile completion-script --bash)"
```

**Example**

```shell
bash-5.1$ resticprofile 
backup             diff               init               profiles           schedule           tag
cache              dump               key                prune              self-update        unlock
cat                find               list               random-key         show               unschedule
check              forget             ls                 rebuild-index      snapshots          version
copy               generate           migrate            recover            stats              
create-completion  help               mount              restore            status             

bash-5.1$ resticprofile -
--config       --help         --name         --no-prio      --theme        --wait         -h             -q
--dry-run      --lock-wait    --no-ansi      --quiet        --trace        -c             -l             -v
--format       --log          --no-lock      --self-update  --verbose      -f             -n             -w

bash-5.1$ resticprofile --config pr
priority       profiles.yaml  progress       prom     

bash-5.1$ resticprofile --config profiles.yaml --no-
--no-ansi  --no-lock  --no-prio  

bash-5.1$ resticprofile --config profiles.yaml --no-lock --theme 
dark   light  none   

bash-5.1$ resticprofile --config profiles.yaml --no-lock --theme dark schedule --
--all       --no-start  

bash-5.1$ resticprofile mount -
--allow-other             --limit-download=         --password-file=          --tls-client-cert
--cacert                  --limit-upload            --path                    --tls-client-cert=
--cacert=                 --limit-upload=           --path=                   --verbose
--cache-dir               --no-cache                --quiet                   -H
--cache-dir=              --no-default-permissions  --repo                    -o
--cleanup-cache           --no-lock                 --repo=                   -p
--host                    --option                  --repository-file         -q
--host=                   --option=                 --repository-file=        -r
--json                    --owner-root              --snapshot-template       -v
--key-hint                --password-command        --snapshot-template=      
--key-hint=               --password-command=       --tag                     
--limit-download          --password-file           --tag=                    
```

# ToDo

- [x] Support bash
- [x] Support zsh (basic only)
- [x] Unit test `complete` function and fix bugs
- [x] Document
