### PR TITLE
Prevent system from idle sleeping

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,6 +1,7 @@
 {
     "cSpell.words": [
         "afero",
+        "caffeinate",
         "crond",
         "ionice",
         "journalctl",

--- a/README.md
+++ b/README.md
@@ -39,6 +39,8 @@ With resticprofile:
 * **[new for v0.17.0]** Run shell commands in the background when non fatal errors are detected from restic
 * **[new for v0.18.0]** Send messages to HTTP hooks before, after a successful or failed job (backup, forget, check, prune, copy)
 * **[new for v0.18.0]** Automatically initialize the secondary repository using `copy-chunker-params` flag
+* **[new for v0.18.0]** Send resticprofile logs to a syslog server
+* **[new for v0.19.0]** Preventing your system from idle sleeping
 
 The configuration file accepts various formats:
 * [TOML](https://github.com/toml-lang/toml) : configuration file with extension _.toml_ and _.conf_ to keep compatibility with versions before 0.6.0

--- a/config/global.go
+++ b/config/global.go
@@ -26,6 +26,7 @@ type Global struct {
 	SystemdTimerTemplate string        `mapstructure:"systemd-timer-template"`
 	SenderTimeout        time.Duration `mapstructure:"send-timeout"`
 	CACertificates       []string      `mapstructure:"ca-certificates"`
+	PreventSleep         bool          `mapstructure:"prevent-sleep"`
 }
 
 // NewGlobal instantiates a new Global with default values

--- a/docs/content/_index.md
+++ b/docs/content/_index.md
@@ -31,6 +31,7 @@ With resticprofile:
 * **[new for v0.18.0]** Send messages to [HTTP hooks]({{< ref "/configuration/http_hooks" >}}) before, after a successful or failed job (backup, forget, check, prune, copy)
 * **[new for v0.18.0]** Automatically initialize the secondary repository using `copy-chunker-params` flag
 * **[new for v0.18.0]** Send resticprofile logs to a syslog server
+* **[new for v0.19.0]** Preventing your system from idle sleeping
 
 The configuration file accepts various formats:
 * [TOML](https://github.com/toml-lang/toml) : configuration file with extension _.toml_ and _.conf_ to keep compatibility with versions before 0.6.0

--- a/docs/content/configuration/reference/index.md
+++ b/docs/content/configuration/reference/index.md
@@ -7,31 +7,44 @@ weight: 50
 
 ## Configuration file reference
 
-`[global]`
+### Section `global`
 
-`global` is a fixed name
+`global` is a fixed section name, at the root of the configuration file
 
-None of these flags are passed on the restic command line
+{{% notice info %}}
+None of these flags are directly passed on to the restic command line
+{{% /notice %}}
 
-* **ionice**: true / false
-* **ionice-class**: integer
-* **ionice-level**: integer
-* **nice**: true / false OR integer
-* **priority**: string = `Idle`, `Background`, `Low`, `Normal`, `High`, `Highest`
-* **default-command**: string
-* **initialize**: true / false
-* **restic-binary**: string
-* **restic-lock-retry-after**: duration
-* **restic-stale-lock-age**: duration
-* **min-memory**: integer (MB) - see [memory]({{< ref "/usage/memory" >}})
-* **shell**: string (shell binary to run commands, default value is OS specific)
-* **scheduler**: string (`crond` is the only non-default value)
-* **systemd-unit-template**: string (file containing a go template to generate systemd unit file)
-* **systemd-timer-template**: string (file containing a go template to generate systemd timer file)
 
-`[profile]`
+| Name | Type | Notes |
+|:-----|:-----|:------|
+| **ionice** | true / false |
+| **ionice-class** | integer |
+| **ionice-level** | integer |
+| **nice** | true / false OR integer |
+| **priority** | string | values are `Idle`, `Background`, `Low`, `Normal`, `High`, `Highest` |
+| **default-command** | string | default is `snapshots` |
+| **initialize** | true / false | auto-initialize a repository |
+| **restic-binary** | string | full path of the restic program |
+| **restic-lock-retry-after** | duration [^duration] | default is 1 minute - see [locks]({{< ref "/usage/locks" >}}) |
+| **restic-stale-lock-age** | duration [^duration] | default is 2 hours - see [locks]({{< ref "/usage/locks" >}}) |
+| **min-memory** | integer (MB) | default is 100MB - see [memory]({{< ref "/usage/memory" >}}) |
+| **shell** | string | shell binary to run commands, default value is OS specific |
+| **scheduler** | string | `crond` is the only non-default value |
+| **systemd-unit-template** | string | file containing a go template to generate systemd unit file - see [systemd templates]({{< ref "/schedules/systemd" >}}) |
+| **systemd-timer-template** | string | file containing a go template to generate systemd timer file - see [systemd templates]({{< ref "/schedules/systemd" >}}) |
+| **send-timeout** | duration [^duration] | timeout when sending messages to a webhook - see [HTTP Hooks]({{< ref "http_hooks" >}}) |
+| **ca-certificates** | string, or list of strings | certificates (file in PEM format) to authenticate HTTP servers - see [HTTP Hooks]({{< ref "http_hooks" >}}) |
+| **prevent-sleep** | true / false | prevent the system from sleeping |
 
-`profile` is the name of your profile
+### Profile sections
+
+The name of this section is the name of your profile.
+
+{{% notice note %}}
+You cannot use the names `global` or `groups`.
+{{% /notice %}}
+
 
 Flags used by resticprofile only
 
@@ -289,3 +302,4 @@ Flags passed to the restic command line
 * **path**: true / false, string OR list of strings
 * **tag**: true / false, string OR list of strings
 
+[^duration]: A duration string is a possibly signed sequence of decimal numbers, each with optional fraction and a unit suffix, such as "300ms", "-1.5h" or "2h45m". Valid time units are "ns", "us" (or "µs"), "ms", "s", "m", "h". 

--- a/docs/content/configuration/reference/index.md
+++ b/docs/content/configuration/reference/index.md
@@ -16,26 +16,26 @@ None of these flags are directly passed on to the restic command line
 {{% /notice %}}
 
 
-| Name | Type | Notes |
-|:-----|:-----|:------|
-| **ionice** | true / false |
-| **ionice-class** | integer |
-| **ionice-level** | integer |
-| **nice** | true / false OR integer |
-| **priority** | string | values are `Idle`, `Background`, `Low`, `Normal`, `High`, `Highest` |
-| **default-command** | string | default is `snapshots` |
-| **initialize** | true / false | auto-initialize a repository |
-| **restic-binary** | string | full path of the restic program |
-| **restic-lock-retry-after** | duration [^duration] | default is 1 minute - see [locks]({{< ref "/usage/locks" >}}) |
-| **restic-stale-lock-age** | duration [^duration] | default is 2 hours - see [locks]({{< ref "/usage/locks" >}}) |
-| **min-memory** | integer (MB) | default is 100MB - see [memory]({{< ref "/usage/memory" >}}) |
-| **shell** | string | shell binary to run commands, default value is OS specific |
-| **scheduler** | string | `crond` is the only non-default value |
-| **systemd-unit-template** | string | file containing a go template to generate systemd unit file - see [systemd templates]({{< ref "/schedules/systemd" >}}) |
-| **systemd-timer-template** | string | file containing a go template to generate systemd timer file - see [systemd templates]({{< ref "/schedules/systemd" >}}) |
-| **send-timeout** | duration [^duration] | timeout when sending messages to a webhook - see [HTTP Hooks]({{< ref "http_hooks" >}}) |
-| **ca-certificates** | string, or list of strings | certificates (file in PEM format) to authenticate HTTP servers - see [HTTP Hooks]({{< ref "http_hooks" >}}) |
-| **prevent-sleep** | true / false | prevent the system from sleeping |
+| Name | Type | Default | Notes |
+|:-----|:-----|:--------|:------|
+| **ionice** | true / false | false |
+| **ionice-class** | integer | 0 |
+| **ionice-level** | integer | 0 |
+| **nice** | true / false OR integer | 0 |
+| **priority** | string | `Normal` | values are `Idle`, `Background`, `Low`, `Normal`, `High`, `Highest` |
+| **default-command** | string | `snapshots` |
+| **initialize** | true / false | false | auto-initialize a repository |
+| **restic-binary** | string | | full path of the restic program |
+| **restic-lock-retry-after** | duration [^duration] | 1 minute | see [locks]({{< ref "/usage/locks" >}}) |
+| **restic-stale-lock-age** | duration [^duration] | 2 hours | see [locks]({{< ref "/usage/locks" >}}) |
+| **min-memory** | integer (MB) | 100MB | see [memory]({{< ref "/usage/memory" >}}) |
+| **shell** | string | OS specific | shell binary to run commands |
+| **scheduler** | string | | `crond` is the only non-default value |
+| **systemd-unit-template** | string | | file containing a go template to generate systemd unit file - see [systemd templates]({{< ref "/schedules/systemd" >}}) |
+| **systemd-timer-template** | string | | file containing a go template to generate systemd timer file - see [systemd templates]({{< ref "/schedules/systemd" >}}) |
+| **send-timeout** | duration [^duration] | 30 seconds | timeout when sending messages to a webhook - see [HTTP Hooks]({{< ref "http_hooks" >}}) |
+| **ca-certificates** | string, or list of strings | | certificates (file in PEM format) to authenticate HTTP servers - see [HTTP Hooks]({{< ref "http_hooks" >}}) |
+| **prevent-sleep** | true / false | false | prevent the system from sleeping - see [Preventing system sleep]({{< ref "sleep" >}}) |
 
 ### Profile sections
 

--- a/docs/content/configuration/sleep/_index.md
+++ b/docs/content/configuration/sleep/_index.md
@@ -1,0 +1,16 @@
+---
+title: "Preventing system sleep"
+tags: ["v0.19.0"]
+weight: 40
+---
+
+This feature is available for:
+- macOS
+- Windows
+- Linux with systemd ([logind](https://www.freedesktop.org/software/systemd/man/systemd-logind.service.html))
+
+There's a `global` parameter called `prevent-sleep` that you can set to `true`, and resticprofile will prevent your system from idle sleeping.
+
+Please note:
+- it will not prevent a sleep if the system is running on batteries
+- it will not prevent a sleep triggered by a user action: using the sleep button, closing the laptop lid, etc.

--- a/examples/dev.yaml
+++ b/examples/dev.yaml
@@ -8,6 +8,7 @@ global:
     default-command: snapshots
     initialize: false
     priority: low
+    prevent-sleep: true
     # restic-binary: ~/fake_restic
     # legacy-arguments: true
 

--- a/examples/linux.yaml
+++ b/examples/linux.yaml
@@ -3,6 +3,7 @@ global:
     initialize: false
     priority: low
     systemd-unit-template: sample.service
+    prevent-sleep: true
 
 default:
     password-file: key

--- a/examples/windows.yaml
+++ b/examples/windows.yaml
@@ -1,6 +1,7 @@
 global:
     priority: low
     min-memory: 10
+    prevent-sleep: true
 
 groups:
     double:

--- a/go.mod
+++ b/go.mod
@@ -33,6 +33,7 @@ require (
 	github.com/fatih/color v1.13.0 // indirect
 	github.com/fsnotify/fsnotify v1.5.4 // indirect
 	github.com/go-ole/go-ole v1.2.6 // indirect
+	github.com/godbus/dbus/v5 v5.0.4 // indirect
 	github.com/golang/protobuf v1.5.2 // indirect
 	github.com/google/go-github/v30 v30.1.0 // indirect
 	github.com/google/go-querystring v1.1.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -104,6 +104,7 @@ github.com/go-ole/go-ole v1.2.4/go.mod h1:XCwSNxSkXRo4vlyPy93sltvi/qJq0jqQhjqQNI
 github.com/go-ole/go-ole v1.2.6 h1:/Fpf6oFPoeFik9ty7siob0G6Ke8QvQEuVcuChpwXzpY=
 github.com/go-ole/go-ole v1.2.6/go.mod h1:pprOEPIfldk/42T2oK7lQ4v4JSDwmV0As9GaiUsvbm0=
 github.com/go-stack/stack v1.8.0/go.mod h1:v0f6uXyyMGvRgIKkXu+yp6POWl0qKG85gN/melR3HDY=
+github.com/godbus/dbus/v5 v5.0.4 h1:9349emZab16e7zQvpmsbtjc18ykshndd8y2PG3sgJbA=
 github.com/godbus/dbus/v5 v5.0.4/go.mod h1:xhWf0FNVPg57R7Z0UbKHbJfkEywrmjJnf7w5xrFpKfA=
 github.com/gogo/protobuf v1.1.1/go.mod h1:r8qH/GZQm5c6nD/R0oafs1akxWv10x8SbQlK7atdtwQ=
 github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b/go.mod h1:SBH7ygxi8pfUlaOkMMuAQtPIUF8ecWP5IEl/CR7VP2Q=

--- a/preventsleep/caffeinate_test.go
+++ b/preventsleep/caffeinate_test.go
@@ -1,0 +1,52 @@
+package preventsleep_test
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/creativeprojects/resticprofile/preventsleep"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCaffeinate(t *testing.T) {
+	caffeinate := preventsleep.New()
+	assert.False(t, caffeinate.IsRunning())
+
+	err := caffeinate.Start()
+	if errors.Is(err, preventsleep.ErrPermissionDenied) {
+		t.Skip("user must be root to run this test")
+	}
+	require.NoError(t, err)
+	assert.True(t, caffeinate.IsRunning())
+
+	err = caffeinate.Stop()
+	require.NoError(t, err)
+	assert.False(t, caffeinate.IsRunning())
+}
+
+func TestStopShouldReturnError(t *testing.T) {
+	caffeinate := preventsleep.New()
+	assert.False(t, caffeinate.IsRunning())
+
+	err := caffeinate.Stop()
+	assert.ErrorIs(t, err, preventsleep.ErrNotStarted)
+}
+
+func TestCannotStartTwice(t *testing.T) {
+	caffeinate := preventsleep.New()
+	assert.False(t, caffeinate.IsRunning())
+
+	err := caffeinate.Start()
+	if errors.Is(err, preventsleep.ErrPermissionDenied) {
+		t.Skip("user must be root to run this test")
+	}
+	require.NoError(t, err)
+	assert.True(t, caffeinate.IsRunning())
+
+	err = caffeinate.Start()
+	assert.ErrorIs(t, err, preventsleep.ErrAlreadyStarted)
+
+	err = caffeinate.Stop()
+	require.NoError(t, err)
+}

--- a/preventsleep/darwin.go
+++ b/preventsleep/darwin.go
@@ -1,0 +1,73 @@
+//go:build darwin
+
+package preventsleep
+
+import (
+	"os"
+	"os/exec"
+	"sync"
+	"sync/atomic"
+
+	"github.com/creativeprojects/clog"
+)
+
+const (
+	signalInterrupt = "signal: interrupt"
+	command         = "/usr/bin/caffeinate"
+	// Create an assertion to prevent the system from sleeping.
+	// This assertion is valid only when system is running on AC power.
+	flag = "-s"
+)
+
+type Caffeinate struct {
+	cmd atomic.Value
+	wg  sync.WaitGroup
+}
+
+func New() *Caffeinate {
+	return &Caffeinate{}
+}
+
+// Start caffeinate in the background and returns.
+func (c *Caffeinate) Start() error {
+	cmd, ok := c.cmd.Load().(*exec.Cmd)
+	if ok {
+		return ErrAlreadyStarted
+	}
+	cmd = exec.Command(command, flag)
+	c.cmd.Store(cmd)
+	if err := cmd.Start(); err != nil {
+		return err
+	}
+	c.wg.Add(1)
+	go func() {
+		defer c.wg.Done()
+		err := cmd.Wait()
+		if err != nil {
+			if err.Error() != signalInterrupt {
+				clog.Warningf("caffeinate: %s", err)
+			}
+		}
+		cmd = nil
+		c.cmd.Store(cmd)
+	}()
+	return nil
+}
+
+// Stop caffeinate (and wait until it's stopped)
+func (c *Caffeinate) Stop() error {
+	cmd, ok := c.cmd.Load().(*exec.Cmd)
+	if !ok || cmd == nil {
+		return ErrNotStarted
+	}
+	if err := cmd.Process.Signal(os.Interrupt); err != nil {
+		return err
+	}
+	c.wg.Wait()
+	return nil
+}
+
+func (c *Caffeinate) IsRunning() bool {
+	cmd, ok := c.cmd.Load().(*exec.Cmd)
+	return ok && cmd != nil
+}

--- a/preventsleep/errors.go
+++ b/preventsleep/errors.go
@@ -1,0 +1,10 @@
+package preventsleep
+
+import "errors"
+
+var (
+	ErrNotStarted       = errors.New("caffeinate is not started")
+	ErrAlreadyStarted   = errors.New("caffeinate is already started")
+	ErrNotRunning       = errors.New("caffeinate is no longer running")
+	ErrPermissionDenied = errors.New("permission denied, you must use sudo to perform this operation")
+)

--- a/preventsleep/errors.go
+++ b/preventsleep/errors.go
@@ -3,6 +3,7 @@ package preventsleep
 import "errors"
 
 var (
+	ErrNotSupported     = errors.New("preventing system sleep is not supported on this platform")
 	ErrNotStarted       = errors.New("caffeinate is not started")
 	ErrAlreadyStarted   = errors.New("caffeinate is already started")
 	ErrNotRunning       = errors.New("caffeinate is no longer running")

--- a/preventsleep/linux.go
+++ b/preventsleep/linux.go
@@ -1,4 +1,4 @@
-//go:build !darwin && !windows
+//go:build linux
 
 package preventsleep
 

--- a/preventsleep/other.go
+++ b/preventsleep/other.go
@@ -1,0 +1,21 @@
+//go:build !darwin && !windows && !linux
+
+package preventsleep
+
+type Caffeinate struct{}
+
+func New() *Caffeinate {
+	return &Caffeinate{}
+}
+
+func (c *Caffeinate) Start() error {
+	return ErrNotSupported
+}
+
+func (c *Caffeinate) Stop() error {
+	return ErrNotSupported
+}
+
+func (c *Caffeinate) IsRunning() bool {
+	return false
+}

--- a/preventsleep/systemd.go
+++ b/preventsleep/systemd.go
@@ -1,0 +1,67 @@
+//go:build !darwin && !windows
+
+package preventsleep
+
+import (
+	"fmt"
+	"os"
+
+	systemd "github.com/coreos/go-systemd/v22/login1"
+	"github.com/creativeprojects/resticprofile/constants"
+)
+
+const (
+	inhibitWhat      = "sleep"
+	inhibitWhy       = "Backup and/or restic repository maintenance"
+	inhibitMode      = "block"
+	permissionDenied = "Permission denied"
+)
+
+type Caffeinate struct {
+	conn *systemd.Conn
+	file *os.File
+}
+
+func New() *Caffeinate {
+	return &Caffeinate{}
+}
+
+func (c *Caffeinate) Start() error {
+	var err error
+
+	if c.file != nil {
+		return ErrAlreadyStarted
+	}
+
+	c.conn, err = systemd.New()
+	if err != nil {
+		return fmt.Errorf("error connecting to dbus: %w", err)
+	}
+	c.file, err = c.conn.Inhibit(inhibitWhat, constants.ApplicationName, inhibitWhy, inhibitMode)
+	if err != nil {
+		if err.Error() == permissionDenied {
+			return ErrPermissionDenied
+		}
+		return err
+	}
+	return nil
+}
+
+func (c *Caffeinate) Stop() error {
+	if c.file == nil {
+		return ErrNotStarted
+	}
+	if c.file != nil {
+		c.file.Close()
+		c.file = nil
+	}
+	if c.conn != nil {
+		c.conn.Close()
+		c.conn = nil
+	}
+	return nil
+}
+
+func (c *Caffeinate) IsRunning() bool {
+	return c.conn != nil && c.file != nil
+}

--- a/preventsleep/windows.go
+++ b/preventsleep/windows.go
@@ -1,0 +1,60 @@
+//go:build windows
+
+package preventsleep
+
+import (
+	"syscall"
+)
+
+// Execution States
+const (
+	EsSystemRequired = 0x00000001
+	EsContinuous     = 0x80000000
+)
+
+const (
+	operationCompleted = "The operation completed successfully."
+)
+
+type Caffeinate struct {
+	setThreadExecStateProc *syscall.LazyProc
+	running                bool
+}
+
+func New() *Caffeinate {
+	kernel32 := syscall.NewLazyDLL("kernel32.dll")
+	setThreadExecStateProc := kernel32.NewProc("SetThreadExecutionState")
+	return &Caffeinate{
+		setThreadExecStateProc: setThreadExecStateProc,
+	}
+}
+
+func (c *Caffeinate) Start() error {
+	if c.IsRunning() {
+		return ErrAlreadyStarted
+	}
+	var err error
+	_, _, err = c.setThreadExecStateProc.Call(uintptr(EsSystemRequired | EsContinuous))
+	if err != nil && err.Error() != operationCompleted {
+		return err
+	}
+	c.running = true
+	return nil
+}
+
+func (c *Caffeinate) Stop() error {
+	if !c.IsRunning() {
+		return ErrNotStarted
+	}
+	var err error
+	_, _, err = c.setThreadExecStateProc.Call(uintptr(EsContinuous))
+	if err != nil && err.Error() != operationCompleted {
+		return err
+	}
+	c.running = false
+	return nil
+}
+
+func (c *Caffeinate) IsRunning() bool {
+	return c.running
+}


### PR DESCRIPTION
This feature is available for:
- macOS
- Windows
- Linux with systemd ([logind](https://www.freedesktop.org/software/systemd/man/systemd-logind.service.html))

There's a `global` parameter called `prevent-sleep` that you can set to `true`, and resticprofile will prevent your system from idle sleeping.

Please note:
- it will not prevent a sleep if the system is running on batteries
- it will not prevent a sleep triggered by a user action: using the sleep button, closing the laptop lid, etc.

Fixes #129 
