### PR TITLE
Add last backup time to prometheus metrics

### DIFF
--- a/docs/content/status/prometheus/index.md
+++ b/docs/content/status/prometheus/index.md
@@ -86,40 +86,43 @@ Here's an example of the generated prometheus file:
 ```
 # HELP resticprofile_backup_added_bytes Total number of bytes added to the repository.
 # TYPE resticprofile_backup_added_bytes gauge
-resticprofile_backup_added_bytes{profile="root"} 35746
+resticprofile_backup_added_bytes{profile="prom"} 70690
 # HELP resticprofile_backup_dir_changed Number of directories with changes.
 # TYPE resticprofile_backup_dir_changed gauge
-resticprofile_backup_dir_changed{profile="root"} 9
+resticprofile_backup_dir_changed{profile="prom"} 15
 # HELP resticprofile_backup_dir_new Number of new directories added to the backup.
 # TYPE resticprofile_backup_dir_new gauge
-resticprofile_backup_dir_new{profile="root"} 0
+resticprofile_backup_dir_new{profile="prom"} 0
 # HELP resticprofile_backup_dir_unmodified Number of directories unmodified since last backup.
 # TYPE resticprofile_backup_dir_unmodified gauge
-resticprofile_backup_dir_unmodified{profile="root"} 314
+resticprofile_backup_dir_unmodified{profile="prom"} 529
 # HELP resticprofile_backup_duration_seconds The backup duration (in seconds).
 # TYPE resticprofile_backup_duration_seconds gauge
-resticprofile_backup_duration_seconds{profile="root"} 0.946567354
+resticprofile_backup_duration_seconds{profile="prom"} 0.879901212
 # HELP resticprofile_backup_files_changed Number of files with changes.
 # TYPE resticprofile_backup_files_changed gauge
-resticprofile_backup_files_changed{profile="root"} 3
+resticprofile_backup_files_changed{profile="prom"} 3
 # HELP resticprofile_backup_files_new Number of new files added to the backup.
 # TYPE resticprofile_backup_files_new gauge
-resticprofile_backup_files_new{profile="root"} 0
+resticprofile_backup_files_new{profile="prom"} 1
 # HELP resticprofile_backup_files_processed Total number of files scanned by the backup for changes.
 # TYPE resticprofile_backup_files_processed gauge
-resticprofile_backup_files_processed{profile="root"} 3925
+resticprofile_backup_files_processed{profile="prom"} 3680
 # HELP resticprofile_backup_files_unmodified Number of files unmodified since last backup.
 # TYPE resticprofile_backup_files_unmodified gauge
-resticprofile_backup_files_unmodified{profile="root"} 3922
+resticprofile_backup_files_unmodified{profile="prom"} 3676
 # HELP resticprofile_backup_processed_bytes Total number of bytes scanned for changes.
 # TYPE resticprofile_backup_processed_bytes gauge
-resticprofile_backup_processed_bytes{profile="root"} 3.8524672e+07
+resticprofile_backup_processed_bytes{profile="prom"} 8.55433765e+08
 # HELP resticprofile_backup_status Backup status: 0=fail, 1=warning, 2=success.
 # TYPE resticprofile_backup_status gauge
-resticprofile_backup_status{profile="root"} 1
+resticprofile_backup_status{profile="prom"} 2
+# HELP resticprofile_backup_time_seconds Last backup run (unixtime).
+# TYPE resticprofile_backup_time_seconds gauge
+resticprofile_backup_time_seconds{profile="prom"} 1.662310865e+09
 # HELP resticprofile_build_info resticprofile build information.
 # TYPE resticprofile_build_info gauge
-resticprofile_build_info{goversion="go1.16.6",version="0.16.0"} 1
+resticprofile_build_info{goversion="go1.19",version="0.19.0"} 1
 
 ```
 

--- a/monitor/prom/backup.go
+++ b/monitor/prom/backup.go
@@ -24,6 +24,7 @@ type BackupMetrics struct {
 	bytesAdded      *prometheus.GaugeVec
 	bytesTotal      *prometheus.GaugeVec
 	status          *prometheus.GaugeVec
+	time            *prometheus.GaugeVec
 }
 
 func newBackupMetrics(group string, configLabels map[string]string) BackupMetrics {
@@ -102,6 +103,12 @@ func newBackupMetrics(group string, configLabels map[string]string) BackupMetric
 			Name:      "status",
 			Help:      "Backup status: 0=fail, 1=warning, 2=success.",
 		}, labels),
+        time: prometheus.NewGaugeVec(prometheus.GaugeOpts{
+            Namespace: namespace,
+            Subsystem: backup,
+            Name:      "time",
+            Help:      "Last backup run (unixtime).",
+        }, labels),
 	}
 	return backupMetrics
 }

--- a/monitor/prom/backup.go
+++ b/monitor/prom/backup.go
@@ -103,12 +103,12 @@ func newBackupMetrics(group string, configLabels map[string]string) BackupMetric
 			Name:      "status",
 			Help:      "Backup status: 0=fail, 1=warning, 2=success.",
 		}, labels),
-        time: prometheus.NewGaugeVec(prometheus.GaugeOpts{
-            Namespace: namespace,
-            Subsystem: backup,
-            Name:      "time",
-            Help:      "Last backup run (unixtime).",
-        }, labels),
+		time: prometheus.NewGaugeVec(prometheus.GaugeOpts{
+			Namespace: namespace,
+			Subsystem: backup,
+			Name:      "time_seconds",
+			Help:      "Last backup run (unixtime).",
+		}, labels),
 	}
 	return backupMetrics
 }

--- a/monitor/prom/metrics.go
+++ b/monitor/prom/metrics.go
@@ -2,6 +2,7 @@ package prom
 
 import (
 	"runtime"
+	"time"
 
 	"github.com/creativeprojects/resticprofile/monitor"
 	"github.com/prometheus/client_golang/prometheus"
@@ -52,6 +53,7 @@ func NewMetrics(group, version string, configLabels map[string]string) *Metrics 
 		p.backup.bytesAdded,
 		p.backup.bytesTotal,
 		p.backup.status,
+		p.backup.time,
 	)
 	return p
 }
@@ -76,6 +78,7 @@ func (p *Metrics) BackupResults(profile string, status Status, summary monitor.S
 	p.backup.bytesAdded.With(labels).Set(float64(summary.BytesAdded))
 	p.backup.bytesTotal.With(labels).Set(float64(summary.BytesTotal))
 	p.backup.status.With(labels).Set(float64(status))
+	p.backup.time.With(labels).Set(float64(time.Now().Unix()))
 }
 
 func (p *Metrics) SaveTo(filename string) error {


### PR DESCRIPTION
For monitoring and alerts like
`time() - resticprofile_backup_time`