### PR TITLE
Feature: Take command output as stdin for restic

### DIFF
--- a/README.md
+++ b/README.md
@@ -607,6 +607,15 @@ stdin = true
 stdin-filename = "stdin-test"
 tag = [ 'stdin' ]
 
+
+[send-stdout]
+inherit = "stdin"
+
+[send-stdout.backup]
+stdin-command = [ 'mysqldump --all-databases --order-by-primary' ]
+stdin-filename = "dump.sql"
+tag = [ 'send-stdout' ]
+
 ```
 
 ## Special case for the `copy` command section
@@ -903,11 +912,15 @@ $ resticprofile full-backup.backup
 Assuming the _stdin_ profile from the configuration file shown before, the command to send a mysqldump to the backup is as simple as:
 
 ```
-$ mysqldump --all-databases | resticprofile --name stdin backup
+$ mysqldump --all-databases --order-by-primary | resticprofile --name stdin backup
 ```
 or
 ```
-$ mysqldump --all-databases | resticprofile stdin.backup
+$ mysqldump --all-databases --order-by-primary | resticprofile stdin.backup
+```
+or when resticprofile runs "mysqldump" (can be scheduled):
+```
+$ resticprofile send-stdout.backup
 ```
 
 Mount the default profile (_default_) in /mnt/restic:
@@ -2173,6 +2186,7 @@ Flags used by resticprofile only
 * **schedule-lock-mode**: string (`default`, `fail` or `ignore`) 
 * **schedule-lock-wait**: duration 
 * **schedule-log**: string
+* **stdin-command**: string OR list of strings
 * **extended-status**: true / false
 * **no-error-on-warning**: true / false
 

--- a/config/config.go
+++ b/config/config.go
@@ -459,7 +459,7 @@ func (c *Config) GetProfile(profileKey string) (*Profile, error) {
 	}
 
 	// Resolve config dependencies
-	profile.resolveConfiguration()
+	profile.ResolveConfiguration()
 
 	// All files in the configuration are relative to the configuration file,
 	// NOT the folder where resticprofile is started

--- a/examples/windows.yaml
+++ b/examples/windows.yaml
@@ -60,3 +60,13 @@ test:
         - "*-7,8-* 12:00"
         schedule-permission: system
         schedule-log: "test-retention.log"
+
+stdin-command:
+    inherit: default
+    backup:
+        stdin-command:
+          - "cat resticprofile*"
+          - "cat resticprofile.*"
+          - "cat %USERPROFILE%/NTUSER.DAT"
+        stdin-filename: stdin-test
+

--- a/shell/command_test.go
+++ b/shell/command_test.go
@@ -89,7 +89,7 @@ func TestShellCommandWithArguments(t *testing.T) {
 			`.`,
 		}, args)
 	} else {
-		assert.Regexp(t, regexp.MustCompile("(/usr)?/bin/sh"), command)
+		assert.Regexp(t, regexp.MustCompile("(/usr)?/bin/(ba)?sh"), command)
 		assert.Equal(t, []string{
 			"-c",
 			"/bin/restic -v --exclude-file \"excludes\" --repo \"/path/with space\" backup .",
@@ -116,7 +116,7 @@ func TestShellCommand(t *testing.T) {
 			"/bin/restic -v --exclude-file \"excludes\" --repo \"/path/with space\" backup .",
 		}, args)
 	} else {
-		assert.Regexp(t, regexp.MustCompile("(/usr)?/bin/sh"), command)
+		assert.Regexp(t, regexp.MustCompile("(/usr)?/bin/(ba)?sh"), command)
 		assert.Equal(t, []string{
 			"-c",
 			"/bin/restic -v --exclude-file \"excludes\" --repo \"/path/with space\" backup .",
@@ -184,7 +184,7 @@ func TestInterruptShellCommand(t *testing.T) {
 	start := time.Now()
 	_, _, err := cmd.Run()
 	// GitHub Actions *sometimes* sends a different message: "signal: interrupt"
-	if err != nil && err.Error() != "exit status 1" && err.Error() != "signal: interrupt" {
+	if err != nil && err.Error() != "exit status 128" && err.Error() != "signal: interrupt" {
 		t.Fatal(err)
 	}
 

--- a/shell/command_windows.go
+++ b/shell/command_windows.go
@@ -1,9 +1,16 @@
-//+build windows
+//go:build windows
 
 package shell
 
 import "os"
 
 // In Windows, all hierarchy will receive the signal (which is good because we cannot send it anyway)
-// In fact, there's nothing for us to do here
-func (c *Command) propagateSignal(*os.Process) {}
+// In fact, there's nothing for us to do here but method must block on channels
+func (c *Command) propagateSignal(*os.Process) {
+	select {
+	case <-c.sigChan:
+		return
+	case <-c.done:
+		return
+	}
+}

--- a/shell_command.go
+++ b/shell_command.go
@@ -15,7 +15,7 @@ type shellCommandDefinition struct {
 	args       []string
 	publicArgs []string
 	env        []string
-	useStdin   bool
+	stdin      io.ReadCloser
 	stdout     io.Writer
 	stderr     io.Writer
 	dryRun     bool
@@ -34,7 +34,7 @@ func newShellCommand(command string, args, env []string, dryRun bool, sigChan ch
 		args:       args,
 		publicArgs: args,
 		env:        env,
-		useStdin:   false,
+		stdin:      nil,
 		stdout:     os.Stdout,
 		stderr:     os.Stderr,
 		dryRun:     dryRun,
@@ -57,8 +57,8 @@ func runShellCommand(command shellCommandDefinition) (progress.Summary, string, 
 	shellCmd.Stdout = command.stdout
 	shellCmd.Stderr = command.stderr
 
-	if command.useStdin {
-		shellCmd.Stdin = os.Stdin
+	if command.stdin != nil {
+		shellCmd.Stdin = command.stdin
 	}
 
 	// set PID callback

--- a/wrapper_streamsource.go
+++ b/wrapper_streamsource.go
@@ -1,0 +1,167 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"io"
+	"os"
+	"os/signal"
+	"runtime"
+	"sync"
+	"syscall"
+	"time"
+
+	"github.com/creativeprojects/clog"
+	"github.com/creativeprojects/resticprofile/term"
+)
+
+func (r *resticWrapper) prepareStreamSource() (io.ReadCloser, error) {
+	if r.profile.Backup != nil && r.profile.Backup.UseStdin {
+		if len(r.profile.Backup.StdinCommand) > 0 {
+			return r.prepareCommandStreamSource()
+		} else {
+			return r.prepareStdinStreamSource()
+		}
+	}
+	return nil, nil
+}
+
+func (r *resticWrapper) prepareStdinStreamSource() (io.ReadCloser, error) {
+	clog.Debug("redirecting stdin to the backup")
+
+	if r.stdin == nil {
+		return nil, fmt.Errorf("stdin was already consumed. cannot read it twice")
+	}
+
+	totalBytes := int64(0)
+
+	readCloser := &readerWrapper{
+		reader: r.stdin,
+		read: func(w *readerWrapper, bytes []byte) (n int, err error) {
+			n, err = w.reader.Read(bytes)
+			totalBytes += int64(n)
+			return
+		},
+		close: func(w *readerWrapper) error {
+			if totalBytes > 0 && r.stdin != nil {
+				r.stdin = nil
+				w.close = nil
+			}
+			return nil
+		},
+	}
+
+	return readCloser, nil
+}
+
+func (r *resticWrapper) prepareCommandStreamSource() (io.ReadCloser, error) {
+	clog.Debug("redirecting command output to the backup")
+	pipeReader, pipeWriter := io.Pipe()
+	bufferedWriter := bufio.NewWriterSize(pipeWriter, 8*1024)
+
+	commandSignals := make(chan os.Signal, 2)
+	signal.Notify(commandSignals, os.Interrupt, syscall.SIGTERM, syscall.SIGABRT)
+
+	go func() {
+		defer pipeWriter.Close()
+		defer bufferedWriter.Flush()
+		defer signal.Stop(commandSignals)
+
+		env := append(os.Environ(), r.getEnvironment()...)
+		env = append(env, r.getProfileEnvironment()...)
+
+		for i, sourceCommand := range r.profile.Backup.StdinCommand {
+			clog.Debugf("starting 'stdin-command' command %d/%d: %s", i+1, len(r.profile.Backup.StdinCommand), sourceCommand)
+			rCommand := newShellCommand(sourceCommand, nil, env, r.dryRun, commandSignals, nil)
+			rCommand.stdout = bufferedWriter
+			rCommand.stderr = term.GetErrorOutput()
+
+			_, stderr, err := runShellCommand(rCommand)
+			if err != nil {
+				// discard unflushed output
+				bufferedWriter.Reset(pipeWriter)
+				// push command error to reader
+				err = newCommandError(rCommand, stderr, fmt.Errorf("'stdin-command' on profile '%s': %w", r.profile.Name, err))
+				if closeError := pipeWriter.CloseWithError(err); closeError != nil {
+					clog.Errorf("Failed closing pipe for command '%s' after %w ; close error: %w", sourceCommand, err, closeError)
+				}
+				return
+			}
+		}
+	}()
+
+	closePipe := func() error {
+		defer func() {
+			clog.Debugf("stopping 'stdin-command'")
+			signal.Stop(commandSignals)
+			commandSignals <- os.Interrupt
+		}()
+		return pipeReader.Close()
+	}
+
+	// read from pipe to ensure the process started and returns content or error before restic is started
+	var initialReader io.Reader
+	{
+		initialBytes := make([]byte, 512)
+		if n, err := pipeReader.Read(initialBytes); err == nil || err == io.EOF {
+			clog.Debugf("initial %d bytes successfully read from 'stdin-command'", n)
+			initialReader = bytes.NewReader(initialBytes[:n])
+		} else {
+			_ = closePipe()
+			return nil, err
+		}
+	}
+
+	readCloser := &readerWrapper{
+		reader: io.MultiReader(initialReader, pipeReader),
+
+		read: func(w *readerWrapper, bytes []byte) (n int, err error) {
+			n, err = w.reader.Read(bytes)
+
+			// Stopping restic when stream source command fails while producing content
+			if err != nil && err != io.EOF {
+				clog.Errorf("interrupting '%s' after stdin read error: %s", r.command, err)
+				if runtime.GOOS == "windows" {
+					os.Exit(1) // no signalling on Windows, use os.Exit() instead
+				} else if r.sigChan != nil {
+					r.sigChan <- os.Interrupt
+				}
+				// Wait for the signal to arrive before allowing further read from stdin
+				time.Sleep(750 * time.Millisecond)
+			}
+			return
+		},
+
+		close: func(w *readerWrapper) error {
+			w.close = nil
+			return closePipe()
+		},
+	}
+
+	return readCloser, nil
+}
+
+type readerWrapper struct {
+	reader              io.Reader
+	readLock, closeLock sync.Mutex
+	read                func(w *readerWrapper, bytes []byte) (n int, err error)
+	close               func(w *readerWrapper) error
+}
+
+func (w *readerWrapper) Read(bytes []byte) (n int, err error) {
+	w.readLock.Lock()
+	defer w.readLock.Unlock()
+
+	return w.read(w, bytes)
+}
+
+func (w *readerWrapper) Close() error {
+	w.closeLock.Lock()
+	defer w.closeLock.Unlock()
+
+	if w.close != nil {
+		return w.close(w)
+	}
+	return nil
+}

--- a/wrapper_streamsource.go
+++ b/wrapper_streamsource.go
@@ -123,7 +123,7 @@ func (r *resticWrapper) prepareCommandStreamSource() (io.ReadCloser, error) {
 			if err != nil && err != io.EOF {
 				clog.Errorf("interrupting '%s' after stdin read error: %s", r.command, err)
 				if runtime.GOOS == "windows" {
-					os.Exit(1) // no signalling on Windows, use os.Exit() instead
+					return // that will close stdin and stops restic
 				} else if r.sigChan != nil {
 					r.sigChan <- os.Interrupt
 				}


### PR DESCRIPTION
PR introducing "stdin-command" to allow scheduling backups of streams (e.g. mysql-dump) without requiring temporary storage.

Usage:

```yaml
my-profile:
  backup:
    schedule: 'hourly'
    stdin-filename: mysql-dump.sql
    stdin-command:
      - mysqldump --order-by-primary --host=db-host --user=db-user --password=db-pw db-name
```

- [x] Needs rebase when PR #94 is merged 
      (depends on `ResolveConfiguration()`)
- [x] Testing (unit & manual tests)
- [x] Contains data race that requires fixing