### PR TITLE
Only pass common CLI args to hooked commands

### DIFF
--- a/wrapper_test.go
+++ b/wrapper_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"bytes"
 	"fmt"
+	"math/rand"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -32,6 +33,33 @@ func init() {
 		mockBinary = "mock.exe"
 	} else {
 		mockBinary = "./mock"
+	}
+
+	// Add params that need to be passed to the mock binary
+	commonResticArgsList = append(commonResticArgsList, "--exit")
+}
+
+func TestCommonResticArgs(t *testing.T) {
+	wrapper := &resticWrapper{}
+	for _, arg := range commonResticArgsList {
+		var args []string
+		list := []string{"-x", "-x=1", "-x 2 x=y", "--xxx", "--xxx=v", "--xxx k=v", arg, arg + "=1", arg + " ka=va"}
+
+		for i := 0; i < 20; i++ {
+			rand.Shuffle(len(list), func(i, j int) { list[i], list[j] = list[j], list[i] })
+			args = args[:0]
+			for _, item := range list {
+				args = append(args, strings.Split(item, " ")...)
+			}
+
+			args = wrapper.commonResticArgs(args)
+
+			assert.Len(t, args, 4)
+			assert.Subset(t, args, []string{arg, arg + "=1", "ka=va"})
+			for _, item := range []string{"-x", "--xxx", "x=y", "k=v", "2"} {
+				assert.NotContains(t, args, item)
+			}
+		}
 	}
 }
 


### PR DESCRIPTION
This is a fix for #100 and changes how CLI args specified with the `resticprofile` command line are passed to `restic`. It does not affect the profile configuration in any way.

With this change, only the primary `restic` command (`backup`) will receive the full set of CLI args. Commands that are hooked to run with the primary command receive only those CLI args that can safely be used with any `restic` command.

Example:
```shell
➜ resticprofile --dry-run test-backup.backup --dry-run --verbose=3 --repo=xyz -p mysecret
...
2022/04/12 21:33:02 profile 'test-backup': initializing repository (if not existing)
2022/04/12 21:33:02 dry-run: /usr/local/bin/restic init --password-file test-repo.key --repo local:test-repo --verbose=3 --repo=xyz -p mysecret
2022/04/12 21:33:02 profile 'test-backup': checking repository consistency
2022/04/12 21:33:02 dry-run: /usr/local/bin/restic check --password-file test-repo.key --repo local:test-repo --verbose=3 --repo=xyz -p mysecret
2022/04/12 21:33:02 profile 'test-backup': starting 'backup'
2022/04/12 21:33:02 dry-run: /usr/local/bin/restic backup --password-file test-repo.key --repo local:test-repo --dry-run --verbose=3 --repo=xyz -p mysecret contrib profiles.yaml
2022/04/12 21:33:02 profile 'test-backup': finished 'backup'
2022/04/12 21:33:02 profile 'test-backup': checking repository consistency
2022/04/12 21:33:02 dry-run: /usr/local/bin/restic check --password-file test-repo.key --repo local:test-repo --verbose=3 --repo=xyz -p mysecret
```