### PR TITLE
Implemented stream-error callbacks

### DIFF
--- a/README.md
+++ b/README.md
@@ -2178,6 +2178,12 @@ Flags passed to the restic command line
 * **tls-client-cert**: string
 * **verbose**: true / false OR integer
 
+`[[profile.stream-error]]`
+* **pattern**: regex (pattern matching stderr of `restic`) 
+* **run**: string (command to run when stderr line is matched)
+* **max-runs**: number
+* **min-matches**: number
+
 `[profile.backup]`
 
 Flags used by resticprofile only
@@ -2456,6 +2462,11 @@ root:
         tag:
         - test
         - dev
+        
+    stream-error:
+        -
+          pattern: "/tmp/restic-check-cache.+no space left on device"
+          run: "rm -Rf /tmp/restic-check-cache*"          
 
 self:
     backup:

--- a/config/display.go
+++ b/config/display.go
@@ -35,6 +35,11 @@ func (d *Display) addEntry(stack []string, key string, values []string) {
 	d.entries = append(d.entries, entry)
 }
 
+func (d *Display) addKeyOnlyEntry(stack []string, key string) {
+	d.addEntry(stack, key, nil)
+	d.entries[len(d.entries)-1].keyOnly = true
+}
+
 func (d *Display) Flush() {
 	tabWriter := tabwriter.NewWriter(d.writer, 0, 2, 2, ' ', 0)
 	// title
@@ -57,6 +62,10 @@ func (d *Display) Flush() {
 		if entry.key == "" {
 			continue
 		}
+		if entry.keyOnly {
+			fmt.Fprintf(tabWriter, "%s%s\n", prefix, entry.key)
+			continue
+		}
 		if len(entry.values) > 0 {
 			fmt.Fprintf(tabWriter, "%s%s:\t%s\n", prefix, entry.key, entry.values[0])
 		}
@@ -73,5 +82,6 @@ func (d *Display) Flush() {
 type Entry struct {
 	section string
 	key     string
+	keyOnly bool
 	values  []string
 }

--- a/config/profile.go
+++ b/config/profile.go
@@ -37,6 +37,7 @@ type Profile struct {
 	RunAfter             []string                     `mapstructure:"run-after"`
 	RunAfterFail         []string                     `mapstructure:"run-after-fail"`
 	RunFinally           []string                     `mapstructure:"run-finally"`
+	StreamError          []StreamErrorSection         `mapstructure:"stream-error"`
 	StatusFile           string                       `mapstructure:"status-file"`
 	PrometheusSaveToFile string                       `mapstructure:"prometheus-save-to-file"`
 	PrometheusPush       string                       `mapstructure:"prometheus-push"`
@@ -124,6 +125,13 @@ type CopySection struct {
 }
 
 func (s *CopySection) IsEmpty() bool { return s == nil }
+
+type StreamErrorSection struct {
+	Pattern    string `mapstructure:"pattern"`
+	MinMatches int    `mapstructure:"min-matches"`
+	MaxRuns    int    `mapstructure:"max-runs"`
+	Run        string `mapstructure:"run"`
+}
 
 // NewProfile instantiates a new blank profile
 func NewProfile(c *Config, name string) *Profile {

--- a/config/show.go
+++ b/config/show.go
@@ -102,6 +102,21 @@ func showField(fieldType reflect.StructField, fieldValue reflect.Value, stack []
 			showMap(append(stack, key), display, fieldValue)
 			return nil
 
+		case reflect.Array | reflect.Slice:
+			length := fieldValue.Len()
+			if length > 0 && fieldValue.Index(0).Kind() == reflect.Struct {
+				listStack := append(stack, key)
+				for i := 0; i < length; i++ {
+					if i > 0 {
+						display.addKeyOnlyEntry(listStack, "-")
+					}
+					if err := showSubStruct(fieldValue.Index(i).Interface(), listStack, display); err != nil {
+						return err
+					}
+				}
+			} else {
+				showKeyValue(stack, display, key, fieldValue)
+			}
 		default:
 			showKeyValue(stack, display, key, fieldValue)
 		}

--- a/config/show_test.go
+++ b/config/show_test.go
@@ -17,6 +17,7 @@ type testObject struct {
 	Id      int                 `mapstructure:"id"`
 	Name    string              `mapstructure:"name"`
 	Person  testPerson          `mapstructure:"person"`
+	Persons []testPerson        `mapstructure:"persons"`
 	Pointer *testPointer        `mapstructure:"pointer"`
 	Other   string              `mapstructure:"other" show:"noshow"`
 	Hidden  string              `mapstructure:""`
@@ -59,6 +60,10 @@ func TestShowStruct(t *testing.T) {
 		{
 			input:  testObject{Id: 11, Person: testPerson{Name: "test", IsValid: true}},
 			output: " id:  11\n\n person:\n  name:   test\n  valid:  true\n",
+		},
+		{
+			input:  testObject{Id: 11, Persons: []testPerson{{Name: "p1", IsValid: true}, {Name: "p2", IsValid: false}}},
+			output: " id:  11\n\n persons:\n  name:   p1\n  valid:  true\n  -\n  name:  p2\n",
 		},
 		{
 			input:  testObject{Id: 11, Pointer: &testPointer{IsValid: true}},

--- a/examples/dev.yaml
+++ b/examples/dev.yaml
@@ -182,6 +182,14 @@ home:
     backup:
         source: "${HOME}/Projects"
 
+    stream-error:
+        -
+            pattern: "find-one"
+            run: "echo Found One!"
+        -
+            pattern: "find-two"
+            run: "echo Found Two!"
+
 stdin:
     backup:
         stdin: true

--- a/shell/analyser_test.go
+++ b/shell/analyser_test.go
@@ -1,10 +1,12 @@
 package shell
 
 import (
+	"fmt"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 const ResticLockFailureOutput = `
@@ -15,19 +17,94 @@ the 'unlock' command can be used to remove stale locks
 `
 
 func TestRemoteLockFailure(t *testing.T) {
-	analysis := NewOutputAnalyser().AnalyseStringLines(ResticLockFailureOutput)
+	analysis := NewOutputAnalyser()
+	require.NoError(t, analysis.AnalyseStringLines(ResticLockFailureOutput))
 
 	assert.Equal(t, true, analysis.ContainsRemoteLockFailure())
 
-	{
+	t.Run("GetRemoteLockedSince", func(t *testing.T) {
 		since, ok := analysis.GetRemoteLockedSince()
 		assert.Equal(t, true, ok)
 		assert.Equal(t, time.Second+(727*time.Millisecond), since)
-	}
+	})
 
-	{
+	t.Run("GetRemoteLockedBy", func(t *testing.T) {
 		name, ok := analysis.GetRemoteLockedBy()
 		assert.Equal(t, true, ok)
 		assert.Equal(t, "PID 27153 on app-server-01 by root (UID 0, GID 0)", name)
+	})
+}
+
+func TestCustomErrorCallback(t *testing.T) {
+	var analyser *OutputAnalyser
+	invoked := 0
+	var cbError error
+	triggerLine := "--TRIGGER_CALLBACK--"
+
+	init := func(t *testing.T, minCount, maxCalls int, stopOnError bool) error {
+		analyser = NewOutputAnalyser()
+		invoked = 0
+		cbError = nil
+		return analyser.SetCallback("cb-test", ".+TRIGGER_CALLBACK.+", minCount, maxCalls, stopOnError, func(line string) error {
+			require.Equal(t, line, triggerLine)
+			invoked++
+			return cbError
+		})
 	}
+
+	writeTrigger := func(t *testing.T) {
+		require.NoError(t, analyser.AnalyseStringLines(triggerLine))
+	}
+
+	t.Run("RequiresMinCountForEachCall", func(t *testing.T) {
+		require.NoError(t, init(t, 3, 4, false))
+
+		for c := 0; c < 2; c++ {
+			for i := 0; i < 3; i++ {
+				assert.Equal(t, c, invoked)
+				writeTrigger(t)
+			}
+			assert.Equal(t, c+1, invoked)
+		}
+	})
+
+	t.Run("CanLimitMaxCalls", func(t *testing.T) {
+		require.NoError(t, init(t, 0, 4, false))
+
+		for i, c := 0, 0; c < 8; c++ {
+			assert.Equal(t, i, invoked)
+			writeTrigger(t)
+			if i < 4 {
+				i++
+			}
+		}
+	})
+
+	t.Run("CallbackErrorIsReturned", func(t *testing.T) {
+		require.NoError(t, init(t, 0, 0, true))
+		cbError = fmt.Errorf("cb-error")
+		assert.ErrorIs(t, analyser.AnalyseStringLines(triggerLine), cbError)
+	})
+
+	t.Run("CallbackErrorCanBeSkipped", func(t *testing.T) {
+		require.NoError(t, init(t, 0, 0, false))
+		cbError = fmt.Errorf("cb-error")
+		assert.ErrorIs(t, analyser.AnalyseStringLines(triggerLine), nil)
+	})
+
+	t.Run("RegexErrorIsReturned", func(t *testing.T) {
+		require.NoError(t, init(t, 0, 0, false))
+		err := analyser.SetCallback("fail", "[", 0, 0, false, nil)
+		assert.EqualError(t, err, "error parsing regexp: missing closing ]: `[`")
+	})
+
+	t.Run("CanUnregisterCallback", func(t *testing.T) {
+		require.NoError(t, init(t, 0, 0, false))
+		writeTrigger(t)
+		assert.Equal(t, 1, invoked)
+
+		require.NoError(t, analyser.SetCallback("cb-test", ".", 0, 0, false, nil))
+		writeTrigger(t)
+		assert.Equal(t, 1, invoked)
+	})
 }


### PR DESCRIPTION
This PR picks the initial changes from `on-error` branch and implements a solution to deal with #87. 
Note: I've skipped the "save" command since it is not related to this feature.

Profile config is:

*yaml*
```yaml
my-profile:
  stream-error:
    - pattern: "/tmp/restic-check-cache.+no space left on device"
      run: "rm -Rf /tmp/restic-check-cache*"
    - pattern: ".+ another error .+"
      run: "echo found another error in $PROFILE_COMMAND"
```

*toml*
```toml
[[my-profile.stream-error]]
pattern = "/tmp/restic-check-cache.+no space left on device"
run = "rm -Rf /tmp/restic-check-cache*"

[[my-profile.stream-error]]
pattern = ".+ another error .+"
run = "echo found another error in $PROFILE_COMMAND"
```
