### PR TITLE
Continue profile in group on error

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,15 +23,15 @@ jobs:
 
     steps:
 
+      - name: Check out code into the Go module directory
+        uses: actions/checkout@v3
+
       - name: Set up Go ${{ matrix.go_version }}
         uses: actions/setup-go@v3
         with:
           go-version: ${{ matrix.go_version }}
           check-latest: true
           cache: true
-
-      - name: Check out code into the Go module directory
-        uses: actions/checkout@v3
 
       - name: Generate mocks
         run: make mocks

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,6 +27,8 @@ jobs:
         uses: actions/setup-go@v3
         with:
           go-version: ${{ matrix.go_version }}
+          check-latest: true
+          cache: true
 
       - name: Check out code into the Go module directory
         uses: actions/checkout@v3
@@ -44,7 +46,7 @@ jobs:
         shell: bash
 
       - name: Code coverage with codecov
-        uses: codecov/codecov-action@v2
+        uses: codecov/codecov-action@v3
 
       - name: Archive code coverage results
         uses: actions/upload-artifact@v3

--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -21,6 +21,8 @@ jobs:
         uses: actions/setup-go@v3
         with:
           go-version: 1.19
+          check-latest: true
+          cache: true
 
       - uses: actions/checkout@v3
         with:

--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -6,6 +6,11 @@ on:
       - master
     paths:
       - "docs/**"
+
+  pull_request:
+    types: [opened, synchronize, reopened]
+    paths:
+      - 'docs/**'
   
 jobs:
   build:

--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -26,8 +26,6 @@ jobs:
         uses: actions/setup-go@v3
         with:
           go-version: 1.19
-          check-latest: true
-          cache: true
 
       - name: Check configuration snippets in documentation
         run: go run ./config/checkdoc -r docs/content

--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -17,17 +17,17 @@ jobs:
     runs-on: ubuntu-latest
     steps:
 
+      - uses: actions/checkout@v3
+        with:
+          submodules: true  # Fetch Hugo themes (true OR recursive)
+          fetch-depth: 0    # Fetch all history for .GitInfo and .Lastmod
+
       - name: Set up Go 1.19
         uses: actions/setup-go@v3
         with:
           go-version: 1.19
           check-latest: true
           cache: true
-
-      - uses: actions/checkout@v3
-        with:
-          submodules: true  # Fetch Hugo themes (true OR recursive)
-          fetch-depth: 0    # Fetch all history for .GitInfo and .Lastmod
 
       - name: Check configuration snippets in documentation
         run: go run ./config/checkdoc -r docs/content

--- a/.github/workflows/release-doc.yml
+++ b/.github/workflows/release-doc.yml
@@ -2,13 +2,11 @@ name: documentation
 
 on:
   push:
-    branches:
-      - master
-    paths:
-      - "docs/**"
+    tags:
+      - '*'
   
 jobs:
-  build:
+  deploy:
     runs-on: ubuntu-latest
     steps:
 
@@ -34,3 +32,11 @@ jobs:
 
       - name: Build
         run: cd docs && hugo --minify
+
+      - name: Deploy
+        uses: peaceiris/actions-gh-pages@v3
+        # if: github.ref == 'refs/heads/main'
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_branch: gh-docs
+          publish_dir: ./public

--- a/bools/bools.go
+++ b/bools/bools.go
@@ -1,0 +1,33 @@
+package bools
+
+func IsTrue(value *bool) bool {
+	if value == nil {
+		return false
+	}
+	return *value
+}
+
+func IsStrictlyFalse(value *bool) bool {
+	if value == nil {
+		return false
+	}
+	return !*value
+}
+
+func IsFalseOrUndefined(value *bool) bool {
+	if value == nil {
+		return true
+	}
+	return !*value
+}
+
+func IsUndefined(value *bool) bool {
+	return value == nil
+}
+
+func IsTrueOrUndefined(value *bool) bool {
+	if value == nil {
+		return true
+	}
+	return *value
+}

--- a/bools/bools_test.go
+++ b/bools/bools_test.go
@@ -1,0 +1,66 @@
+package bools
+
+import (
+	"strconv"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestBools(t *testing.T) {
+	fixtures := []struct {
+		source             *bool
+		isTrue             bool
+		isStrictlyFalse    bool
+		isFalseOrUndefined bool
+		isUndefined        bool
+		isTrueOrUndefined  bool
+	}{
+		{
+			source:             nil,
+			isTrue:             false,
+			isStrictlyFalse:    false,
+			isFalseOrUndefined: true,
+			isUndefined:        true,
+			isTrueOrUndefined:  true,
+		},
+		{
+			source:             boolPointer(true),
+			isTrue:             true,
+			isStrictlyFalse:    false,
+			isFalseOrUndefined: false,
+			isUndefined:        false,
+			isTrueOrUndefined:  true,
+		},
+		{
+			source:             boolPointer(false),
+			isTrue:             false,
+			isStrictlyFalse:    true,
+			isFalseOrUndefined: true,
+			isUndefined:        false,
+			isTrueOrUndefined:  false,
+		},
+	}
+
+	for _, fixture := range fixtures {
+		t.Run(toString(fixture.source), func(t *testing.T) {
+			assert.Equal(t, fixture.isTrue, IsTrue(fixture.source))
+			assert.Equal(t, fixture.isStrictlyFalse, IsStrictlyFalse(fixture.source))
+			assert.Equal(t, fixture.isFalseOrUndefined, IsFalseOrUndefined(fixture.source))
+			assert.Equal(t, fixture.isUndefined, IsUndefined(fixture.source))
+			assert.Equal(t, fixture.isTrueOrUndefined, IsTrueOrUndefined(fixture.source))
+		})
+	}
+}
+
+func boolPointer(value bool) *bool {
+	output := &value
+	return output
+}
+
+func toString(value *bool) string {
+	if value == nil {
+		return "<nil>"
+	}
+	return strconv.FormatBool(*value)
+}

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -197,6 +197,157 @@ profile:
 	}
 }
 
+func TestBoolPointer(t *testing.T) {
+	boolPointer := func(value bool) *bool {
+		output := &value
+		return output
+	}
+
+	fixtures := []struct {
+		testTemplate
+		continueOnError *bool
+	}{
+		{
+			testTemplate: testTemplate{
+				format: FormatTOML,
+				config: `
+version = 2
+[groups]
+[groups.groupname]
+profiles = []
+`,
+			},
+			continueOnError: nil,
+		},
+		{
+			testTemplate: testTemplate{
+				format: FormatYAML,
+				config: `
+version: 2
+groups:
+  groupname:
+    profiles: []
+`,
+			},
+			continueOnError: nil,
+		},
+		{
+			testTemplate: testTemplate{
+				format: FormatJSON,
+				config: `
+{
+	"version": 2,
+	"groups": {
+		"groupname":{
+			"profiles": []
+		}
+	}
+}
+`,
+			},
+			continueOnError: nil,
+		},
+		{
+			testTemplate: testTemplate{
+				format: FormatTOML,
+				config: `
+version = 2
+[groups]
+[groups.groupname]
+profiles = []
+continue-on-error = true
+`,
+			},
+			continueOnError: boolPointer(true),
+		},
+		{
+			testTemplate: testTemplate{
+				format: FormatYAML,
+				config: `
+version: 2
+groups:
+ groupname:
+  profiles: []
+  continue-on-error: true
+`,
+			},
+			continueOnError: boolPointer(true),
+		},
+		{
+			testTemplate: testTemplate{
+				format: FormatJSON,
+				config: `
+{
+	"version": 2,
+	"groups": {
+		"groupname":{
+			"profiles": [],
+			"continue-on-error": true
+		}
+	}
+}
+`,
+			},
+			continueOnError: boolPointer(true),
+		},
+		{
+			testTemplate: testTemplate{
+				format: FormatTOML,
+				config: `
+version = 2
+[groups]
+[groups.groupname]
+profiles = []
+continue-on-error = false
+`,
+			},
+			continueOnError: boolPointer(false),
+		},
+		{
+			testTemplate: testTemplate{
+				format: FormatYAML,
+				config: `
+version: 2
+groups:
+  groupname:
+    profiles: []
+    continue-on-error: false
+`,
+			},
+			continueOnError: boolPointer(false),
+		},
+		{
+			testTemplate: testTemplate{
+				format: FormatJSON,
+				config: `
+{
+	"version": 2,
+	"groups": {
+		"groupname":{
+			"profiles": [],
+			"continue-on-error": false
+		}
+	}
+}
+`,
+			},
+			continueOnError: boolPointer(false),
+		},
+	}
+
+	for _, fixture := range fixtures {
+		t.Run(fixture.format, func(t *testing.T) {
+			c, err := Load(bytes.NewBufferString(fixture.config), fixture.format)
+			require.NoError(t, err)
+
+			group, err := c.GetProfileGroup("groupname")
+			require.NoError(t, err)
+
+			assert.Equal(t, fixture.continueOnError, group.ContinueOnError)
+		})
+	}
+}
+
 func TestGetIncludes(t *testing.T) {
 	config, err := Load(bytes.NewBufferString(`includes=["i1", "i2"]`), "toml")
 	require.NoError(t, err)

--- a/config/config_v1.go
+++ b/config/config_v1.go
@@ -68,7 +68,7 @@ func (c *Config) loadGroupsV1() (err error) {
 					c.groups[groupName] = Group{
 						Description:     "",
 						Profiles:        group,
-						ContinueOnError: false,
+						ContinueOnError: nil,
 					}
 				}
 			}

--- a/config/config_v1.go
+++ b/config/config_v1.go
@@ -66,9 +66,9 @@ func (c *Config) loadGroupsV1() (err error) {
 				// fits previous version into new structure
 				for groupName, group := range groups {
 					c.groups[groupName] = Group{
-						Description: "",
-						Profiles:    group,
-						NextOnError: false,
+						Description:     "",
+						Profiles:        group,
+						ContinueOnError: false,
 					}
 				}
 			}

--- a/config/config_v1.go
+++ b/config/config_v1.go
@@ -15,13 +15,13 @@ import (
 // Most configuration file formats allow only one declaration per section
 // This is not the case for HCL where you can declare a bloc multiple times:
 //
-// "global" {
-//   key1 = "value"
-// }
+//	"global" {
+//	  key1 = "value"
+//	}
 //
-// "global" {
-//   key2 = "value"
-// }
+//	"global" {
+//	  key2 = "value"
+//	}
 //
 // For that matter, viper creates a slice of maps instead of a map for the other configuration file formats
 // This configOptionV1HCL deals with the slice to merge it into a single map
@@ -66,13 +66,15 @@ func (c *Config) loadGroupsV1() (err error) {
 				// fits previous version into new structure
 				for groupName, group := range groups {
 					c.groups[groupName] = Group{
-						Profiles: group,
+						Description: "",
+						Profiles:    group,
+						NextOnError: false,
 					}
 				}
 			}
 		}
 	}
-	return
+	return err
 }
 
 // getProfileV1 from version 1 configuration. If the profile is not found, it returns errNotFound

--- a/config/global.go
+++ b/config/global.go
@@ -27,7 +27,7 @@ type Global struct {
 	SenderTimeout        time.Duration `mapstructure:"send-timeout"`
 	CACertificates       []string      `mapstructure:"ca-certificates"`
 	PreventSleep         bool          `mapstructure:"prevent-sleep"`
-	GroupNextOnError     bool          `mapstructure:"group-next-on-error"`
+	GroupContinueOnError bool          `mapstructure:"group-continue-on-error"`
 }
 
 // NewGlobal instantiates a new Global with default values

--- a/config/global.go
+++ b/config/global.go
@@ -27,6 +27,7 @@ type Global struct {
 	SenderTimeout        time.Duration `mapstructure:"send-timeout"`
 	CACertificates       []string      `mapstructure:"ca-certificates"`
 	PreventSleep         bool          `mapstructure:"prevent-sleep"`
+	GroupNextOnError     bool          `mapstructure:"group-next-on-error"`
 }
 
 // NewGlobal instantiates a new Global with default values

--- a/config/group.go
+++ b/config/group.go
@@ -4,4 +4,5 @@ package config
 type Group struct {
 	Description string   `mapstructure:"description"`
 	Profiles    []string `mapstructure:"profiles"`
+	NextOnError bool     `mapstructure:"next-on-error"`
 }

--- a/config/group.go
+++ b/config/group.go
@@ -4,5 +4,5 @@ package config
 type Group struct {
 	Description     string   `mapstructure:"description"`
 	Profiles        []string `mapstructure:"profiles"`
-	ContinueOnError bool     `mapstructure:"continue-on-error"`
+	ContinueOnError *bool    `mapstructure:"continue-on-error"`
 }

--- a/config/group.go
+++ b/config/group.go
@@ -2,7 +2,7 @@ package config
 
 // Group of profiles
 type Group struct {
-	Description string   `mapstructure:"description"`
-	Profiles    []string `mapstructure:"profiles"`
-	NextOnError bool     `mapstructure:"next-on-error"`
+	Description     string   `mapstructure:"description"`
+	Profiles        []string `mapstructure:"profiles"`
+	ContinueOnError bool     `mapstructure:"continue-on-error"`
 }

--- a/docs/content/configuration/reference/index.md
+++ b/docs/content/configuration/reference/index.md
@@ -36,7 +36,7 @@ None of these flags are directly passed on to the restic command line
 | **send-timeout** | duration [^duration] | 30 seconds | timeout when sending messages to a webhook - see [HTTP Hooks]({{< ref "http_hooks" >}}) |
 | **ca-certificates** | string, or list of strings | | certificates (file in PEM format) to authenticate HTTP servers - see [HTTP Hooks]({{< ref "http_hooks" >}}) |
 | **prevent-sleep** | true / false | false | prevent the system from sleeping - see [Preventing system sleep]({{< ref "sleep" >}}) |
-| **group-next-on-error** | true / false | false | if set to `true` it allows the next profile(s) to run after a failure |
+| **group-continue-on-error** | true / false | false | if set to `true` it allows the next profile(s) to run after a failure |
 
 ### Profile sections
 

--- a/docs/content/configuration/reference/index.md
+++ b/docs/content/configuration/reference/index.md
@@ -36,6 +36,7 @@ None of these flags are directly passed on to the restic command line
 | **send-timeout** | duration [^duration] | 30 seconds | timeout when sending messages to a webhook - see [HTTP Hooks]({{< ref "http_hooks" >}}) |
 | **ca-certificates** | string, or list of strings | | certificates (file in PEM format) to authenticate HTTP servers - see [HTTP Hooks]({{< ref "http_hooks" >}}) |
 | **prevent-sleep** | true / false | false | prevent the system from sleeping - see [Preventing system sleep]({{< ref "sleep" >}}) |
+| **group-next-on-error** | true / false | false | if set to `true` it allows the next profile(s) to run after a failure |
 
 ### Profile sections
 

--- a/examples/dev.yaml
+++ b/examples/dev.yaml
@@ -11,7 +11,7 @@ global:
     prevent-sleep: true
     # restic-binary: ~/fake_restic
     # legacy-arguments: true
-    group-next-on-error: true
+    group-continue-on-error: true
 
 groups:
     full-backup:

--- a/examples/dev.yaml
+++ b/examples/dev.yaml
@@ -11,11 +11,12 @@ global:
     prevent-sleep: true
     # restic-binary: ~/fake_restic
     # legacy-arguments: true
+    group-next-on-error: true
 
 groups:
     full-backup:
-    - root
     - src
+    - root
 
 default:
     description: Contains default parameters like repository and password file

--- a/main.go
+++ b/main.go
@@ -264,7 +264,7 @@ func main() {
 				err = runProfile(c, global, flags, profileName, resticBinary, resticArguments, resticCommand, flags.name)
 				if err != nil {
 					clog.Error(err)
-					if group.NextOnError || global.GroupNextOnError {
+					if group.ContinueOnError || global.GroupContinueOnError {
 						// keep going to the next profile
 						continue
 					}

--- a/main.go
+++ b/main.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/creativeprojects/clog"
+	"github.com/creativeprojects/resticprofile/bools"
 	"github.com/creativeprojects/resticprofile/config"
 	"github.com/creativeprojects/resticprofile/constants"
 	"github.com/creativeprojects/resticprofile/filesearch"
@@ -264,7 +265,8 @@ func main() {
 				err = runProfile(c, global, flags, profileName, resticBinary, resticArguments, resticCommand, flags.name)
 				if err != nil {
 					clog.Error(err)
-					if group.ContinueOnError || global.GroupContinueOnError {
+					if global.GroupContinueOnError && bools.IsTrueOrUndefined(group.ContinueOnError) ||
+						bools.IsTrue(group.ContinueOnError) {
 						// keep going to the next profile
 						continue
 					}

--- a/main.go
+++ b/main.go
@@ -264,6 +264,10 @@ func main() {
 				err = runProfile(c, global, flags, profileName, resticBinary, resticArguments, resticCommand, flags.name)
 				if err != nil {
 					clog.Error(err)
+					if group.NextOnError || global.GroupNextOnError {
+						// keep going to the next profile
+						continue
+					}
 					exitCode = 1
 					return
 				}


### PR DESCRIPTION
- add one global flag `group-continue-on-error` in configuration file format `v1`
- add one group flag `continue-on-error` in configuration format `v2`

When setting the global flag `group-continue-on-error` to true, it allows the next profile(s) to run after a failing profile. Without the option all the following profiles are not started.

In a similar way on configuration file `v2` you can set the `continue-on-error` on each group independently:

```yaml
groups:
  double:
    continue-on-error: true
    profiles:
      - profile1
      - profile2

profiles:
  profile1:

  profile2:

```

Fixes #135 