### PR TITLE
New docker image

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -9,7 +9,7 @@ COPY build/restic-${ARCH} /usr/bin/restic
 COPY build/rclone-${ARCH} /usr/bin/rclone
 COPY resticprofile /usr/bin/resticprofile
 
-RUN apk add --no-cache openssh-client-default curl tzdata
+RUN apk add --no-cache openssh-client-default curl tzdata ca-certificates
 
 VOLUME /resticprofile
 WORKDIR /resticprofile

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -3,12 +3,13 @@ FROM alpine:latest
 LABEL maintainer Fred <fred@gcreativeprojects.tech>
 
 ARG ARCH=amd64
+ENV TZ=Etc/UTC
 
 COPY build/restic-${ARCH} /usr/bin/restic
 COPY build/rclone-${ARCH} /usr/bin/rclone
 COPY resticprofile /usr/bin/resticprofile
 
-RUN apk add --no-cache openssh
+RUN apk add --no-cache openssh-client-default curl tzdata
 
 VOLUME /resticprofile
 WORKDIR /resticprofile

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -8,6 +8,8 @@ COPY build/restic-${ARCH} /usr/bin/restic
 COPY build/rclone-${ARCH} /usr/bin/rclone
 COPY resticprofile /usr/bin/resticprofile
 
+RUN apk add --no-cache openssh
+
 VOLUME /resticprofile
 WORKDIR /resticprofile
 

--- a/commands.go
+++ b/commands.go
@@ -9,7 +9,6 @@ import (
 	"io"
 	"os"
 	"regexp"
-	"runtime"
 	"sort"
 	"strconv"
 	"strings"
@@ -17,6 +16,7 @@ import (
 	"github.com/creativeprojects/clog"
 	"github.com/creativeprojects/resticprofile/config"
 	"github.com/creativeprojects/resticprofile/constants"
+	"github.com/creativeprojects/resticprofile/platform"
 	"github.com/creativeprojects/resticprofile/remote"
 	"github.com/creativeprojects/resticprofile/schedule"
 	"github.com/creativeprojects/resticprofile/term"
@@ -570,7 +570,7 @@ func retryElevated(err error, flags commandLineFlags) error {
 		return nil
 	}
 	// maybe can find a better way than searching for the word "denied"?
-	if runtime.GOOS == "windows" && !flags.isChild && strings.Contains(err.Error(), "denied") {
+	if platform.IsWindows() && !flags.isChild && strings.Contains(err.Error(), "denied") {
 		clog.Info("restarting resticprofile in elevated mode...")
 		err := elevated(flags)
 		if err != nil {
@@ -582,7 +582,7 @@ func retryElevated(err error, flags commandLineFlags) error {
 }
 
 func elevated(flags commandLineFlags) error {
-	if runtime.GOOS != "windows" {
+	if !platform.IsWindows() {
 		return errors.New("only available on Windows platform")
 	}
 

--- a/contrib/schedule-in-docker/README.md
+++ b/contrib/schedule-in-docker/README.md
@@ -1,0 +1,3 @@
+# Scheduling inside a docker container
+
+[Discussion](https://github.com/creativeprojects/resticprofile/issues/74)

--- a/contrib/schedule-in-docker/README.md
+++ b/contrib/schedule-in-docker/README.md
@@ -1,3 +1,58 @@
 # Scheduling inside a docker container
 
 [Discussion](https://github.com/creativeprojects/resticprofile/issues/74)
+
+You can schedule your backups with resticprofile by running `crond` inside a container.
+
+Here's a `docker-compose` example:
+
+```yaml
+version: '2'
+
+services:
+  scheduled-backup:
+    image: creativeprojects/resticprofile:${RP_VERSION:-latest}
+    container_name: backup_container
+    hostname: backup_container
+    entrypoint: '/bin/sh'
+    command:
+      - '-c'
+      - 'crond && resticprofile-schedule.sh && inotifyd resticprofile-schedule.sh /etc/resticprofile/profiles.yaml:w'
+    volumes:
+      - ~/.ssh:/root/.ssh
+      - './profiles.yaml:/etc/resticprofile/profiles.yaml:ro'
+      - './key:/etc/resticprofile/key:ro'
+      - './resticprofile-schedule.sh:/usr/local/bin/resticprofile-schedule.sh:ro'
+    environment:
+      - TZ=Etc/UTC
+```
+
+with the corresponding resticprofile configuration running a backup every 15 minutes:
+
+```yaml
+
+global:
+  scheduler: crond
+
+default:
+  password-file: key
+  repository: sftp:storage_server:/tmp/backup
+  initialize: true
+  backup:
+    source: /
+    exclude-caches: true
+    one-file-system: true
+    schedule: "*:00,15,30,45"
+    schedule-permission: system
+    check-before: true
+
+```
+
+The `resticprofile-schedule.sh` is only setting up the cron tasks:
+
+```sh
+#!/bin/sh
+
+resticprofile schedule --all
+
+```

--- a/contrib/schedule-in-docker/README.md
+++ b/contrib/schedule-in-docker/README.md
@@ -17,12 +17,11 @@ services:
     entrypoint: '/bin/sh'
     command:
       - '-c'
-      - 'crond && resticprofile-schedule.sh && inotifyd resticprofile-schedule.sh /etc/resticprofile/profiles.yaml:w'
+      - 'resticprofile schedule --all && crond -f'
     volumes:
       - ~/.ssh:/root/.ssh
       - './profiles.yaml:/etc/resticprofile/profiles.yaml:ro'
       - './key:/etc/resticprofile/key:ro'
-      - './resticprofile-schedule.sh:/usr/local/bin/resticprofile-schedule.sh:ro'
     environment:
       - TZ=Etc/UTC
 ```
@@ -45,14 +44,5 @@ default:
     schedule: "*:00,15,30,45"
     schedule-permission: system
     check-before: true
-
-```
-
-The `resticprofile-schedule.sh` is only setting up the cron tasks:
-
-```sh
-#!/bin/sh
-
-resticprofile schedule --all
 
 ```

--- a/contrib/schedule-in-docker/docker-compose.yml
+++ b/contrib/schedule-in-docker/docker-compose.yml
@@ -3,6 +3,8 @@ version: '2'
 services:
   scheduled-backup:
     image: creativeprojects/resticprofile:${RP_VERSION:-latest}
+    container_name: backup_container
+    hostname: backup_container
     entrypoint: '/bin/sh'
     command:
       - '-c'
@@ -12,3 +14,5 @@ services:
       - './profiles.yaml:/etc/resticprofile/profiles.yaml:ro'
       - './key:/etc/resticprofile/key:ro'
       - './resticprofile-schedule.sh:/usr/local/bin/resticprofile-schedule.sh:ro'
+    environment:
+      - TZ=Etc/UTC

--- a/contrib/schedule-in-docker/docker-compose.yml
+++ b/contrib/schedule-in-docker/docker-compose.yml
@@ -1,0 +1,14 @@
+version: '2'
+
+services:
+  scheduled-backup:
+    image: creativeprojects/resticprofile:${RP_VERSION:-latest}
+    entrypoint: '/bin/sh'
+    command:
+      - '-c'
+      - 'crond && resticprofile-schedule.sh && inotifyd resticprofile-schedule.sh /etc/resticprofile/profiles.yaml:w'
+    volumes:
+      - ~/.ssh:/root/.ssh
+      - './profiles.yaml:/etc/resticprofile/profiles.yaml:ro'
+      - './key:/etc/resticprofile/key:ro'
+      - './resticprofile-schedule.sh:/usr/local/bin/resticprofile-schedule.sh:ro'

--- a/contrib/schedule-in-docker/docker-compose.yml
+++ b/contrib/schedule-in-docker/docker-compose.yml
@@ -8,11 +8,10 @@ services:
     entrypoint: '/bin/sh'
     command:
       - '-c'
-      - 'crond && resticprofile-schedule.sh && inotifyd resticprofile-schedule.sh /etc/resticprofile/profiles.yaml:w'
+      - 'resticprofile schedule --all && crond -f'
     volumes:
       - ~/.ssh:/root/.ssh
       - './profiles.yaml:/etc/resticprofile/profiles.yaml:ro'
       - './key:/etc/resticprofile/key:ro'
-      - './resticprofile-schedule.sh:/usr/local/bin/resticprofile-schedule.sh:ro'
     environment:
       - TZ=Etc/UTC

--- a/contrib/schedule-in-docker/key
+++ b/contrib/schedule-in-docker/key
@@ -1,0 +1,1 @@
+This is a test backup key

--- a/contrib/schedule-in-docker/profiles.yaml
+++ b/contrib/schedule-in-docker/profiles.yaml
@@ -1,0 +1,15 @@
+
+global:
+  scheduler: crond
+
+default:
+  password-file: key
+  repository: sftp:nas17:/tmp/backup
+  initialize: true
+  backup:
+    source: /
+    exclude-caches: true
+    one-file-system: true
+    schedule: "*:00,05,10,15,30,45"
+    schedule-permission: system
+    check-before: true

--- a/contrib/schedule-in-docker/resticprofile-schedule.sh
+++ b/contrib/schedule-in-docker/resticprofile-schedule.sh
@@ -1,3 +1,0 @@
-#!/bin/sh
-
-resticprofile schedule --all

--- a/contrib/schedule-in-docker/resticprofile-schedule.sh
+++ b/contrib/schedule-in-docker/resticprofile-schedule.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+resticprofile schedule --all

--- a/docs/content/contributions/_index.md
+++ b/docs/content/contributions/_index.md
@@ -16,3 +16,4 @@ I have created a [contributions section](https://github.com/creativeprojects/res
 - [export status to grafana](https://github.com/creativeprojects/resticprofile/tree/master/contrib/grafana)
 - [send email on systemd timer error](https://github.com/creativeprojects/resticprofile/tree/master/contrib/systemd)
 - [get backup status information in zabbix](https://github.com/creativeprojects/resticprofile/tree/master/contrib/zabbix)
+- [scheduling inside a docker container](https://github.com/creativeprojects/resticprofile/tree/master/contrib/schedule-in-docker)

--- a/docs/content/installation/docker/_index.md
+++ b/docs/content/installation/docker/_index.md
@@ -45,4 +45,12 @@ Starting from version `0.18.0`, the resticprofile docker image is available in t
 
 Starting from version `0.18.0`, the resticprofile docker image also includes [rclone][1].
 
+## Scheduling with docker compose
+
+There's an example in the contribution section how to schedule backups in a long running container.
+The configuration needs to specify the use `crond` as a scheduler.
+
+See [contrib][2]
+
 [1]: https://rclone.org/
+[2]: https://github.com/creativeprojects/resticprofile/tree/master/contrib/schedule-in-docker

--- a/main.go
+++ b/main.go
@@ -27,7 +27,7 @@ import (
 
 // These fields are populated by the goreleaser build
 var (
-	version = "0.19.0-dev"
+	version = "0.20.0-dev"
 	commit  = ""
 	date    = ""
 	builtBy = ""

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,7 +1,7 @@
 sonar.organization=creativeprojects
 sonar.projectKey=creativeprojects_resticprofile
 sonar.projectName=resticprofile
-sonar.projectVersion=0.18.0
+sonar.projectVersion=0.20.0
 
 sonar.sources=.
 sonar.exclusions=**/*_test.go,/docs/**


### PR DESCRIPTION
Docker image with these new packages added:

- ssh client (needed for `sftp`)
- tzdata (to get local time in logs)
- curl (has more options than resticprofile hooks)
- ca-certificates

Fixes #159 
Closes #158 
