### PR TITLE
Allow to choose `shell` in global config

### DIFF
--- a/config/global.go
+++ b/config/global.go
@@ -18,6 +18,7 @@ type Global struct {
 	ResticBinary         string        `mapstructure:"restic-binary"`
 	ResticLockRetryAfter time.Duration `mapstructure:"restic-lock-retry-after"`
 	ResticStaleLockAge   time.Duration `mapstructure:"restic-stale-lock-age"`
+	ShellBinary          []string      `mapstructure:"shell"`
 	MinMemory            uint64        `mapstructure:"min-memory"`
 	Scheduler            string        `mapstructure:"scheduler"`
 	LegacyArguments      bool          `mapstructure:"legacy-arguments"` // broken arguments mode (before v0.15.0)

--- a/config/global_test.go
+++ b/config/global_test.go
@@ -49,6 +49,7 @@ nice = 1
 priority = "low"
 default-command = "version"
 initialize = true
+shell = "bash"
 restic-binary = "/tmp/restic"
 restic-lock-retry-after = "2m30s"
 restic-stale-lock-age = "4h"
@@ -65,6 +66,7 @@ restic-stale-lock-age = "4h"
 	assert.Equal(t, "low", global.Priority)
 	assert.Equal(t, "version", global.DefaultCommand)
 	assert.True(t, global.Initialize)
+	assert.Equal(t, []string{"bash"}, global.ShellBinary)
 	assert.Equal(t, "/tmp/restic", global.ResticBinary)
 	assert.Equal(t, 150*time.Second, global.ResticLockRetryAfter)
 	assert.Equal(t, 4*time.Hour, global.ResticStaleLockAge)

--- a/constants/env.go
+++ b/constants/env.go
@@ -4,6 +4,7 @@ const (
 	EnvProfileName      = "PROFILE_NAME"
 	EnvProfileCommand   = "PROFILE_COMMAND"
 	EnvError            = "ERROR"
+	EnvErrorMessage     = "ERROR_MESSAGE"
 	EnvErrorCommandLine = "ERROR_COMMANDLINE"
 	EnvErrorExitCode    = "ERROR_EXIT_CODE"
 	EnvErrorStderr      = "ERROR_STDERR"

--- a/docs/content/configuration/reference/index.md
+++ b/docs/content/configuration/reference/index.md
@@ -24,6 +24,7 @@ None of these flags are passed on the restic command line
 * **restic-lock-retry-after**: duration
 * **restic-stale-lock-age**: duration
 * **min-memory**: integer (MB) - see [memory]({{< ref "/usage/memory" >}})
+* **shell**: string (shell binary to run commands, default value is OS specific)
 * **scheduler**: string (`crond` is the only non-default value)
 * **systemd-unit-template**: string (file containing a go template to generate systemd unit file)
 * **systemd-timer-template**: string (file containing a go template to generate systemd timer file)

--- a/shell/command.go
+++ b/shell/command.go
@@ -200,10 +200,6 @@ func (c *Command) getShellCommand() (shell string, arguments []string, err error
 // removeQuotes removes single and double quotes when the whole string is quoted.
 // this is only useful for windows where the arguments are sent one by one.
 func removeQuotes(args []string) []string {
-	if args == nil {
-		return nil
-	}
-
 	singleQuote := `'`
 	doubleQuote := `"`
 

--- a/shell/command.go
+++ b/shell/command.go
@@ -253,7 +253,7 @@ func composePowershellArguments(c *Command) []string {
 		if powershellBuiltins.MatchString(name) {
 			return fmt.Sprintf("${%s}", name)
 		} else {
-			return fmt.Sprintf("$($_=${Env:%[1]s}; if ($_) {$_} else {${%[1]s}})", name)
+			return fmt.Sprintf("${Env:%s}", name)
 		}
 	}
 	arguments := rewriteVariables(c.Arguments, mapper)
@@ -295,8 +295,8 @@ func resolveCommand(command string) string {
 	return command
 }
 
-// unixVariablesMatcher matches all "$var" and "${var}" inside a string
-var unixVariablesMatcher = regexp.MustCompile("(?i)\\$(\\w+)([^\\w:.]|$)|\\$\\{(\\w+)}")
+// unixVariablesMatcher matches all "$var" and "${var}" inside a string (excluding "$var.prop", "$var[]" & "$var:prop")
+var unixVariablesMatcher = regexp.MustCompile(`(?i)\$(\w+)([^\w:.\[]|$)|\$\{(\w+)}`)
 
 // makeRegexVariablesFunc converts a variables expand func to a func for ReplaceAllStringFunc
 func makeRegexVariablesFunc(mapper func(string) string) func(string) string {

--- a/shell/command_test.go
+++ b/shell/command_test.go
@@ -124,6 +124,14 @@ func TestShellCommand(t *testing.T) {
 	}
 }
 
+func TestSelectCustomShell(t *testing.T) {
+	cmd := NewCommand("sleep", []string{"1"})
+	cmd.Shell = []string{mockBinary}
+	shell, _, err := cmd.getShellCommand()
+	assert.Nil(t, err)
+	assert.Equal(t, mockBinary, shell)
+}
+
 func TestRunShellEcho(t *testing.T) {
 	buffer := &bytes.Buffer{}
 	cmd := NewCommand("echo", []string{"TestRunShellEcho"})
@@ -238,7 +246,9 @@ func TestSummaryDurationCommand(t *testing.T) {
 	buffer := &bytes.Buffer{}
 
 	cmd := NewCommand("sleep", []string{"1"})
-	cmd.UsePowershell = true
+	if runtime.GOOS == "windows" {
+		cmd.Shell = []string{windowsPowershell}
+	}
 	cmd.Stdout = buffer
 
 	start := time.Now()
@@ -259,7 +269,9 @@ func TestSummaryDurationSignalledCommand(t *testing.T) {
 
 	sigChan := make(chan os.Signal, 1)
 	cmd := NewSignalledCommand("sleep", []string{"1"}, sigChan)
-	cmd.UsePowershell = true
+	if runtime.GOOS == "windows" {
+		cmd.Shell = []string{windowsPowershell}
+	}
 	cmd.Stdout = buffer
 
 	start := time.Now()

--- a/shell/command_test.go
+++ b/shell/command_test.go
@@ -78,7 +78,7 @@ func TestShellCommandWithArguments(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		assert.Equal(t, `c:\windows\system32\cmd.exe`, strings.ToLower(command))
 		assert.Equal(t, []string{
-			`/C`,
+			`/V:ON`, `/C`,
 			`/bin/restic`,
 			`-v`,
 			`--exclude-file`,
@@ -112,7 +112,7 @@ func TestShellCommand(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		assert.Equal(t, `c:\windows\system32\cmd.exe`, strings.ToLower(command))
 		assert.Equal(t, []string{
-			"/C",
+			"/V:ON", "/C",
 			"/bin/restic -v --exclude-file \"excludes\" --repo \"/path/with space\" backup .",
 		}, args)
 	} else {

--- a/shell/command_unix.go
+++ b/shell/command_unix.go
@@ -4,7 +4,6 @@ package shell
 
 import (
 	"os"
-	"strings"
 	"syscall"
 )
 
@@ -31,17 +30,12 @@ func (c *Command) propagateGroupSignal(process *os.Process) {
 	}
 }
 
+// getShellSearchList returns a priority sorted list of default shells to pick when none was specified
 func (c *Command) getShellSearchList() []string {
-	// prefer bash if available as it has better signal propagation (sh may fail to forward signals)
-	return []string{unixBashShell, unixShell}
-}
-
-func (c *Command) composeShellArguments(_ string) []string {
-	// Flatten all arguments into one string, sh expects one big string
-	flatCommand := append([]string{c.Command}, c.Arguments...)
-
 	return []string{
-		"-c",
-		strings.Join(flatCommand, " "),
+		// prefer "bash" if available as it has better signal propagation (sh may fail to forward signals)
+		bashShell,
+		// fallback to "sh"
+		defaultShell,
 	}
 }

--- a/shell/command_unix.go
+++ b/shell/command_unix.go
@@ -1,9 +1,10 @@
-//+build !windows
+//go:build !windows
 
 package shell
 
 import (
 	"os"
+	"strings"
 	"syscall"
 )
 
@@ -27,5 +28,20 @@ func (c *Command) propagateGroupSignal(process *os.Process) {
 		return
 	case <-c.done:
 		return
+	}
+}
+
+func (c *Command) getShellSearchList() []string {
+	// prefer bash if available as it has better signal propagation (sh may fail to forward signals)
+	return []string{unixBashShell, unixShell}
+}
+
+func (c *Command) composeShellArguments(_ string) []string {
+	// Flatten all arguments into one string, sh expects one big string
+	flatCommand := append([]string{c.Command}, c.Arguments...)
+
+	return []string{
+		"-c",
+		strings.Join(flatCommand, " "),
 	}
 }

--- a/shell/command_windows.go
+++ b/shell/command_windows.go
@@ -3,6 +3,7 @@
 package shell
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -30,10 +31,13 @@ func (c *Command) composeShellArguments(shell string) []string {
 		// Powershell requires ".\" prefix for executables in CWD (same as unix shells)
 		if filepath.Base(c.Command) == c.Command {
 			if s, err := os.Stat(c.Command); err == nil && !s.IsDir() {
-				c.Command = `.\` + c.Command
+				c.Command = fmt.Sprintf(`.\%s`, c.Command)
 			}
 		}
 		command = []string{"-Command", c.Command}
+	} else if sh == windowsShell {
+		// Enable delayed variable expansion (!variable! syntax)
+		command = append([]string{"/V:ON"}, command...)
 	}
 
 	return append(

--- a/shell/command_windows.go
+++ b/shell/command_windows.go
@@ -2,7 +2,11 @@
 
 package shell
 
-import "os"
+import (
+	"os"
+	"path/filepath"
+	"strings"
+)
 
 // In Windows, all hierarchy will receive the signal (which is good because we cannot send it anyway)
 // In fact, there's nothing for us to do here but method must block on channels
@@ -13,4 +17,27 @@ func (c *Command) propagateSignal(*os.Process) {
 	case <-c.done:
 		return
 	}
+}
+
+func (c *Command) getShellSearchList() []string {
+	return []string{windowsShell, windowsPowershell6, windowsPowershell}
+}
+
+func (c *Command) composeShellArguments(shell string) []string {
+	command := []string{"/C", c.Command}
+
+	if sh := strings.ToLower(filepath.Base(shell)); sh == windowsPowershell || sh == windowsPowershell6 {
+		// Powershell requires ".\" prefix for executables in CWD (same as unix shells)
+		if filepath.Base(c.Command) == c.Command {
+			if s, err := os.Stat(c.Command); err == nil && !s.IsDir() {
+				c.Command = `.\` + c.Command
+			}
+		}
+		command = []string{"-Command", c.Command}
+	}
+
+	return append(
+		command,
+		removeQuotes(c.Arguments)...,
+	)
 }

--- a/shell_command.go
+++ b/shell_command.go
@@ -17,6 +17,7 @@ type shellCommandDefinition struct {
 	args        []string
 	publicArgs  []string
 	env         []string
+	shell       []string
 	stdin       io.ReadCloser
 	stdout      io.Writer
 	stderr      io.Writer
@@ -28,7 +29,7 @@ type shellCommandDefinition struct {
 }
 
 // newShellCommand creates a new shell command definition
-func newShellCommand(command string, args, env []string, dryRun bool, sigChan chan os.Signal, setPID func(pid int)) shellCommandDefinition {
+func newShellCommand(command string, args, env, shell []string, dryRun bool, sigChan chan os.Signal, setPID func(pid int)) shellCommandDefinition {
 	if env == nil {
 		env = make([]string, 0)
 	}
@@ -37,6 +38,7 @@ func newShellCommand(command string, args, env []string, dryRun bool, sigChan ch
 		args:       args,
 		publicArgs: args,
 		env:        env,
+		shell:      shell,
 		stdin:      nil,
 		stdout:     os.Stdout,
 		stderr:     os.Stderr,
@@ -55,6 +57,7 @@ func runShellCommand(command shellCommandDefinition) (summary monitor.Summary, s
 
 	shellCmd := shell.NewSignalledCommand(command.command, command.args, command.sigChan)
 
+	shellCmd.Shell = command.shell
 	shellCmd.Stdout = command.stdout
 	shellCmd.Stderr = command.stderr
 
@@ -93,6 +96,7 @@ func setupStreamErrorHandlers(command *shellCommandDefinition, shellCmd *shell.C
 		callback := func(line string) error {
 			errorCmd := shell.NewSignalledCommand(commandLine, nil, command.sigChan)
 			errorCmd.Environ = shellCmd.Environ
+			errorCmd.Shell = command.shell
 			errorCmd.Stdout = command.stdout
 			errorCmd.Stderr = command.stderr
 

--- a/wrapper.go
+++ b/wrapper.go
@@ -275,6 +275,13 @@ func (r *resticWrapper) commonResticArgs(args []string) (commonArgs []string) {
 	return
 }
 
+func (r *resticWrapper) getShell() (shell []string) {
+	if r.global != nil {
+		shell = r.global.ShellBinary
+	}
+	return
+}
+
 func (r *resticWrapper) prepareCommand(command string, args *shell.Args, moreArgs ...string) shellCommandDefinition {
 	// Create local instance to allow modification
 	args = args.Clone()
@@ -298,7 +305,7 @@ func (r *resticWrapper) prepareCommand(command string, args *shell.Args, moreArg
 	env = append(env, r.getProfileEnvironment()...)
 
 	clog.Debugf("starting command: %s %s", r.resticBinary, strings.Join(publicArguments, " "))
-	rCommand := newShellCommand(r.resticBinary, arguments, env, r.dryRun, r.sigChan, r.setPID)
+	rCommand := newShellCommand(r.resticBinary, arguments, env, r.getShell(), r.dryRun, r.sigChan, r.setPID)
 	rCommand.publicArgs = publicArguments
 	// stdout are stderr are coming from the default terminal (in case they're redirected)
 	rCommand.stdout = term.GetOutput()
@@ -465,7 +472,7 @@ func (r *resticWrapper) runBeforeCommands(command string) error {
 
 	for i, preCommand := range r.profile.Backup.RunBefore {
 		clog.Debugf("starting pre-backup command %d/%d", i+1, len(r.profile.Backup.RunBefore))
-		rCommand := newShellCommand(preCommand, nil, env, r.dryRun, r.sigChan, r.setPID)
+		rCommand := newShellCommand(preCommand, nil, env, r.getShell(), r.dryRun, r.sigChan, r.setPID)
 		// stdout are stderr are coming from the default terminal (in case they're redirected)
 		rCommand.stdout = term.GetOutput()
 		rCommand.stderr = term.GetErrorOutput()
@@ -490,7 +497,7 @@ func (r *resticWrapper) runAfterCommands(command string) error {
 
 	for i, postCommand := range r.profile.Backup.RunAfter {
 		clog.Debugf("starting post-backup command %d/%d", i+1, len(r.profile.Backup.RunAfter))
-		rCommand := newShellCommand(postCommand, nil, env, r.dryRun, r.sigChan, r.setPID)
+		rCommand := newShellCommand(postCommand, nil, env, r.getShell(), r.dryRun, r.sigChan, r.setPID)
 		// stdout are stderr are coming from the default terminal (in case they're redirected)
 		rCommand.stdout = term.GetOutput()
 		rCommand.stderr = term.GetErrorOutput()
@@ -512,7 +519,7 @@ func (r *resticWrapper) runBeforeProfileCommands() error {
 
 	for i, preCommand := range r.profile.RunBefore {
 		clog.Debugf("starting 'run-before' profile command %d/%d", i+1, len(r.profile.RunBefore))
-		rCommand := newShellCommand(preCommand, nil, env, r.dryRun, r.sigChan, r.setPID)
+		rCommand := newShellCommand(preCommand, nil, env, r.getShell(), r.dryRun, r.sigChan, r.setPID)
 		// stdout are stderr are coming from the default terminal (in case they're redirected)
 		rCommand.stdout = term.GetOutput()
 		rCommand.stderr = term.GetErrorOutput()
@@ -534,7 +541,7 @@ func (r *resticWrapper) runAfterProfileCommands() error {
 
 	for i, postCommand := range r.profile.RunAfter {
 		clog.Debugf("starting 'run-after' profile command %d/%d", i+1, len(r.profile.RunAfter))
-		rCommand := newShellCommand(postCommand, nil, env, r.dryRun, r.sigChan, r.setPID)
+		rCommand := newShellCommand(postCommand, nil, env, r.getShell(), r.dryRun, r.sigChan, r.setPID)
 		// stdout are stderr are coming from the default terminal (in case they're redirected)
 		rCommand.stdout = term.GetOutput()
 		rCommand.stderr = term.GetErrorOutput()
@@ -557,7 +564,7 @@ func (r *resticWrapper) runAfterFailProfileCommands(fail error) error {
 
 	for i, postCommand := range r.profile.RunAfterFail {
 		clog.Debugf("starting 'run-after-fail' profile command %d/%d", i+1, len(r.profile.RunAfterFail))
-		rCommand := newShellCommand(postCommand, nil, env, r.dryRun, r.sigChan, r.setPID)
+		rCommand := newShellCommand(postCommand, nil, env, r.getShell(), r.dryRun, r.sigChan, r.setPID)
 		// stdout are stderr are coming from the default terminal (in case they're redirected)
 		rCommand.stdout = term.GetOutput()
 		rCommand.stderr = term.GetErrorOutput()
@@ -588,7 +595,7 @@ func (r *resticWrapper) runFinalCommands(command string, fail error) {
 		// Using defer stack for "finally" to ensure every command is run even on panic
 		defer func(index int, cmd string) {
 			clog.Debugf("starting final command %d/%d", index+1, len(commands))
-			rCommand := newShellCommand(cmd, nil, env, r.dryRun, r.sigChan, r.setPID)
+			rCommand := newShellCommand(cmd, nil, env, r.getShell(), r.dryRun, r.sigChan, r.setPID)
 			// stdout are stderr are coming from the default terminal (in case they're redirected)
 			rCommand.stdout = term.GetOutput()
 			rCommand.stderr = term.GetErrorOutput()

--- a/wrapper.go
+++ b/wrapper.go
@@ -703,7 +703,8 @@ func (r *resticWrapper) getProfileEnvironment() []string {
 func (r *resticWrapper) getFailEnvironment(err error) (env []string) {
 	ctx := r.getErrorContext(err)
 	if ctx.Message != "" {
-		env = append(env, fmt.Sprintf("%s=%s", constants.EnvError, ctx.Message))
+		env = append(env, fmt.Sprintf("%s=%s", constants.EnvError, ctx.Message)) // powershell already has $ERROR
+		env = append(env, fmt.Sprintf("%s=%s", constants.EnvErrorMessage, ctx.Message))
 	}
 	if ctx.CommandLine != "" {
 		env = append(env, fmt.Sprintf("%s=%s", constants.EnvErrorCommandLine, ctx.CommandLine))

--- a/wrapper_streamsource.go
+++ b/wrapper_streamsource.go
@@ -73,7 +73,7 @@ func (r *resticWrapper) prepareCommandStreamSource() (io.ReadCloser, error) {
 
 		for i, sourceCommand := range r.profile.Backup.StdinCommand {
 			clog.Debugf("starting 'stdin-command' command %d/%d: %s", i+1, len(r.profile.Backup.StdinCommand), sourceCommand)
-			rCommand := newShellCommand(sourceCommand, nil, env, r.dryRun, commandSignals, nil)
+			rCommand := newShellCommand(sourceCommand, nil, env, r.getShell(), r.dryRun, commandSignals, nil)
 			rCommand.stdout = bufferedWriter
 			rCommand.stderr = term.GetErrorOutput()
 


### PR DESCRIPTION
In relation to #111 this PR allows to choose what shell is used in `resticprofile`:

```
.\resticprofile test-backup.snapshots

2022/05/26 15:07:15 using configuration file: profiles.yaml

global:
  shell: "powershell"

profile:
  initialize: true
  repository: local:test-repo
  password-file: test-repo.key

  run-before:
    - gc profiles.yaml
    - echo $Env:windir

  run-after-fail:
    - 'echo "EXIT: $Env:ERROR_EXIT_CODE" "STDERR: $Env:ERROR_STDERR"'

test-backup:
  inherit: profile
  backup:
    check-before: true
    check-after: true
    source:
      - test.sql

C:\Windows

2022/05/26 15:07:16 profile 'test-backup': initializing repository (if not existing)
2022/05/26 15:07:16 profile 'test-backup': starting 'snapshots'
repository 6a55e541 opened successfully, password is correct

ID        Time                 Host               Tags        Paths
---------------------------------------------------------------------------------------------------------------------------------
735928a5  2022-03-06 18:29:30  TEST                           test.sql
...
```

On error:
```
.\resticprofile test-backup.snapshots --invalid
...
2022/05/26 16:23:53 profile 'test-backup': starting 'snapshots'
unknown flag: --invalid
EXIT: 1
STDERR: unknown flag: --invalid
```


On error using default Windows shell (cmd.exe) with delayed expansion (to support newlines):
```yaml
  run-after-fail:
    - "echo 'EXIT: %ERROR_EXIT_CODE%' 'STDERR ( !ERROR_STDERR! )'"
```
results in:
```
.\resticprofile test-backup.snapshots --invalid
...
2022/05/26 17:27:43 profile 'test-backup': starting 'snapshots'
unknown flag: --invalid
'EXIT: 1' 'STDERR ( unknown flag: --invalid
 )'
2022/05/26 17:27:43 snapshots on profile 'test-backup': exit status 1
```