### PR TITLE
Add --help to own commands (e.g. generate --help)

### DIFF
--- a/commands.go
+++ b/commands.go
@@ -10,11 +10,9 @@ import (
 	"os"
 	"regexp"
 	"runtime"
-	"runtime/debug"
 	"sort"
 	"strconv"
 	"strings"
-	"text/tabwriter"
 
 	"github.com/creativeprojects/clog"
 	"github.com/creativeprojects/resticprofile/config"
@@ -28,6 +26,7 @@ import (
 type ownCommand struct {
 	name              string
 	description       string
+	longDescription   string
 	action            func(io.Writer, *config.Config, commandLineFlags, []string) error
 	needConfiguration bool              // true if the action needs a configuration file loaded
 	hide              bool              // don't display the command in help and completion
@@ -44,15 +43,24 @@ func init() {
 func getOwnCommands() []ownCommand {
 	return []ownCommand{
 		{
+			name:              "help",
+			description:       "display help (use resticprofile help [command])",
+			longDescription:   "The \"help\" command prints commandline help on resticprofile flags & commands (own and restic) including information on flags passed to restic from various profiles defined in the current configuration.\n\nHelp on a specific command is displayed by adding the command name as argument after \"help\", e.g. use \"resticprofile help version\" to get details on the \"version\" command.",
+			action:            displayHelpCommand,
+			needConfiguration: false,
+		},
+		{
 			name:              "version",
 			description:       "display version (run in verbose mode for detailed information)",
+			longDescription:   "The \"version\" command displays brief or detailed version information",
 			action:            displayVersion,
 			needConfiguration: false,
-			flags:             map[string]string{"-v, --verbose": "display details information"},
+			flags:             map[string]string{"-v, --verbose": "display detailed version information"},
 		},
 		{
 			name:              "self-update",
-			description:       "update to latest resticprofile (use -q/--quiet flag to update without confirmation)",
+			description:       "update to latest resticprofile",
+			longDescription:   "The \"self-update\" command checks for the latest resticprofile release and updates the current application binary if a newer version is available",
 			action:            selfUpdate,
 			needConfiguration: false,
 			flags:             map[string]string{"-q, --quiet": "update without confirmation prompt"},
@@ -60,12 +68,14 @@ func getOwnCommands() []ownCommand {
 		{
 			name:              "profiles",
 			description:       "display profile names from the configuration file",
+			longDescription:   "The \"profiles\" command prints brief information on all profiles and groups that are declared in the configuration file",
 			action:            displayProfilesCommand,
 			needConfiguration: true,
 		},
 		{
 			name:              "show",
 			description:       "show all the details of the current profile",
+			longDescription:   "The \"show\" command prints the effective configuration of the selected profile.\n\nThe effective profile configuration is built by loading all includes, applying inheritance, mixins, templates and variables and parsing the result.",
 			action:            showProfile,
 			needConfiguration: true,
 		},
@@ -78,7 +88,8 @@ func getOwnCommands() []ownCommand {
 		},
 		{
 			name:              "schedule",
-			description:       "schedule jobs from a profile (use --all flag to schedule all jobs of all profiles)",
+			description:       "schedule jobs from a profile (or of all profiles)",
+			longDescription:   "The \"schedule\" command registers declared schedules of the selected profile (or of all profiles) as scheduled jobs within the scheduling service of the operating system",
 			action:            createSchedule,
 			needConfiguration: true,
 			hide:              false,
@@ -89,7 +100,8 @@ func getOwnCommands() []ownCommand {
 		},
 		{
 			name:              "unschedule",
-			description:       "remove scheduled jobs of a profile (use --all flag to unschedule all profiles)",
+			description:       "remove scheduled jobs of a profile (or of all profiles)",
+			longDescription:   "The \"unschedule\" command removes scheduled jobs from the scheduling service of the operating system. The command removes jobs for schedules declared in the selected profile (or of all profiles)",
 			action:            removeSchedule,
 			needConfiguration: true,
 			hide:              false,
@@ -97,7 +109,8 @@ func getOwnCommands() []ownCommand {
 		},
 		{
 			name:              "status",
-			description:       "display the status of scheduled jobs (use --all flag for all profiles)",
+			description:       "display the status of scheduled jobs of a profile (or of all profiles)",
+			longDescription:   "The \"status\" command prints all declared schedules of the selected profile (or of all profiles) and shows the status of related scheduled jobs in the scheduling service of the operating system",
 			action:            statusSchedule,
 			needConfiguration: true,
 			hide:              false,
@@ -105,14 +118,15 @@ func getOwnCommands() []ownCommand {
 		},
 		{
 			name:              "generate",
-			description:       "generate resources (--random-key [size], --bash-completion & --zsh-completion)",
+			description:       "generate resources such as random key, bash/zsh completion scripts, etc.",
+			longDescription:   "The \"generate\" command is used to create various resources and print them to stdout",
 			action:            generateCommand,
 			needConfiguration: false,
 			hide:              false,
 			flags: map[string]string{
-				"--random-key":      "generate a cryptographically secure random key to use as a restic keyfile",
-				"--bash-completion": "generate a shell completion script for bash",
-				"--zsh-completion":  "generate a shell completion script for zsh",
+				"--random-key [size]": "generate a cryptographically secure random key to use as a restic keyfile (size defaults to 1024 when omitted)",
+				"--bash-completion":   "generate a shell completion script for bash",
+				"--zsh-completion":    "generate a shell completion script for zsh",
 			},
 		},
 		// hidden commands
@@ -147,36 +161,6 @@ func getOwnCommands() []ownCommand {
 	}
 }
 
-func displayOwnCommands(output io.Writer, showFlags bool, onlySelected ...string) {
-	commandsWriter := tabwriter.NewWriter(output, 0, 0, 3, ' ', 0)
-	for _, command := range ownCommands {
-		if command.hide {
-			continue
-		}
-		if len(onlySelected) > 0 && !containsString(onlySelected, command.name) {
-			continue
-		}
-
-		_, _ = fmt.Fprintf(commandsWriter, "\t%s\t%s\n", command.name, command.description)
-
-		if showFlags {
-			var flags []string
-			for f, _ := range command.flags {
-				flags = append(flags, f)
-			}
-			if len(flags) > 0 {
-				sort.Strings(flags)
-				_, _ = fmt.Fprintln(commandsWriter, "\t\tflags:")
-				for _, f := range flags {
-					_, _ = fmt.Fprintf(commandsWriter, "\t\t%s\t%s\n", f, command.flags[f])
-				}
-				_, _ = fmt.Fprintln(commandsWriter, "\t\t")
-			}
-		}
-	}
-	_ = commandsWriter.Flush()
-}
-
 func isOwnCommand(command string, configurationLoaded bool) bool {
 	for _, commandDef := range ownCommands {
 		if commandDef.name == command && commandDef.needConfiguration == configurationLoaded {
@@ -190,88 +174,14 @@ func runOwnCommand(configuration *config.Config, command string, flags commandLi
 	for _, commandDef := range ownCommands {
 		if commandDef.name == command {
 			if containsString(args, "--help") || containsString(args, "-h") {
-				_, _ = fmt.Fprintln(os.Stdout, "resticprofile own command:")
-				displayOwnCommands(os.Stdout, true, command)
-				return nil
+				args = append([]string{commandDef.name}, args...)
+				return displayHelpCommand(os.Stdout, configuration, flags, args)
 			} else {
 				return commandDef.action(os.Stdout, configuration, flags, args)
 			}
 		}
 	}
 	return fmt.Errorf("command not found: %v", command)
-}
-
-func displayProfilesCommand(output io.Writer, configuration *config.Config, _ commandLineFlags, _ []string) error {
-	displayProfiles(output, configuration)
-	displayGroups(output, configuration)
-	return nil
-}
-
-func displayVersion(output io.Writer, _ *config.Config, flags commandLineFlags, args []string) error {
-	fmt.Fprintf(output, "resticprofile version %s commit %q\n", version, commit)
-
-	// allow for the general verbose flag, or specified after the command
-	if flags.verbose || (len(args) > 0 && (args[0] == "-v" || args[0] == "--verbose")) {
-		w := tabwriter.NewWriter(output, 0, 0, 3, ' ', 0)
-		_, _ = fmt.Fprintf(w, "\n")
-		_, _ = fmt.Fprintf(w, "\t%s:\t%s\n", "home", "https://github.com/creativeprojects/resticprofile")
-		_, _ = fmt.Fprintf(w, "\t%s:\t%s\n", "os", runtime.GOOS)
-		_, _ = fmt.Fprintf(w, "\t%s:\t%s\n", "arch", runtime.GOARCH)
-		if goarm > 0 {
-			_, _ = fmt.Fprintf(w, "\t%s:\tv%d\n", "arm", goarm)
-		}
-		_, _ = fmt.Fprintf(w, "\t%s:\t%s\n", "version", version)
-		_, _ = fmt.Fprintf(w, "\t%s:\t%s\n", "commit", commit)
-		_, _ = fmt.Fprintf(w, "\t%s:\t%s\n", "compiled", date)
-		_, _ = fmt.Fprintf(w, "\t%s:\t%s\n", "by", builtBy)
-		_, _ = fmt.Fprintf(w, "\t%s:\t%s\n", "go version", runtime.Version())
-		_, _ = fmt.Fprintf(w, "\n")
-		_, _ = fmt.Fprintf(w, "\t%s:\n", "go modules")
-		bi, _ := debug.ReadBuildInfo()
-		for _, dep := range bi.Deps {
-			_, _ = fmt.Fprintf(w, "\t\t%s\t%s\n", dep.Path, dep.Version)
-		}
-		_, _ = fmt.Fprintf(w, "\n")
-
-		w.Flush()
-	}
-	return nil
-}
-
-func displayProfiles(output io.Writer, configuration *config.Config) {
-	profiles := configuration.GetProfiles()
-	keys := sortedProfileKeys(profiles)
-	if len(profiles) == 0 {
-		fmt.Fprintln(output, "\nThere's no available profile in the configuration")
-	} else {
-		fmt.Fprintln(output, "\nProfiles available (name, sections, description):")
-		w := tabwriter.NewWriter(output, 0, 0, 2, ' ', 0)
-		for _, name := range keys {
-			sections := profiles[name].DefinedCommands()
-			sort.Strings(sections)
-			if len(sections) == 0 {
-				_, _ = fmt.Fprintf(w, "\t%s:\t(n/a)\t%s\n", name, profiles[name].Description)
-			} else {
-				_, _ = fmt.Fprintf(w, "\t%s:\t(%s)\t%s\n", name, strings.Join(sections, ", "), profiles[name].Description)
-			}
-		}
-		_ = w.Flush()
-	}
-	fmt.Fprintln(output, "")
-}
-
-func displayGroups(output io.Writer, configuration *config.Config) {
-	groups := configuration.GetProfileGroups()
-	if len(groups) == 0 {
-		return
-	}
-	fmt.Fprintln(output, "Groups available (name, profiles, description):")
-	w := tabwriter.NewWriter(output, 0, 0, 2, ' ', 0)
-	for name, groupList := range groups {
-		_, _ = fmt.Fprintf(w, "\t%s:\t[%s]\t%s\n", name, strings.Join(groupList.Profiles, ", "), groupList.Description)
-	}
-	_ = w.Flush()
-	fmt.Fprintln(output, "")
 }
 
 func selfUpdate(_ io.Writer, _ *config.Config, flags commandLineFlags, args []string) error {
@@ -337,6 +247,9 @@ var bashCompletionScript string
 var zshCompletionScript string
 
 func generateCommand(output io.Writer, config *config.Config, flags commandLineFlags, args []string) (err error) {
+	// enforce no-log
+	clog.GetDefaultLogger().SetHandler(clog.NewDiscardHandler())
+
 	if containsString(args, "--bash-completion") {
 		_, err = fmt.Fprintln(output, bashCompletionScript)
 	} else if containsString(args, "--random-key") {

--- a/commands.go
+++ b/commands.go
@@ -170,18 +170,18 @@ func isOwnCommand(command string, configurationLoaded bool) bool {
 	return false
 }
 
-func runOwnCommand(configuration *config.Config, command string, flags commandLineFlags, args []string) error {
-	for _, commandDef := range ownCommands {
-		if commandDef.name == command {
-			if containsString(args, "--help") || containsString(args, "-h") {
-				args = append([]string{commandDef.name}, args...)
+func runOwnCommand(configuration *config.Config, commandName string, flags commandLineFlags, args []string) error {
+	for _, command := range ownCommands {
+		if command.name == commandName {
+			if help := containsString(args, "--help") || containsString(args, "-h"); help && !command.hide {
+				args = append([]string{command.name}, args...)
 				return displayHelpCommand(os.Stdout, configuration, flags, args)
 			} else {
-				return commandDef.action(os.Stdout, configuration, flags, args)
+				return command.action(os.Stdout, configuration, flags, args)
 			}
 		}
 	}
-	return fmt.Errorf("command not found: %v", command)
+	return fmt.Errorf("command not found: %v", commandName)
 }
 
 func selfUpdate(_ io.Writer, _ *config.Config, flags commandLineFlags, args []string) error {

--- a/commands_display.go
+++ b/commands_display.go
@@ -39,7 +39,7 @@ func displayWriter(output io.Writer, flags commandLineFlags) (out func(args ...a
 		output = colorable.NewNonColorable(output)
 	}
 
-	w := tabwriter.NewWriter(output, 0, 0, 3, ' ', 0)
+	w := tabwriter.NewWriter(output, 0, 0, 2, ' ', 0)
 
 	out = func(args ...any) io.Writer {
 		if len(args) > 0 {
@@ -301,14 +301,14 @@ func displayProfiles(output io.Writer, configuration *config.Config, flags comma
 	if len(profiles) == 0 {
 		out("\nThere's no available profile in the configuration\n")
 	} else {
-		out("\nProfiles available (name, sections, description):\n")
+		out("\n%s (name, sections, description):\n", ansiBold("Profiles available"))
 		for _, name := range keys {
 			sections := profiles[name].DefinedCommands()
 			sort.Strings(sections)
 			if len(sections) == 0 {
 				out("\t%s:\t(n/a)\t%s\n", name, profiles[name].Description)
 			} else {
-				out("\t%s:\t(%s)\t%s\n", name, strings.Join(sections, ", "), profiles[name].Description)
+				out("\t%s:\t(%s)\t%s\n", name, ansiCyan(strings.Join(sections, ", ")), profiles[name].Description)
 			}
 		}
 	}
@@ -323,9 +323,9 @@ func displayGroups(output io.Writer, configuration *config.Config, flags command
 	if len(groups) == 0 {
 		return
 	}
-	out("Groups available (name, profiles, description):\n")
+	out("%s (name, profiles, description):\n", ansiBold("Groups available"))
 	for name, groupList := range groups {
-		out("\t%s:\t[%s]\t%s\n", name, strings.Join(groupList.Profiles, ", "), groupList.Description)
+		out("\t%s:\t[%s]\t%s\n", name, ansiCyan(strings.Join(groupList.Profiles, ", ")), groupList.Description)
 	}
 	out("\n")
 }

--- a/commands_display.go
+++ b/commands_display.go
@@ -1,0 +1,424 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"regexp"
+	"runtime"
+	"runtime/debug"
+	"sort"
+	"strings"
+	"text/tabwriter"
+
+	"github.com/creativeprojects/clog"
+	"github.com/creativeprojects/resticprofile/config"
+	"github.com/creativeprojects/resticprofile/filesearch"
+	"github.com/creativeprojects/resticprofile/shell"
+	"github.com/creativeprojects/resticprofile/term"
+	"github.com/fatih/color"
+	"github.com/mattn/go-colorable"
+)
+
+var (
+	ansiBold   = color.New(color.Bold).SprintFunc()
+	ansiCyan   = color.New(color.FgCyan).SprintFunc()
+	ansiYellow = color.New(color.FgYellow).SprintFunc()
+)
+
+func displayWriter(output io.Writer, flags commandLineFlags) (out func(args ...any) io.Writer, closer func()) {
+	if term.GetOutput() == output {
+		output = term.GetColorableOutput()
+
+		if width, _ := term.OsStdoutTerminalSize(); width > 10 {
+			output = newLineLengthWriter(output, width)
+		}
+	}
+
+	if flags.noAnsi {
+		output = colorable.NewNonColorable(output)
+	}
+
+	w := tabwriter.NewWriter(output, 0, 0, 3, ' ', 0)
+
+	out = func(args ...any) io.Writer {
+		if len(args) > 0 {
+			if msg, ok := args[0].(string); ok {
+				if len(args) > 1 {
+					_, _ = fmt.Fprintf(w, msg, args[1:]...)
+				} else {
+					_, _ = fmt.Fprint(w, msg)
+				}
+			}
+		}
+		return w
+	}
+
+	closer = func() {
+		_ = w.Flush()
+	}
+
+	return
+}
+
+func getCommonUsageHelpLine(commandName string, withProfile bool) string {
+	profile := ""
+	if withProfile {
+		profile = "[profile name.]"
+	}
+	return fmt.Sprintf(
+		"%s [resticprofile flags] %s%s",
+		ansiBold("resticprofile"), profile, ansiBold(commandName),
+	)
+}
+
+func displayOwnCommands(output io.Writer, flags commandLineFlags) {
+	out, closer := displayWriter(output, flags)
+	defer closer()
+
+	for _, command := range ownCommands {
+		if command.hide {
+			continue
+		}
+
+		out("\t%s\t%s\n", command.name, command.description)
+	}
+}
+
+func displayOwnCommandHelp(output io.Writer, commandName string, clf commandLineFlags) {
+	out, closer := displayWriter(output, clf)
+	defer closer()
+
+	var command *ownCommand
+	for _, c := range ownCommands {
+		if c.name == commandName {
+			command = &c
+			break
+		}
+	}
+
+	if command == nil || command.hide {
+		out("No help available for command \"%s\"\n", commandName)
+		return
+	}
+
+	if len(command.longDescription) > 0 {
+		out("%s\n\n", command.longDescription)
+	} else {
+		out("Purpose: %s\n\n", command.description)
+	}
+
+	commandFlags := ""
+	if len(command.flags) > 0 {
+		commandFlags = "[command specific flags]"
+	}
+	out("Usage:\n")
+	out("\t%s %s\n\n", getCommonUsageHelpLine(command.name, command.needConfiguration), commandFlags)
+
+	var flags []string
+	for f, _ := range command.flags {
+		flags = append(flags, f)
+	}
+	if len(flags) > 0 {
+		sort.Strings(flags)
+		out("Flags:\n")
+		for _, f := range flags {
+			out("\t%s\t%s\n", f, command.flags[f])
+		}
+		out("\n")
+	}
+}
+
+func displayCommonUsageHelp(output io.Writer, flags commandLineFlags) {
+	out, closer := displayWriter(output, flags)
+	defer closer()
+
+	out("resticprofile is a configuration profiles manager for backup profiles and ")
+	out("is the missing link between a configuration file and restic backup\n\n")
+
+	out("Usage:\n")
+	out("\t%s [restic flags]\n", getCommonUsageHelpLine("restic-command", true))
+	out("\t%s [command specific flags]\n", getCommonUsageHelpLine("resticprofile-command", true))
+	out("\n")
+	out(ansiBold("resticprofile flags:\n"))
+	out(flags.usagesHelp)
+	out("\n\n")
+	out(ansiBold("resticprofile own commands:\n"))
+	displayOwnCommands(out(), flags)
+	out("\n")
+
+	out("%s at %s\n",
+		ansiBold("Documentation available"),
+		ansiBold(ansiCyan("https://creativeprojects.github.io/resticprofile/")))
+	out("\n")
+}
+
+func displayResticHelp(output io.Writer, configuration *config.Config, flags commandLineFlags, command string) {
+	out, closer := displayWriter(output, flags)
+	defer closer()
+
+	// try to load the config
+	if configuration == nil {
+		if file, err := filesearch.FindConfigurationFile(flags.config); err == nil {
+			if configuration, err = config.LoadFile(file, flags.format); err != nil {
+				configuration = nil
+			}
+		}
+	}
+
+	resticBinary := ""
+	if configuration != nil {
+		if section, err := configuration.GetGlobalSection(); err == nil {
+			resticBinary = section.ResticBinary
+		}
+	}
+
+	if restic, err := filesearch.FindResticBinary(resticBinary); err == nil {
+		buf := bytes.Buffer{}
+		cmd := shell.NewCommand(restic, []string{"help", command})
+		cmd.Stdout = &buf
+		_, _, err = cmd.Run()
+		if err != nil {
+			out("\nFailed requesting help from restic: %s\n", err.Error())
+			return
+		} else if buf.Len() == 0 {
+			out("\nNo help from restic for \"%s\"\n", command)
+			return
+		}
+		replacer := strings.NewReplacer(
+			// restic command => resticprofile [resticprofile flags] command
+			fmt.Sprintf("restic %s", command), getCommonUsageHelpLine(command, true),
+		)
+		_, _ = replacer.WriteString(out(), buf.String())
+	} else {
+		out("restic binary not found: %s\n", err.Error())
+	}
+
+	if configuration != nil {
+		out("\nFlags applied by resticprofile (configuration \"%s\"):\n\n", ansiBold(configuration.GetConfigFile()))
+
+		if profileNames := configuration.GetProfileNames(); len(profileNames) > 0 {
+			profiles := configuration.GetProfiles()
+			sort.Strings(profileNames)
+			unescaper := strings.NewReplacer(
+				`\\`, `^^`,
+				`\ `, ` `,
+				`\'`, `'`,
+				`\"`, `"`,
+				`^^`, `\`,
+			)
+
+			for _, name := range profileNames {
+				out("\tprofile \"%s\":", ansiBold(name))
+				profile := profiles[name]
+				cmdFlags := config.GetNonConfidentialArgs(profile, profile.GetCommandFlags(command))
+				for _, flag := range cmdFlags.GetAll() {
+					if strings.HasPrefix(flag, "-") {
+						out("\n\t\t")
+					}
+					out("%s\t", ansiCyan(unescaper.Replace(flag)))
+				}
+				out("\n")
+			}
+		} else {
+			out("none\n")
+		}
+	}
+}
+
+func displayHelpCommand(output io.Writer, configuration *config.Config, flags commandLineFlags, args []string) error {
+	out, closer := displayWriter(output, flags)
+	defer closer()
+
+	if flags.log == "" {
+		clog.GetDefaultLogger().SetHandler(clog.NewDiscardHandler()) // disable log output
+	}
+
+	helpForCommand := ""
+	for _, arg := range args {
+		if !strings.HasPrefix(arg, "-") && regexp.MustCompile(`^\w{2,}[-\w]*$`).MatchString(arg) {
+			helpForCommand = arg
+			break
+		}
+	}
+
+	if helpForCommand == "" {
+		displayCommonUsageHelp(out("\n"), flags)
+
+	} else if isOwnCommand(helpForCommand, true) || isOwnCommand(helpForCommand, false) {
+		displayOwnCommandHelp(out("\n"), helpForCommand, flags)
+
+	} else {
+		displayResticHelp(out(), configuration, flags, helpForCommand)
+	}
+
+	return nil
+}
+
+func displayVersion(output io.Writer, _ *config.Config, flags commandLineFlags, args []string) error {
+	out, closer := displayWriter(output, flags)
+	defer closer()
+
+	out("resticprofile version %s commit %s\n", ansiBold(version), ansiYellow(commit))
+
+	// allow for the general verbose flag, or specified after the command
+	if flags.verbose || (len(args) > 0 && (args[0] == "-v" || args[0] == "--verbose")) {
+		out("\n")
+		out("\t%s:\t%s\n", "home", "https://github.com/creativeprojects/resticprofile")
+		out("\t%s:\t%s\n", "os", runtime.GOOS)
+		out("\t%s:\t%s\n", "arch", runtime.GOARCH)
+		if goarm > 0 {
+			out("\t%s:\tv%d\n", "arm", goarm)
+		}
+		out("\t%s:\t%s\n", "version", version)
+		out("\t%s:\t%s\n", "commit", commit)
+		out("\t%s:\t%s\n", "compiled", date)
+		out("\t%s:\t%s\n", "by", builtBy)
+		out("\t%s:\t%s\n", "go version", runtime.Version())
+		out("\n")
+		out("\t%s:\n", "go modules")
+		bi, _ := debug.ReadBuildInfo()
+		for _, dep := range bi.Deps {
+			out("\t\t%s\t%s\n", ansiCyan(dep.Path), dep.Version)
+		}
+		out("\n")
+	}
+	return nil
+}
+
+func displayProfilesCommand(output io.Writer, configuration *config.Config, flags commandLineFlags, _ []string) error {
+	displayProfiles(output, configuration, flags)
+	displayGroups(output, configuration, flags)
+	return nil
+}
+
+func displayProfiles(output io.Writer, configuration *config.Config, flags commandLineFlags) {
+	out, closer := displayWriter(output, flags)
+	defer closer()
+
+	profiles := configuration.GetProfiles()
+	keys := sortedProfileKeys(profiles)
+	if len(profiles) == 0 {
+		out("\nThere's no available profile in the configuration\n")
+	} else {
+		out("\nProfiles available (name, sections, description):\n")
+		for _, name := range keys {
+			sections := profiles[name].DefinedCommands()
+			sort.Strings(sections)
+			if len(sections) == 0 {
+				out("\t%s:\t(n/a)\t%s\n", name, profiles[name].Description)
+			} else {
+				out("\t%s:\t(%s)\t%s\n", name, strings.Join(sections, ", "), profiles[name].Description)
+			}
+		}
+	}
+	out("\n")
+}
+
+func displayGroups(output io.Writer, configuration *config.Config, flags commandLineFlags) {
+	out, closer := displayWriter(output, flags)
+	defer closer()
+
+	groups := configuration.GetProfileGroups()
+	if len(groups) == 0 {
+		return
+	}
+	out("Groups available (name, profiles, description):\n")
+	for name, groupList := range groups {
+		out("\t%s:\t[%s]\t%s\n", name, strings.Join(groupList.Profiles, ", "), groupList.Description)
+	}
+	out("\n")
+}
+
+// lineLengthWriter limits the max line length, adding line breaks ('\n') as needed.
+// the writer detects the right most column (consecutive whitespace) and aligns content if possible.
+type lineLengthWriter struct {
+	writer                                            io.Writer
+	tokens                                            []byte
+	maxLineLength, lastWhite, breakLength, lineLength int
+	ansiLength, lastWhiteAnsiLength                   int
+}
+
+func newLineLengthWriter(writer io.Writer, maxLineLength int) *lineLengthWriter {
+	return &lineLengthWriter{writer: writer, maxLineLength: maxLineLength}
+}
+
+func (l *lineLengthWriter) Write(p []byte) (n int, err error) {
+	written := 0
+	inAnsi := false
+	offset := l.lineLength
+	lineLength := func() int { return l.lineLength - l.ansiLength }
+
+	if len(l.tokens) == 0 {
+		l.tokens = []byte{' ', '\n'}
+	}
+
+	for i := 0; i < len(p); i++ {
+		l.lineLength++
+		ws := p[i] == l.tokens[0] // ' '
+		br := p[i] == l.tokens[1] // '\n'
+
+		// don't count ansi control sequences
+		if inAnsi = inAnsi || p[i] == 0x1b; inAnsi {
+			inAnsi = p[i] != 'm'
+			l.ansiLength++
+			continue
+		}
+
+		if !br && lineLength() > l.maxLineLength && l.lastWhite-offset > 0 {
+			lastWhiteIndex := l.lastWhite - offset - 1
+			remainder := i - lastWhiteIndex
+
+			if written, err = l.writer.Write(p[:lastWhiteIndex]); err == nil {
+				p = p[lastWhiteIndex+1:]
+				i = remainder - 1
+				n += written + 1
+
+				_, _ = l.writer.Write(l.tokens[1:]) // write break (instead of WS at lastWhiteIndex)
+				for j := 0; j < l.breakLength; j++ {
+					_, _ = l.writer.Write(l.tokens[0:1]) // fill spaces for alignment
+				}
+
+				l.lineLength = l.breakLength + remainder
+				l.lastWhite = l.breakLength
+				offset = l.breakLength
+
+				l.ansiLength -= l.lastWhiteAnsiLength
+				l.lastWhiteAnsiLength = 0
+			} else {
+				return
+			}
+		}
+
+		if ws {
+			if l.lastWhite == l.lineLength-1 && lineLength() < l.maxLineLength*2/3 {
+				l.breakLength = lineLength()
+			}
+			l.lastWhite = l.lineLength
+			l.lastWhiteAnsiLength = l.ansiLength
+
+		} else if br {
+			if written, err = l.writer.Write(p[:i+1]); err == nil {
+				p = p[i+1:]
+				i = -1
+				n += written
+
+				l.lineLength = 0
+				l.lastWhite = 0
+				l.breakLength = 0
+				offset = 0
+
+				l.ansiLength = 0
+				l.lastWhiteAnsiLength = 0
+			} else {
+				return
+			}
+		}
+	}
+
+	// write remainder
+	if written, err = l.writer.Write(p); err == nil {
+		n += written
+	}
+	return
+}

--- a/commands_display_test.go
+++ b/commands_display_test.go
@@ -1,0 +1,297 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/fatih/color"
+	"github.com/stretchr/testify/assert"
+)
+
+var ansiColor = func() (c *color.Color) {
+	c = color.New(color.FgCyan)
+	c.EnableColor()
+	return
+}()
+
+var colored = ansiColor.SprintFunc()
+
+func TestDisplayWriter(t *testing.T) {
+	flags, noAnsiFlags := commandLineFlags{}, commandLineFlags{noAnsi: true}
+
+	buffer := bytes.Buffer{}
+	write := func(clf commandLineFlags, v ...any) string {
+		buffer.Reset()
+		out, closer := displayWriter(&buffer, clf)
+		out(v...)
+		closer()
+		return buffer.String()
+	}
+
+	t.Run("write-plain", func(t *testing.T) {
+		actual := write(flags, "hello %s %d")
+		assert.Equal(t, "hello %s %d", actual)
+	})
+
+	t.Run("write-with-format", func(t *testing.T) {
+		actual := write(flags, "hello %s %02d", "world", 5)
+		assert.Equal(t, "hello world 05", actual)
+	})
+
+	t.Run("write-tabs", func(t *testing.T) {
+		actual := write(flags, "col1\tcol2\tcol3\nvalue1\tvalue2\tvalue3")
+		assert.Equal(t, "col1     col2     col3\nvalue1   value2   value3", actual)
+	})
+
+	t.Run("no-ansi", func(t *testing.T) {
+		actual := write(flags, colored("test"))
+		assert.Equal(t, colored("test"), actual)
+
+		actual = write(noAnsiFlags, colored("test"))
+		assert.Equal(t, "test", actual)
+	})
+}
+
+func TestLineLengthWriter(t *testing.T) {
+	tests := []struct {
+		input, expected string
+		chunks, scale   int
+	}{
+		// test non-breakable
+		{input: strings.Repeat("-", 50), expected: strings.Repeat("-", 50), chunks: 15},
+
+		// test breakable without columns
+		{
+			input: strings.Repeat("word ", 20),
+			expected: "" +
+				strings.TrimSpace(strings.Repeat("word ", 8)) + "\n" +
+				strings.TrimSpace(strings.Repeat("word ", 8)) + "\n" +
+				strings.Repeat("word ", 4),
+			chunks: 5, scale: 6,
+		},
+
+		// test breakable with ANSI color
+		{
+			input: strings.Repeat(colored("word "), 20),
+			expected: "" +
+				strings.Repeat(colored("word "), 7) + colored("word\n") +
+				strings.Repeat(colored("word "), 7) + colored("word\n") +
+				strings.Repeat(colored("word "), 4),
+		},
+
+		// test breakable with 2 columns
+		{
+			input: "word word  word word  " +
+				strings.Repeat("word ", 20),
+			expected: "" +
+				"word word  word word  " +
+				"word word word\n" +
+				strings.Repeat("                      word word word\n", 5) +
+				"                      word word ",
+			chunks: 3, scale: 15,
+		},
+
+		// test breakable with 2 columns and ANSI color
+		{
+			input: colored("word word  word word  ") +
+				strings.Repeat(colored("word "), 20),
+			expected: "" +
+				colored("word word  word word  ") +
+				colored("word ") + colored("word ") + colored("word\n                      ") +
+				strings.Repeat(colored("word ")+colored("word ")+colored("word\n                      "), 5) +
+				colored("word ") + colored("word "),
+		},
+
+		// test real-world content
+		{
+			input: `
+Usage of resticprofile:
+   resticprofile [resticprofile flags] [profile name.][restic command] [restic flags]
+   resticprofile [resticprofile flags] [profile name.][resticprofile command] [command specific flags]
+
+resticprofile flags:
+  -c, --config string        configuration file (default "profiles")
+      --dry-run              display the restic commands instead of running them
+  -f, --format string        file format of the configuration (default is to use the file extension)
+  -h, --help                 display this help
+      --lock-wait duration   wait up to duration to acquire a lock (syntax "1h5m30s")
+  -l, --log string           logs to a target instead of the console
+  -n, --name string          profile name (default "default")
+      --no-ansi              disable ansi control characters (disable console colouring)
+      --no-lock              skip profile lock file
+      --no-prio              don't set any priority on load: used when started from a service that has already set the priority
+  -q, --quiet                display only warnings and errors
+      --theme string         console colouring theme (dark, light, none) (default "light")
+      --trace                display even more debugging information
+  -v, --verbose              display some debugging information
+  -w, --wait                 wait at the end until the user presses the enter key
+
+
+resticprofile own commands:
+   help          display help (run in verbose mode for detailed information)
+   version       display version (run in verbose mode for detailed information)
+   self-update   update to latest resticprofile (use -q/--quiet flag to update without confirmation)
+   profiles      display profile names from the configuration file
+   show          show all the details of the current profile
+   schedule      schedule jobs from a profile (use --all flag to schedule all jobs of all profiles)
+   unschedule    remove scheduled jobs of a profile (use --all flag to unschedule all profiles)
+   status        display the status of scheduled jobs (use --all flag for all profiles)
+   generate      generate resources (--random-key [size], --bash-completion & --zsh-completion)
+
+Documentation available at https://creativeprojects.github.io/resticprofile/
+`,
+			expected: `
+Usage of resticprofile:
+   resticprofile [resticprofile flags]
+   [profile name.][restic command]
+   [restic flags]
+   resticprofile [resticprofile flags]
+   [profile name.][resticprofile
+   command] [command specific flags]
+
+resticprofile flags:
+  -c, --config string       
+                         configuration
+                         file (default
+                         "profiles")
+      --dry-run              display
+                         the restic
+                         commands
+                         instead of
+                         running them
+  -f, --format string        file
+                         format of the
+                         configuration
+                         (default is to
+                         use the file
+                         extension)
+  -h, --help                 display
+                         this help
+      --lock-wait duration   wait up to
+      duration to acquire a lock
+      (syntax "1h5m30s")
+  -l, --log string           logs to a
+                         target instead
+                         of the console
+  -n, --name string          profile
+                         name (default
+                         "default")
+      --no-ansi              disable
+                         ansi control
+                         characters
+                         (disable
+                         console
+                         colouring)
+      --no-lock              skip
+                         profile lock
+                         file
+      --no-prio              don't set
+                         any priority
+                         on load: used
+                         when started
+                         from a service
+                         that has
+                         already set
+                         the priority
+  -q, --quiet                display
+                         only warnings
+                         and errors
+      --theme string         console
+                         colouring
+                         theme (dark,
+                         light, none)
+                         (default
+                         "light")
+      --trace                display
+                         even more
+                         debugging
+                         information
+  -v, --verbose              display
+                         some debugging
+                         information
+  -w, --wait                 wait at
+                         the end until
+                         the user
+                         presses the
+                         enter key
+
+
+resticprofile own commands:
+   help          display help (run in
+                 verbose mode for
+                 detailed information)
+   version       display version (run
+                 in verbose mode for
+                 detailed information)
+   self-update   update to latest
+                 resticprofile (use
+                 -q/--quiet flag to
+                 update without
+                 confirmation)
+   profiles      display profile names
+                 from the configuration
+                 file
+   show          show all the details
+                 of the current profile
+   schedule      schedule jobs from a
+                 profile (use --all
+                 flag to schedule all
+                 jobs of all profiles)
+   unschedule    remove scheduled jobs
+                 of a profile (use
+                 --all flag to
+                 unschedule all
+                 profiles)
+   status        display the status of
+                 scheduled jobs (use
+                 --all flag for all
+                 profiles)
+   generate      generate resources
+                 (--random-key [size],
+                 --bash-completion &
+                 --zsh-completion)
+
+Documentation available at
+https://creativeprojects.github.io/resticprofile/
+`,
+		},
+	}
+
+	for i, test := range tests {
+		if test.scale == 0 {
+			test.scale = 1
+		}
+		for chunkSize := 0; chunkSize <= test.chunks; chunkSize++ {
+			t.Run(fmt.Sprintf("%d-%d", i, chunkSize), func(t *testing.T) {
+				buffer := bytes.Buffer{}
+				writer := newLineLengthWriter(&buffer, 40)
+				input := []byte(test.input)
+
+				var (
+					n   int
+					err error
+				)
+				switch chunkSize {
+				case 0:
+					n, err = writer.Write(input)
+					assert.Equal(t, len(input), n)
+				default:
+					for len(input) > 0 && err == nil {
+						length := test.scale * chunkSize
+						if length > len(input) {
+							length = len(input)
+						}
+						n, err = writer.Write(input[:length])
+						assert.Equal(t, length, n)
+						input = input[length:]
+					}
+				}
+
+				assert.Nil(t, err)
+				assert.Equal(t, test.expected, buffer.String())
+			})
+		}
+	}
+}

--- a/commands_display_test.go
+++ b/commands_display_test.go
@@ -42,7 +42,7 @@ func TestDisplayWriter(t *testing.T) {
 
 	t.Run("write-tabs", func(t *testing.T) {
 		actual := write(flags, "col1\tcol2\tcol3\nvalue1\tvalue2\tvalue3")
-		assert.Equal(t, "col1     col2     col3\nvalue1   value2   value3", actual)
+		assert.Equal(t, "col1    col2    col3\nvalue1  value2  value3", actual)
 	})
 
 	t.Run("no-ansi", func(t *testing.T) {

--- a/commands_test.go
+++ b/commands_test.go
@@ -28,6 +28,10 @@ func init() {
 			description:       "second second",
 			action:            secondCommand,
 			needConfiguration: true,
+			flags: map[string]string{
+				"-f, --first":   "first flag",
+				"-s, --seccond": "second flag",
+			},
 		},
 		{
 			name:              "third",
@@ -53,8 +57,12 @@ func thirdCommand(_ io.Writer, _ *config.Config, _ commandLineFlags, _ []string)
 
 func TestDisplayOwnCommands(t *testing.T) {
 	buffer := &strings.Builder{}
-	displayOwnCommands(buffer)
+	displayOwnCommands(buffer, false)
 	assert.Equal(t, "   first    first first\n   second   second second\n", buffer.String())
+
+	buffer.Reset()
+	displayOwnCommands(buffer, true, "second")
+	assert.Equal(t, "   second   second second\n            flags:\n            -f, --first     first flag\n            -s, --seccond   second flag\n            \n", buffer.String())
 }
 
 func TestIsOwnCommand(t *testing.T) {

--- a/commands_test.go
+++ b/commands_test.go
@@ -59,7 +59,7 @@ func TestDisplayOwnCommands(t *testing.T) {
 	buffer := &strings.Builder{}
 	flags := commandLineFlags{}
 	displayOwnCommands(buffer, flags)
-	assert.Equal(t, "   first    first first\n   second   second second\n", buffer.String())
+	assert.Equal(t, "  first   first first\n  second  second second\n", buffer.String())
 }
 
 func TestDisplayOwnCommand(t *testing.T) {
@@ -69,11 +69,11 @@ func TestDisplayOwnCommand(t *testing.T) {
 	assert.Equal(t, `Purpose: second second
 
 Usage:
-   resticprofile [resticprofile flags] [profile name.]second [command specific flags]
+  resticprofile [resticprofile flags] [profile name.]second [command specific flags]
 
 Flags:
-   -f, --first     first flag
-   -s, --seccond   second flag
+  -f, --first    first flag
+  -s, --seccond  second flag
 
 `, buffer.String())
 }

--- a/commands_test.go
+++ b/commands_test.go
@@ -57,12 +57,25 @@ func thirdCommand(_ io.Writer, _ *config.Config, _ commandLineFlags, _ []string)
 
 func TestDisplayOwnCommands(t *testing.T) {
 	buffer := &strings.Builder{}
-	displayOwnCommands(buffer, false)
+	flags := commandLineFlags{}
+	displayOwnCommands(buffer, flags)
 	assert.Equal(t, "   first    first first\n   second   second second\n", buffer.String())
+}
 
-	buffer.Reset()
-	displayOwnCommands(buffer, true, "second")
-	assert.Equal(t, "   second   second second\n            flags:\n            -f, --first     first flag\n            -s, --seccond   second flag\n            \n", buffer.String())
+func TestDisplayOwnCommand(t *testing.T) {
+	buffer := &strings.Builder{}
+	flags := commandLineFlags{}
+	displayOwnCommandHelp(buffer, "second", flags)
+	assert.Equal(t, `Purpose: second second
+
+Usage:
+   resticprofile [resticprofile flags] [profile name.]second [command specific flags]
+
+Flags:
+   -f, --first     first flag
+   -s, --seccond   second flag
+
+`, buffer.String())
 }
 
 func TestIsOwnCommand(t *testing.T) {

--- a/complete.go
+++ b/complete.go
@@ -179,11 +179,11 @@ func (c *Completer) completeOwnCommandFlags(name, word string) (completions []st
 
 	for _, command := range c.ownCommands {
 		if command.name == name {
-			for names, _ := range command.flags { // e.g. "-q, --quiet"
+			for names, _ := range command.flags { // e.g. "-q, --quiet, --size [size|"
 				var flagNames []string
 
 				for _, flag := range strings.Split(names, ",") {
-					flag = strings.TrimSpace(flag)
+					flag = strings.Split(strings.TrimSpace(flag), " ")[0] // strip value (if any)
 					flagNames = append(flagNames, flag)
 
 					// Remove this flag if already specified

--- a/complete_test.go
+++ b/complete_test.go
@@ -204,7 +204,8 @@ func TestCompleter(t *testing.T) {
 			}
 			for flag, _ := range command.flags {
 				for _, v := range strings.Split(flag, ",") {
-					commandValues[command.name] = append(commandValues[command.name], strings.TrimSpace(v))
+					v = strings.Split(strings.TrimSpace(v), " ")[0]
+					commandValues[command.name] = append(commandValues[command.name], v)
 					sort.Strings(commandValues[command.name])
 				}
 			}

--- a/flags.go
+++ b/flags.go
@@ -1,13 +1,13 @@
 package main
 
 import (
-	"fmt"
 	"os"
 	"strings"
 	"time"
 
 	"github.com/creativeprojects/resticprofile/constants"
 	"github.com/creativeprojects/resticprofile/platform"
+	"github.com/creativeprojects/resticprofile/term"
 	"github.com/spf13/pflag"
 )
 
@@ -32,6 +32,7 @@ type commandLineFlags struct {
 	parentPort  int
 	noPriority  bool
 	run         string
+	usagesHelp  string
 }
 
 // loadFlags loads command line flags (before any command)
@@ -41,15 +42,7 @@ func loadFlags(args []string) (*pflag.FlagSet, commandLineFlags, error) {
 	flags := commandLineFlags{}
 
 	flagset.Usage = func() {
-		fmt.Println("\nUsage of resticprofile:")
-		fmt.Println("\tresticprofile [resticprofile flags] [profile name.][restic command] [restic flags]")
-		fmt.Println("\tresticprofile [resticprofile flags] [profile name.][resticprofile command] [command specific flags]")
-		fmt.Println("\nresticprofile flags:")
-		flagset.PrintDefaults()
-		fmt.Println("\nresticprofile own commands:")
-		displayOwnCommands(os.Stdout, flags.verbose)
-		fmt.Println("\nDocumentation available at https://creativeprojects.github.io/resticprofile/")
-		fmt.Println("")
+		_ = displayHelpCommand(os.Stdout, nil, flags, args)
 	}
 
 	flagset.BoolVarP(&flags.help, "help", "h", false, "display this help")
@@ -86,6 +79,10 @@ func loadFlags(args []string) (*pflag.FlagSet, commandLineFlags, error) {
 
 	// stop at the first non flag found; the rest will be sent to the restic command line
 	flagset.SetInterspersed(false)
+
+	// Store usage help for help command
+	width, _ := term.OsStdoutTerminalSize()
+	flags.usagesHelp = flagset.FlagUsagesWrapped(width)
 
 	err := flagset.Parse(args)
 	if err != nil {

--- a/flags.go
+++ b/flags.go
@@ -38,6 +38,8 @@ type commandLineFlags struct {
 func loadFlags(args []string) (*pflag.FlagSet, commandLineFlags, error) {
 	flagset := pflag.NewFlagSet("resticprofile", pflag.ContinueOnError)
 
+	flags := commandLineFlags{}
+
 	flagset.Usage = func() {
 		fmt.Println("\nUsage of resticprofile:")
 		fmt.Println("\tresticprofile [resticprofile flags] [profile name.][restic command] [restic flags]")
@@ -45,12 +47,10 @@ func loadFlags(args []string) (*pflag.FlagSet, commandLineFlags, error) {
 		fmt.Println("\nresticprofile flags:")
 		flagset.PrintDefaults()
 		fmt.Println("\nresticprofile own commands:")
-		displayOwnCommands(os.Stdout)
+		displayOwnCommands(os.Stdout, flags.verbose)
 		fmt.Println("\nDocumentation available at https://creativeprojects.github.io/resticprofile/")
 		fmt.Println("")
 	}
-
-	flags := commandLineFlags{}
 
 	flagset.BoolVarP(&flags.help, "help", "h", false, "display this help")
 	flagset.BoolVarP(&flags.quiet, "quiet", "q", constants.DefaultQuietFlag, "display only warnings and errors")

--- a/main.go
+++ b/main.go
@@ -272,8 +272,8 @@ func main() {
 
 	} else {
 		clog.Errorf("profile or group not found '%s'", flags.name)
-		displayProfiles(os.Stdout, c)
-		displayGroups(os.Stdout, c)
+		displayProfiles(os.Stdout, c, flags)
+		displayGroups(os.Stdout, c, flags)
 		exitCode = 1
 		return
 	}


### PR DESCRIPTION
This PR adds a new `help` command supporting the following:

| Commandline                             | Purpose                                          |
|-----------------------------------------|--------------------------------------------------|
| `resticprofile OWNCOMMAND --help` or `resticprofile help OWNCOMMAND` | Display detailed command help including supported flags |
| `resticprofile help COMMAND`            | Display restic command help with extra information what flags are set by profiles |
| `resticprofile help`                    | Same as `resticprofile --help`                   |

E.g.:

```
➜ resticprofile help version

The "version" command displays brief or detailed version information

Usage:
   resticprofile [resticprofile flags] version [command specific flags]

Flags:
   -v, --verbose   display detailed version information
```

---

```
➜ resticprofile help prune 

The "prune" command checks the repository and removes data that is not
referenced and therefore not needed any more.

EXIT STATUS
===========

Exit status is 0 if the command was successful, and non-zero if there was any error.

Usage:
  resticprofile [resticprofile flags] [profile name.]prune [flags]

Flags:
  -n, --dry-run                               do not modify the repository, just print what would be done
  -h, --help                                  help for prune

....

Flags applied by resticprofile (configuration "profiles.yaml"):

   profile "documents":
      --password-file   test-repo.key     
      --repo            local:test-repo   
   profile "p1-base":
      --password-file   test-repo.key     
      --repo            local:test-repo   
   profile "p1-overridden":
      --password-file   test-repo.key     
      --repo            local:test-repo   

....
```

Besides the things mentioned above, the `help` command also introduces slight use of ANSI colors and respects the width of the console window.