### PR TITLE
Added "generate" command to create resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -260,16 +260,16 @@ To load completions in shell or profile, use:
 
 ```shell
 # bash
-eval "$(resticprofile completion-script --bash)"
+eval "$(resticprofile generate --bash-completion)"
 
 # zsh
-eval "$(resticprofile completion-script --zsh)"
+eval "$(resticprofile generate --zsh-completion)"
 ```
 
 To install them permanently:
 
 ```
-$ resticprofile completion-script --bash > /etc/bash_completion.d/resticprofile
+$ resticprofile generate --bash-completion > /etc/bash_completion.d/resticprofile
 $ chmod +x /etc/bash_completion.d/resticprofile
 ```
 
@@ -965,10 +965,10 @@ resticprofile own commands:
    self-update   update to latest resticprofile (use -q/--quiet flag to update without confirmation)
    profiles      display profile names from the configuration file
    show          show all the details of the current profile
-   random-key    generate a cryptographically secure random key to use as a restic keyfile
    schedule      schedule jobs from a profile (use --all flag to schedule all jobs of all profiles)
    unschedule    remove scheduled jobs of a profile (use --all flag to unschedule all profiles)
    status        display the status of scheduled jobs (use --all flag for all profiles)
+   generate      generate resources (--random-key [size], --bash-completion & --zsh-completion)
 
 
 ```
@@ -1022,7 +1022,7 @@ On Linux and FreeBSD, the generator uses getrandom(2) if available, /dev/urandom
 [Reference from the Go documentation](https://golang.org/pkg/crypto/rand/#pkg-variables)
 
 ```
-$ resticprofile random-key
+$ resticprofile generate --random-key
 ```
 
 generates a 1024 bytes random key (converted into 1368 base64 characters) and displays it on the console
@@ -1030,7 +1030,7 @@ generates a 1024 bytes random key (converted into 1368 base64 characters) and di
 To generate a different size of key, you can specify the bytes length on the command line:
 
 ```
-$ resticprofile random-key 2048
+$ resticprofile generate --random-key 2048
 ```
 
 # Scheduled backups

--- a/commands_test.go
+++ b/commands_test.go
@@ -263,17 +263,38 @@ func TestCompleteCall(t *testing.T) {
 	}
 }
 
-func TestCompletionScriptCall(t *testing.T) {
+func TestGenerateCommand(t *testing.T) {
 	flags := commandLineFlags{}
 	buffer := &strings.Builder{}
 
-	buffer.Reset()
-	assert.Nil(t, completionScriptCommand(buffer, nil, flags, nil))
-	assert.Equal(t, strings.TrimSpace(bashCompletionScript), strings.TrimSpace(buffer.String()))
-	assert.Contains(t, bashCompletionScript, "#!/usr/bin/env bash")
+	t.Run("--bash-completion", func(t *testing.T) {
+		buffer.Reset()
+		assert.Nil(t, generateCommand(buffer, nil, flags, []string{"--bash-completion"}))
+		assert.Equal(t, strings.TrimSpace(bashCompletionScript), strings.TrimSpace(buffer.String()))
+		assert.Contains(t, bashCompletionScript, "#!/usr/bin/env bash")
+	})
 
-	buffer.Reset()
-	assert.Nil(t, completionScriptCommand(buffer, nil, flags, []string{"--zsh"}))
-	assert.Equal(t, strings.TrimSpace(zshCompletionScript), strings.TrimSpace(buffer.String()))
-	assert.Contains(t, zshCompletionScript, "#!/usr/bin/env zsh")
+	t.Run("--zsh-completion", func(t *testing.T) {
+		buffer.Reset()
+		assert.Nil(t, generateCommand(buffer, nil, flags, []string{"--zsh-completion"}))
+		assert.Equal(t, strings.TrimSpace(zshCompletionScript), strings.TrimSpace(buffer.String()))
+		assert.Contains(t, zshCompletionScript, "#!/usr/bin/env zsh")
+	})
+
+	t.Run("--random-key", func(t *testing.T) {
+		buffer.Reset()
+		assert.Nil(t, generateCommand(buffer, nil, flags, []string{"--random-key", "512"}))
+		assert.Equal(t, 684, len(strings.TrimSpace(buffer.String())))
+	})
+
+	t.Run("invalid-option", func(t *testing.T) {
+		buffer.Reset()
+		opts := []string{"", "invalid", "--unknown"}
+		for _, option := range opts {
+			buffer.Reset()
+			err := generateCommand(buffer, nil, flags, []string{option})
+			assert.EqualError(t, err, fmt.Sprintf("nothing to generate for: %s", option))
+			assert.Equal(t, 0, buffer.Len())
+		}
+	})
 }


### PR DESCRIPTION
Implements #109 - "generate" command

Replaces commands: 
* `random-key` is hidden for backward compatibility
* `completion-script` is removed since #90 was not released yet