### PR TITLE
Update Docker to include SSH and latest binaries

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -4,9 +4,21 @@ LABEL maintainer Fred <fred@gcreativeprojects.tech>
 
 ARG ARCH=amd64
 
-COPY build/restic-${ARCH} /usr/bin/restic
-COPY build/rclone-${ARCH} /usr/bin/rclone
+RUN apk add --no-cache restic
+RUN /usr/bin/restic self-update
+
+RUN wget -O rclone.zip https://downloads.rclone.org/rclone-current-linux-${ARCH}.zip --no-check-certificate
+RUN unzip rclone.zip
+RUN cp rclone-*-linux-${ARCH}/rclone /usr/bin/rclone
+RUN rm -r rclone-*-linux-${ARCH}
+
 COPY resticprofile /usr/bin/resticprofile
+#RUN wget -O install.sh https://raw.githubusercontent.com/creativeprojects/resticprofile/master/install.sh
+#RUN chmod +x install.sh
+#RUN ./install.sh -b /usr/bin
+#RUN rm ./install.sh
+
+RUN apk add --no-cache openssh
 
 VOLUME /resticprofile
 WORKDIR /resticprofile


### PR DESCRIPTION
SFTP repositories not working in Docker image as SSH is not installed. Proposing to install SSH in contaimner.
This is tested and works well, need to include instructions to mount .ssh as a volume like this 
   volumes:
      - ~/.ssh:/root/.ssh

Also updated the Dockerfile to pull the latest versions of restic and rclone  (and optionally resticprofile) instead of using a static local binary.