### PR TITLE
Run-hooks for all non-conflicting commands (#151)

### DIFF
--- a/config/profile.go
+++ b/config/profile.go
@@ -62,17 +62,25 @@ type Profile struct {
 	Retention               *RetentionSection                 `mapstructure:"retention"`
 	Check                   *SectionWithScheduleAndMonitoring `mapstructure:"check"`
 	Prune                   *SectionWithScheduleAndMonitoring `mapstructure:"prune"`
-	Snapshots               *OtherFlagsSection                `mapstructure:"snapshots"`
+	Snapshots               *GenericSection                   `mapstructure:"snapshots"`
 	Forget                  *SectionWithScheduleAndMonitoring `mapstructure:"forget"`
-	Mount                   *OtherFlagsSection                `mapstructure:"mount"`
+	Mount                   *GenericSection                   `mapstructure:"mount"`
 	Copy                    *CopySection                      `mapstructure:"copy"`
-	Dump                    *OtherFlagsSection                `mapstructure:"dump"`
-	Find                    *OtherFlagsSection                `mapstructure:"find"`
-	Ls                      *OtherFlagsSection                `mapstructure:"ls"`
-	Restore                 *OtherFlagsSection                `mapstructure:"restore"`
-	Stats                   *OtherFlagsSection                `mapstructure:"stats"`
-	Tag                     *OtherFlagsSection                `mapstructure:"tag"`
+	Dump                    *GenericSection                   `mapstructure:"dump"`
+	Find                    *GenericSection                   `mapstructure:"find"`
+	Ls                      *GenericSection                   `mapstructure:"ls"`
+	Restore                 *GenericSection                   `mapstructure:"restore"`
+	Stats                   *GenericSection                   `mapstructure:"stats"`
+	Tag                     *GenericSection                   `mapstructure:"tag"`
 }
+
+// GenericSection is used for all restic commands that are not covered in specific section types
+type GenericSection struct {
+	OtherFlagsSection       `mapstructure:",squash"`
+	RunShellCommandsSection `mapstructure:",squash"`
+}
+
+func (g *GenericSection) IsEmpty() bool { return g == nil }
 
 // InitSection contains the specific configuration to the 'init' command
 type InitSection struct {

--- a/docs/content/configuration/run_hooks/index.md
+++ b/docs/content/configuration/run_hooks/index.md
@@ -10,7 +10,7 @@ weight: 20
 resticprofile has 2 places where you can run commands around restic:
 
 - commands that will run before and after every restic command (snapshots, backup, check, forget, prune, mount, etc.). These are placed at the root of each profile and are always considered.
-- commands that will only run before and after specific restic commands. These are placed in supported sections of your profiles (supported are `backup` & `copy`).
+- commands that will only run before and after specific restic commands. These are placed in supported sections of your profiles (currently supported are `backup`, `copy`, `dump`, `find`, `ls`, `mount`, `restore`, `snapshots`, `stats` and `tag`).
 
 Here's an example of all the external commands that you can run during the execution of a profile:
 

--- a/wrapper_test.go
+++ b/wrapper_test.go
@@ -557,10 +557,27 @@ func TestRunShellCommands(t *testing.T) {
 	profile.Init = &config.InitSection{}
 	profile.Prune = &config.SectionWithScheduleAndMonitoring{}
 
+	profile.Dump = &config.GenericSection{}
+	profile.Find = &config.GenericSection{}
+	profile.Ls = &config.GenericSection{}
+	profile.Mount = &config.GenericSection{}
+	profile.Restore = &config.GenericSection{}
+	profile.Snapshots = &config.GenericSection{}
+	profile.Stats = &config.GenericSection{}
+	profile.Tag = &config.GenericSection{}
+
 	sections := map[string]*config.RunShellCommandsSection{
-		"backup": profile.Backup.GetRunShellCommands(),
+		"backup":    profile.Backup.GetRunShellCommands(),
+		"copy":      profile.Copy.GetRunShellCommands(),
+		"dump":      profile.Dump.GetRunShellCommands(),
+		"find":      profile.Find.GetRunShellCommands(),
+		"ls":        profile.Ls.GetRunShellCommands(),
+		"mount":     profile.Mount.GetRunShellCommands(),
+		"restore":   profile.Restore.GetRunShellCommands(),
+		"snapshots": profile.Snapshots.GetRunShellCommands(),
+		"stats":     profile.Stats.GetRunShellCommands(),
+		"tag":       profile.Tag.GetRunShellCommands(),
 		//"check":  profile.Check.GetRunShellCommands(),
-		"copy": profile.Copy.GetRunShellCommands(),
 		//"forget": profile.Forget.GetRunShellCommands(),
 		//"init": profile.Init.GetRunShellCommands(),
 		//"prune":  profile.Prune.GetRunShellCommands(),


### PR DESCRIPTION
Adds shell command hooks to the following additional commands: `dump`, `find`, `ls`, `mount`, `restore`, `snapshots`, `stats` and `tag`.

This is an enhancement to #138 and implements #151 

The remaining commands `check`, `forget`, `init`, `retention` and `prune` depend on the _alias_ feature discussed in #138 and should be added when aliases are implemented.