### PR TITLE
Added configuration support for additional restic commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -2234,8 +2234,8 @@ Flags passed to the restic command line
 * **group-by**: string
 * **host**: true / false OR string
 * **last**: true / false
-* **path**: string OR list of strings
-* **tag**: string OR list of strings
+* **path**: true / false, string OR list of strings
+* **tag**: true / false, string OR list of strings
 
 `[profile.forget]`
 
@@ -2258,8 +2258,8 @@ Flags passed to the restic command line
 * **keep-within**: string
 * **keep-tag**: string OR list of strings
 * **host**: true / false OR string
-* **tag**: string OR list of strings
-* **path**: string OR list of strings
+* **tag**: true / false, string OR list of strings
+* **path**: true / false, string OR list of strings
 * **compact**: true / false
 * **group-by**: string
 * **dry-run**: true / false
@@ -2301,26 +2301,79 @@ Flags passed to the restic command line
 * **host**: true / false OR string
 * **no-default-permissions**: true / false
 * **owner-root**: true / false
-* **path**: string OR list of strings
+* **path**: true / false, string OR list of strings
 * **snapshot-template**: string
-* **tag**: string OR list of strings
+* **tag**: true / false, string OR list of strings
 
 `[profile.copy]`
 
 Flags used by resticprofile only
 
 * **initialize**: true / false
-
+* **schedule**: string OR list of strings
+* **schedule-permission**: string (`user` or `system`)
+* **schedule-lock-mode**: string (`default`, `fail` or `ignore`)
+* **schedule-lock-wait**: duration
+* **schedule-log**: string
 
 Flags passed to the restic command line
 
-* **key-hint**: string
-* **password-command**: command
-* **password-file**: string
-* **path**: string OR list of strings
-* **repository**: repository
-* **repository-file**: string
-* **tag**: string OR list of strings
+* **key-hint**: string **(will be passed as 'key-hint2')**
+* **password-command**: command **(will be passed as 'password-command2')**
+* **password-file**: string **(will be passed as 'password-file2')**
+* **host**: true / false OR string
+* **path**: true / false, string OR list of strings
+* **repository**: repository **(will be passed as 'repo2')**
+* **repository-file**: string **(will be passed as 'repository-file2')**
+* **tag**: true / false, string OR list of strings
+
+`[profile.dump]`
+
+Flags passed to the restic command line
+
+* **host**: true / false OR string
+* **path**: true / false, string OR list of strings
+* **tag**: true / false, string OR list of strings
+
+`[profile.find]`
+
+Flags passed to the restic command line
+
+* **host**: true / false OR string
+* **path**: true / false, string OR list of strings
+* **tag**: true / false, string OR list of strings
+
+`[profile.ls]`
+
+Flags passed to the restic command line
+
+* **host**: true / false OR string
+* **path**: true / false, string OR list of strings
+* **tag**: true / false, string OR list of strings
+
+`[profile.restore]`
+
+Flags passed to the restic command line
+
+* **host**: true / false OR string
+* **path**: true / false, string OR list of strings
+* **tag**: true / false, string OR list of strings
+
+`[profile.stats]`
+
+Flags passed to the restic command line
+
+* **host**: true / false OR string
+* **path**: true / false, string OR list of strings
+* **tag**: true / false, string OR list of strings
+
+`[profile.tag]`
+
+Flags passed to the restic command line
+
+* **host**: true / false OR string
+* **path**: true / false, string OR list of strings
+* **tag**: true / false, string OR list of strings
 
 
 # Appendix

--- a/commands.go
+++ b/commands.go
@@ -340,6 +340,8 @@ func containsString(args []string, arg string) bool {
 }
 
 func showProfile(output io.Writer, c *config.Config, flags commandLineFlags, args []string) error {
+	defer c.DisplayConfigurationIssues()
+
 	// Show global section first
 	global, err := c.GetGlobalSection()
 	if err != nil {
@@ -443,6 +445,8 @@ func flagsForProfile(flags commandLineFlags, profileName string) commandLineFlag
 
 // createSchedule accepts one argument from the commandline: --no-start
 func createSchedule(_ io.Writer, c *config.Config, flags commandLineFlags, args []string) error {
+	defer c.DisplayConfigurationIssues()
+
 	type profileJobs struct {
 		scheduler schedule.SchedulerConfig
 		profile   string
@@ -511,6 +515,8 @@ func removeSchedule(_ io.Writer, c *config.Config, flags commandLineFlags, args 
 }
 
 func statusSchedule(w io.Writer, c *config.Config, flags commandLineFlags, args []string) error {
+	defer c.DisplayConfigurationIssues()
+
 	if !containsString(args, "--all") {
 		// simple case of displaying status for one profile
 		scheduler, profile, schedules, err := getScheduleJobs(c, flags)

--- a/constants/command.go
+++ b/constants/command.go
@@ -11,4 +11,10 @@ const (
 	CommandUnlock    = "unlock"
 	CommandMount     = "mount"
 	CommandCopy      = "copy"
+	CommandDump      = "dump"
+	CommandFind      = "find"
+	CommandLs        = "ls"
+	CommandRestore   = "restore"
+	CommandStats     = "stats"
+	CommandTag       = "tag"
 )

--- a/main.go
+++ b/main.go
@@ -309,6 +309,7 @@ func runProfile(
 	}
 
 	displayProfileDeprecationNotices(profile)
+	c.DisplayConfigurationIssues()
 
 	// Send the quiet/verbose down to restic as well (override profile configuration)
 	if flags.quiet {


### PR DESCRIPTION
This PR is a cherry-pick from #66 to support configuration of additional commands that manage snapshots (or restore files).

Support for the following additional commands is added: `dump`, `find`, `ls`, `restore`, `stats`, `tag`. All of the commands optionally have host, path and tag filters which can now be set in the profile.

In detail, this PR adds the following:

* Adds config sections for the commands above
* Implements `tag` and `path` copy from `backup` with boolean `true` for all commands
* Fixes `SetHost` for the `copy` section
* Resolves paths for all path parameters in dynamic flags maps (for consistency).
* Changes the defaults of `path` and `tag` for `retention` in config file version 2. Both parameters are copied from `backup` when not explicitly defined. Was mentioned in #67 that it would be better to have the same defaults for both filters but couldn't be implemented to not break existing configs.
