### PR TITLE
add suppport for user_logged_on

### DIFF
--- a/commands.go
+++ b/commands.go
@@ -141,7 +141,7 @@ func getOwnCommands() []ownCommand {
 			name:              "elevation",
 			description:       "test windows elevated mode",
 			action:            testElevationCommand,
-			needConfiguration: true,
+			needConfiguration: false,
 			hide:              true,
 		},
 		{
@@ -554,7 +554,7 @@ func testElevationCommand(_ io.Writer, c *config.Config, flags commandLineFlags,
 		client := remote.NewClient(flags.parentPort)
 		term.Print("first line", "\n")
 		term.Println("second", "one")
-		term.Printf("value = %d", 11)
+		term.Printf("value = %d\n", 11)
 		err := client.Done()
 		if err != nil {
 			return err

--- a/constants/value.go
+++ b/constants/value.go
@@ -4,6 +4,7 @@ package constants
 const (
 	SchedulePermissionUser         = "user"
 	SchedulePermissionUserLoggedOn = "user_logged_on"
+	SchedulePermissionUserLoggedIn = "user_logged_in"
 	SchedulePermissionSystem       = "system"
 	SchedulePriorityBackground     = "background"
 	SchedulePriorityStandard       = "standard"

--- a/constants/value.go
+++ b/constants/value.go
@@ -2,8 +2,9 @@ package constants
 
 // Parameter values
 const (
-	SchedulePermissionUser     = "user"
-	SchedulePermissionSystem   = "system"
-	SchedulePriorityBackground = "background"
-	SchedulePriorityStandard   = "standard"
+	SchedulePermissionUser         = "user"
+	SchedulePermissionUserLoggedOn = "user_logged_on"
+	SchedulePermissionSystem       = "system"
+	SchedulePriorityBackground     = "background"
+	SchedulePriorityStandard       = "standard"
 )

--- a/docs/content/configuration/reference/index.md
+++ b/docs/content/configuration/reference/index.md
@@ -99,7 +99,7 @@ Flags used by resticprofile only
 * **check-before**: true / false
 * **check-after**: true / false
 * **schedule**: string OR list of strings
-* **schedule-permission**: string (`user` or `system`)
+* **schedule-permission**: string (`user`, `system` or `user_logged_in` for Windows only)
 * **schedule-lock-mode**: string (`default`, `fail` or `ignore`) 
 * **schedule-lock-wait**: duration 
 * **schedule-log**: string
@@ -134,7 +134,7 @@ Flags used by resticprofile only
 * **before-backup**: true / false
 * **after-backup**: true / false
 * **schedule**: string OR list of strings
-* **schedule-permission**: string (`user` or `system`)
+* **schedule-permission**: string (`user` or `system` or `user_logged_in` for Windows only)
 * **schedule-lock-mode**: string (`default`, `fail` or `ignore`)
 * **schedule-lock-wait**: duration
 * **schedule-log**: string
@@ -173,7 +173,7 @@ Flags passed to the restic command line
 Flags used by resticprofile only
 
 * **schedule**: string OR list of strings
-* **schedule-permission**: string (`user` or `system`)
+* **schedule-permission**: string (`user` or `system` or `user_logged_in` for Windows only)
 * **schedule-lock-mode**: string (`default`, `fail` or `ignore`)
 * **schedule-lock-wait**: duration
 * **schedule-log**: string
@@ -201,7 +201,7 @@ Flags passed to the restic command line
 Flags used by resticprofile only
 
 * **schedule**: string OR list of strings
-* **schedule-permission**: string (`user` or `system`)
+* **schedule-permission**: string (`user` or `system` or `user_logged_in` for Windows only)
 * **schedule-lock-mode**: string (`default`, `fail` or `ignore`)
 * **schedule-lock-wait**: duration
 * **schedule-log**: string
@@ -218,7 +218,7 @@ Flags passed to the restic command line
 Flags used by resticprofile only
 
 * **schedule**: string OR list of strings
-* **schedule-permission**: string (`user` or `system`)
+* **schedule-permission**: string (`user` or `system` or `user_logged_in` for Windows only)
 * **schedule-lock-mode**: string (`default`, `fail` or `ignore`)
 * **schedule-lock-wait**: duration
 * **schedule-log**: string
@@ -246,7 +246,7 @@ Flags used by resticprofile only
 * **run-after-fail**: string OR list of strings
 * **run-finally**: string OR list of strings
 * **schedule**: string OR list of strings
-* **schedule-permission**: string (`user` or `system`)
+* **schedule-permission**: string (`user` or `system` or `user_logged_in` for Windows only)
 * **schedule-lock-mode**: string (`default`, `fail` or `ignore`)
 * **schedule-lock-wait**: duration
 * **schedule-log**: string

--- a/docs/content/configuration/reference/index.md
+++ b/docs/content/configuration/reference/index.md
@@ -99,7 +99,7 @@ Flags used by resticprofile only
 * **check-before**: true / false
 * **check-after**: true / false
 * **schedule**: string OR list of strings
-* **schedule-permission**: string (`user`, `system` or `user_logged_in` for Windows only)
+* **schedule-permission**: string (`user`, `system` or `user_logged_on` for Windows only)
 * **schedule-lock-mode**: string (`default`, `fail` or `ignore`) 
 * **schedule-lock-wait**: duration 
 * **schedule-log**: string
@@ -134,7 +134,7 @@ Flags used by resticprofile only
 * **before-backup**: true / false
 * **after-backup**: true / false
 * **schedule**: string OR list of strings
-* **schedule-permission**: string (`user` or `system` or `user_logged_in` for Windows only)
+* **schedule-permission**: string (`user` or `system` or `user_logged_on` for Windows only)
 * **schedule-lock-mode**: string (`default`, `fail` or `ignore`)
 * **schedule-lock-wait**: duration
 * **schedule-log**: string
@@ -173,7 +173,7 @@ Flags passed to the restic command line
 Flags used by resticprofile only
 
 * **schedule**: string OR list of strings
-* **schedule-permission**: string (`user` or `system` or `user_logged_in` for Windows only)
+* **schedule-permission**: string (`user` or `system` or `user_logged_on` for Windows only)
 * **schedule-lock-mode**: string (`default`, `fail` or `ignore`)
 * **schedule-lock-wait**: duration
 * **schedule-log**: string
@@ -201,7 +201,7 @@ Flags passed to the restic command line
 Flags used by resticprofile only
 
 * **schedule**: string OR list of strings
-* **schedule-permission**: string (`user` or `system` or `user_logged_in` for Windows only)
+* **schedule-permission**: string (`user` or `system` or `user_logged_on` for Windows only)
 * **schedule-lock-mode**: string (`default`, `fail` or `ignore`)
 * **schedule-lock-wait**: duration
 * **schedule-log**: string
@@ -218,7 +218,7 @@ Flags passed to the restic command line
 Flags used by resticprofile only
 
 * **schedule**: string OR list of strings
-* **schedule-permission**: string (`user` or `system` or `user_logged_in` for Windows only)
+* **schedule-permission**: string (`user` or `system` or `user_logged_on` for Windows only)
 * **schedule-lock-mode**: string (`default`, `fail` or `ignore`)
 * **schedule-lock-wait**: duration
 * **schedule-log**: string
@@ -246,7 +246,7 @@ Flags used by resticprofile only
 * **run-after-fail**: string OR list of strings
 * **run-finally**: string OR list of strings
 * **schedule**: string OR list of strings
-* **schedule-permission**: string (`user` or `system` or `user_logged_in` for Windows only)
+* **schedule-permission**: string (`user` or `system` or `user_logged_on` for Windows only)
 * **schedule-lock-mode**: string (`default`, `fail` or `ignore`)
 * **schedule-lock-wait**: duration
 * **schedule-log**: string

--- a/docs/content/schedules/configuration/index.md
+++ b/docs/content/schedules/configuration/index.md
@@ -72,15 +72,15 @@ profile:
 
 ### schedule-permission
 
-`schedule-permission` accepts three parameters: `system`, `user` or `user_logged_in`:
+`schedule-permission` accepts three parameters: `system`, `user` or `user_logged_on`:
 
 * `system`: if you need to access some system or protected files. You will need to run resticprofile with `sudo` on unixes and with elevated prompt on Windows (please note on Windows resticprofile will ask you for elevated permissions automatically if needed).
 
 * `user`: your backup will be running using your current user permissions on files. This is fine if you're only saving your documents (or any other file inside your profile). Please note on **systemd** that the schedule **will only run when your user is logged in**. This mode will ask you for your user password on Windows.
 
-* `user_logged_in`: **For Windows only** - This gives the same permissions as `user`. This mode is not asking for your user password but will only run while the user is logged in.
+* `user_logged_on`: **For Windows only** - This gives the same permissions as `user`. This mode is not asking for your user password but will only run while the user is logged on.
 
-* *empty*: resticprofile will try its best guess based on how you started it (with sudo or as a normal user) and fallback to `user`
+* *empty*: resticprofile will try its best guess based on how you started it (with sudo or as a normal user). The fallback is `system` on Windows, and `user` on the other platforms.
 
 
 #### Changing schedule-permission from user to system, or system to user

--- a/docs/content/schedules/configuration/index.md
+++ b/docs/content/schedules/configuration/index.md
@@ -72,11 +72,13 @@ profile:
 
 ### schedule-permission
 
-`schedule-permission` accepts two parameters: `user` or `system`:
-
-* `user`: your backup will be running using your current user permissions on files. This is fine if you're only saving your documents (or any other file inside your profile). Please note on **systemd** that the schedule **will only run when your user is logged in**.
+`schedule-permission` accepts three parameters: `system`, `user` or `user_logged_in`:
 
 * `system`: if you need to access some system or protected files. You will need to run resticprofile with `sudo` on unixes and with elevated prompt on Windows (please note on Windows resticprofile will ask you for elevated permissions automatically if needed).
+
+* `user`: your backup will be running using your current user permissions on files. This is fine if you're only saving your documents (or any other file inside your profile). Please note on **systemd** that the schedule **will only run when your user is logged in**. This mode will ask you for your user password on Windows.
+
+* `user_logged_in`: **For Windows only** - This gives the same permissions as `user`. This mode is not asking for your user password but will only run while the user is logged in.
 
 * *empty*: resticprofile will try its best guess based on how you started it (with sudo or as a normal user) and fallback to `user`
 

--- a/schedule/handler_windows.go
+++ b/schedule/handler_windows.go
@@ -59,7 +59,7 @@ func (h *HandlerWindows) CreateJob(job *config.ScheduleConfig, schedules []*cale
 	perm := schtasks.SystemAccount
 	if permission == constants.SchedulePermissionUser {
 		perm = schtasks.UserAccount
-	} else if permission == constants.SchedulePermissionUserLoggedOn {
+	} else if permission == constants.SchedulePermissionUserLoggedOn || permission == constants.SchedulePermissionUserLoggedIn {
 		perm = schtasks.UserLoggedOnAccount
 	}
 	err := schtasks.Create(job, schedules, perm)

--- a/schedule/handler_windows.go
+++ b/schedule/handler_windows.go
@@ -59,6 +59,8 @@ func (h *HandlerWindows) CreateJob(job *config.ScheduleConfig, schedules []*cale
 	perm := schtasks.SystemAccount
 	if permission == constants.SchedulePermissionUser {
 		perm = schtasks.UserAccount
+	} else if permission == constants.SchedulePermissionUserLoggedOn {
+		perm = schtasks.UserLoggedOnAccount
 	}
 	err := schtasks.Create(job, schedules, perm)
 	if err != nil {

--- a/schedule/permission_test.go
+++ b/schedule/permission_test.go
@@ -31,6 +31,8 @@ func TestDetectSchedulePermissionOnWindows(t *testing.T) {
 		{"something", "system", true},
 		{"system", "system", true},
 		{"user", "user", true},
+		{"user_logged_on", "user_logged_on", true},
+		{"user_logged_in", "user_logged_on", true}, // I did the typo as I was writing the doc, so let's add it here :)
 	}
 	for _, fixture := range fixtures {
 		t.Run(fixture.input, func(t *testing.T) {

--- a/schedule/permission_windows.go
+++ b/schedule/permission_windows.go
@@ -15,6 +15,9 @@ func detectSchedulePermission(permission string) (detected string, safe bool) {
 	if permission == constants.SchedulePermissionUser {
 		return constants.SchedulePermissionUser, true
 	}
+	if permission == constants.SchedulePermissionUserLoggedOn {
+		return constants.SchedulePermissionUserLoggedOn, true
+	}
 	return constants.SchedulePermissionSystem, true
 }
 

--- a/schedule/permission_windows.go
+++ b/schedule/permission_windows.go
@@ -15,7 +15,7 @@ func detectSchedulePermission(permission string) (detected string, safe bool) {
 	if permission == constants.SchedulePermissionUser {
 		return constants.SchedulePermissionUser, true
 	}
-	if permission == constants.SchedulePermissionUserLoggedOn {
+	if permission == constants.SchedulePermissionUserLoggedOn || permission == constants.SchedulePermissionUserLoggedIn {
 		return constants.SchedulePermissionUserLoggedOn, true
 	}
 	return constants.SchedulePermissionSystem, true

--- a/schtasks/taskscheduler.go
+++ b/schtasks/taskscheduler.go
@@ -40,7 +40,7 @@ const (
 	maxTriggers = 60
 )
 
-// Permission is a choice between User and System
+// Permission is a choice between System, User and User Logged On
 type Permission int
 
 // Permission available


### PR DESCRIPTION
Adds a new option to `schedule-permission` **for Windows only**
- `system` run as built-in user `SYSTEM` - **same as before**
- `user` run as current user (logged on or not) - **same as before**
- `user_logged_on` run when current user is logged on (no need for a password in that case)

Fixes #155 