### PR TITLE
Allow config encoding in UTF8-BOM, UTF16 and ISO88591

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -146,6 +146,10 @@ func (c *Config) templateName(name string) string {
 }
 
 func (c *Config) addTemplate(input io.Reader, name string, replace bool) error {
+	if rs, ok := input.(io.ReadSeeker); ok {
+		input = NewUTF8Reader(rs)
+	}
+
 	inputString := &strings.Builder{}
 	_, err := io.Copy(inputString, input)
 	if err != nil {

--- a/config/decoder.go
+++ b/config/decoder.go
@@ -1,0 +1,110 @@
+package config
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+
+	"golang.org/x/text/encoding"
+	"golang.org/x/text/encoding/charmap"
+	"golang.org/x/text/encoding/unicode"
+	"golang.org/x/text/transform"
+)
+
+var decoders []DecoderFunc
+
+// DecoderFunc detects a charset and provides a transformer for it.
+// May return nil when no charset was detected.
+// The func is responsible for setting the reader's offset (e.g. rewind) before returning.
+type DecoderFunc func(reader io.ReadSeeker) transform.Transformer
+
+// RegisterCharsetDecoder allow to register a func that detects and decodes the charset of an arbitrary text stream
+func RegisterCharsetDecoder(fn DecoderFunc) {
+	if fn != nil {
+		decoders = append(decoders, fn)
+	}
+}
+
+// NewUTF8Reader returns a reader that decodes the provided input to an UTF8 stream using registered DecoderFunc
+func NewUTF8Reader(reader io.ReadSeeker) io.Reader {
+	for i := len(decoders) - 1; i >= 0; i-- {
+		if transformer := decoders[i](reader); transformer != nil {
+			return transform.NewReader(reader, transformer)
+		}
+	}
+	return reader
+}
+
+func utfDecoder() DecoderFunc {
+	var utfBoms = [][]byte{
+		{0xef, 0xbb, 0xbf}, //UTF-8
+		{0xfe, 0xff},       //UTF16-BE
+		{0xff, 0xfe},       //UTF16-LE
+	}
+
+	return func(reader io.ReadSeeker) transform.Transformer {
+		head := make([]byte, 3)
+		if headLen, err := reader.Read(head); err == nil || err == io.EOF {
+			defer mustRewindToStart(reader)
+
+			for _, bom := range utfBoms {
+				bl := len(bom)
+				if bl > headLen {
+					continue
+				}
+				if bytes.Equal(bom, head[:bl]) {
+					return unicode.BOMOverride(transform.Nop)
+				}
+			}
+		}
+		return nil
+	}
+}
+
+func isoDecoder() DecoderFunc {
+	const (
+		readSize    = 4 * 1024
+		maxScanSize = 128 * 1024
+	)
+	return func(reader io.ReadSeeker) transform.Transformer {
+		if invalid, _ := isInvalidUTF(reader, readSize, maxScanSize); invalid {
+			return charmap.ISO8859_1.NewDecoder()
+		}
+		return nil
+	}
+}
+
+func isInvalidUTF(reader io.ReadSeeker, readSize, scanSize int) (invalid bool, err error) {
+	defer func() {
+		if err == nil {
+			mustRewindToStart(reader)
+		}
+	}()
+
+	buf := make([]byte, readSize)
+	transformer := unicode.BOMOverride(encoding.UTF8Validator)
+	validator := transform.NewReader(io.LimitReader(reader, int64(scanSize)), transformer)
+
+	for n := 1; n > 0; {
+		n, err = validator.Read(buf)
+		invalid = err == encoding.ErrInvalidUTF8
+		if invalid || err == io.EOF {
+			err = nil
+			break
+		}
+	}
+	return
+}
+
+func mustRewindToStart(seeker io.Seeker) {
+	if offset, err := seeker.Seek(0, io.SeekStart); offset != 0 {
+		panic(fmt.Errorf("failed reverting read offset to start: offset was %d", offset))
+	} else if err != nil && err != io.EOF {
+		panic(fmt.Errorf("failed reverting read offset to start: %w", err))
+	}
+}
+
+func init() {
+	RegisterCharsetDecoder(utfDecoder())
+	RegisterCharsetDecoder(isoDecoder())
+}

--- a/config/decoder_test.go
+++ b/config/decoder_test.go
@@ -1,0 +1,112 @@
+package config
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestDecoders(t *testing.T) {
+	tests := []struct {
+		input      []byte
+		expected   string
+		expectAsIs bool
+	}{
+		{input: []byte("hello"), expected: "hello", expectAsIs: true},
+		{input: []byte("hËllØ"), expected: "hËllØ", expectAsIs: true},
+		{input: []byte("h"), expected: "h", expectAsIs: true},
+		{input: []byte(""), expected: "", expectAsIs: true},
+		{input: []byte("\ufeffhËllØ"), expected: "hËllØ"},                                      // UTF8-BOM
+		{input: []byte{0xef, 0xbb, 0xbf, 'h', 'e', 'l', 'l', 'o'}, expected: "hello"},          // UTF8-BOM
+		{input: []byte{0xfe, 0xff, 0, 'h', 0, 'e', 0, 'l', 0, 'l', 0, 'o'}, expected: "hello"}, // UTF16-BE
+		{input: []byte{0xff, 0xfe, 'h', 0, 'e', 0, 'l', 0, 'l', 0, 'o', 0}, expected: "hello"}, // UTF16-LE
+		{input: []byte{'h', 0xcb, 'l', 'l', 0xd8}, expected: "hËllØ"},                          // ISO-8859-1
+	}
+
+	for i, test := range tests {
+		t.Run(fmt.Sprintf("%d", i), func(t *testing.T) {
+			input := bytes.NewReader(test.input)
+			reader := NewUTF8Reader(input)
+			if test.expectAsIs {
+				assert.Same(t, input, reader)
+			} else {
+				assert.NotSame(t, input, reader)
+			}
+
+			data, err := io.ReadAll(reader)
+			assert.NoError(t, err)
+			assert.Equal(t, test.expected, string(data))
+		})
+	}
+}
+
+func TestDecoderOnErrorInput(t *testing.T) {
+	custom := fmt.Errorf("custom")
+	tests := []struct {
+		input    io.ReadSeeker
+		expected error
+	}{
+		{input: &failingSeeker{err: io.EOF}, expected: io.EOF},
+		{input: &failingSeeker{err: custom}, expected: custom},
+		{input: &failingSeeker{buf: make([]byte, 0), err: custom}, expected: custom},
+		{input: &failingSeeker{buf: make([]byte, 1024), err: custom}, expected: custom},
+	}
+	for i, test := range tests {
+		t.Run(fmt.Sprintf("%d", i), func(t *testing.T) {
+			_, err := NewUTF8Reader(test.input).Read(make([]byte, 1))
+			assert.Equal(t, test.expected, err)
+		})
+	}
+}
+
+func TestMustRewindToStart(t *testing.T) {
+	buf := make([]byte, 1)
+	read := func(t *testing.T, reader io.Reader) byte {
+		n, err := reader.Read(buf)
+		assert.Equal(t, n, 1)
+		assert.NoError(t, err)
+		return buf[0]
+	}
+
+	t.Run("rewinds", func(t *testing.T) {
+		reader := bytes.NewReader([]byte("AB"))
+		assert.Equal(t, byte('A'), read(t, reader))
+		assert.Equal(t, byte('B'), read(t, reader))
+		mustRewindToStart(reader)
+		assert.Equal(t, byte('A'), read(t, reader))
+	})
+
+	t.Run("panics-on-offset", func(t *testing.T) {
+		assert.PanicsWithError(t, "failed reverting read offset to start: offset was 1", func() {
+			mustRewindToStart(&failingSeeker{n: 1})
+		})
+	})
+
+	t.Run("panics-on-error", func(t *testing.T) {
+		assert.PanicsWithError(t, "failed reverting read offset to start: seek-failed", func() {
+			mustRewindToStart(&failingSeeker{err: fmt.Errorf("seek-failed")})
+		})
+	})
+
+	t.Run("no-panic-on-EOF", func(t *testing.T) {
+		mustRewindToStart(&failingSeeker{err: io.EOF})
+	})
+}
+
+type failingSeeker struct {
+	buf []byte
+	n   int
+	err error
+}
+
+func (f *failingSeeker) Read(data []byte) (int, error) {
+	if f.buf != nil {
+		defer func() { f.buf = nil }()
+		return copy(data, f.buf), nil
+	}
+	return f.n, f.err
+}
+func (f *failingSeeker) Seek(offset int64, whence int) (int64, error) { return int64(f.n), f.err }


### PR DESCRIPTION
This PR allows config files to be encoded with BOM (UTF8/UTF16) or in ISO-8859-1 8bit charset.

Found when testing in Windows, where UTF16 or ISO-8859-1 is more common and even UTF8 may get a BOM and fails.