### PR TITLE
ConfigV2: Replace list params - fix #108

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -591,7 +591,7 @@ func (c *Config) getSchedule(key string) (Schedule, error) {
 func (c *Config) unmarshalKey(key string, rawVal interface{}) error {
 	if c.format == "hcl" {
 		return c.viper.UnmarshalKey(key, rawVal, configOptionHCL)
-	} else if c.GetVersion() == Version02 {
+	} else if c.GetVersion() >= Version02 {
 		return c.viper.UnmarshalKey(key, rawVal, configOptionV2)
 	}
 	return c.viper.UnmarshalKey(key, rawVal, configOption)


### PR DESCRIPTION
This is a fix for #108 in version 2 configs (version 2 configs #80 are available but not yet in the documentation). Version 1 configs keep the unintuitive behaviour to avoid breaking any existing profiles.

In order to extend list params with inheritance, an additional PR may provide extended config syntax for this (is covered in #115).