### PR TITLE
Non-locking log appender and template func {{tempFile "filename"}} 

### DIFF
--- a/config/profile.go
+++ b/config/profile.go
@@ -2,14 +2,18 @@ package config
 
 import (
 	"fmt"
+	"path"
+	"path/filepath"
 	"reflect"
 	"sort"
+	"strings"
 	"time"
 
 	"github.com/Masterminds/semver/v3"
 	"github.com/creativeprojects/resticprofile/constants"
 	"github.com/creativeprojects/resticprofile/restic"
 	"github.com/creativeprojects/resticprofile/shell"
+	"github.com/creativeprojects/resticprofile/util"
 	"github.com/creativeprojects/resticprofile/util/bools"
 	"github.com/mitchellh/mapstructure"
 	"golang.org/x/exp/maps"
@@ -706,6 +710,12 @@ func (p *Profile) Schedules() []*ScheduleConfig {
 				ConfigFile:  p.config.configFile,
 			}
 
+			if len(config.Log) > 0 {
+				if tempDir, err := util.TempDir(); err == nil && strings.HasPrefix(config.Log, filepath.ToSlash(tempDir)) {
+					config.Log = path.Join(constants.TemporaryDirMarker, config.Log[len(tempDir):])
+				}
+			}
+
 			configs = append(configs, config)
 		}
 	}
@@ -726,9 +736,9 @@ func (p *Profile) GetRunShellCommandsSections(command string) (profileCommands R
 	return
 }
 
-func (p *Profile) GetMonitoringSections(command string) (monitoring *SendMonitoringSections) {
+func (p *Profile) GetMonitoringSections(command string) (monitoring SendMonitoringSections) {
 	if section, ok := GetSectionWith[Monitoring](p, command); ok {
-		monitoring = section.GetSendMonitoring()
+		monitoring = *section.GetSendMonitoring()
 	}
 	return
 }

--- a/constants/other.go
+++ b/constants/other.go
@@ -1,0 +1,5 @@
+package constants
+
+const (
+	TemporaryDirMarker = "temp:"
+)

--- a/docs/content/configuration/templates/index.md
+++ b/docs/content/configuration/templates/index.md
@@ -569,7 +569,7 @@ Please note there are some functions only made available by hugo though, resticp
 
 ## Template functions
 
-In addition to the defaults, resticprofile provides the following functions in all templates:
+resticprofile supports the following set of own functions in all templates:
 
 * `{{ "some old string" | replace "old" "new" }}` => `"some new string"`
 * `{{ "some old string" | regex "(old)" "$1 and new" }}` => `"some old and new string"`
@@ -581,5 +581,9 @@ In addition to the defaults, resticprofile provides the following functions in a
 * `{{ "A,B,C" | split "," }}` => `["A", "B", "C"]`
 * `{{ "A,B,C" | split "," | join ";" }}` => `"A;B;C"`
 * `{{ range $v := list "A" "B" "C" }} ({{ $v }}) {{ end }}` => ` (A)  (B)  (C) `
+* `{{ tempDir }}` => `"/tmp/resticprofile.../t"` - unique OS specific existing temporary directory
+* `{{ tempFile "filename" }}` => `"/tmp/resticprofile.../t/filename"` - unique OS specific existing temporary file
 
-Please refer to the official documentation for the set of default functions provided in go templates. 
+The temporary directory and files returned by the `{{ temp* }}` functions are guaranteed to exist, accessible and removed when resticprofile ends.
+
+Please refer to the official documentation for the set of additional default functions provided in go templates. 

--- a/docs/content/usage/_index.md
+++ b/docs/content/usage/_index.md
@@ -120,7 +120,11 @@ There are not many options on the command line, most of the options are in the c
 * **[--theme]**: Can be `light`, `dark` or `none`. The colours will adjust to a 
 light or dark terminal (none to disable colouring)
 * **[--lock-wait] duration**: Retry to acquire resticprofile and restic locks for up to the specified amount of time before failing on a lock failure. 
-* **[-l | --log] file path or url**: To write the logs to a file or a syslog server instead of displaying on the console. The format of the server url is `tcp://192.168.0.1:514` or `udp://localhost:514`
-* **[-w | --wait]**: Wait at the very end of the execution for the user to press enter. This is only useful in Windows when resticprofile is started from explorer and the console window closes automatically at the end.
+* **[-l | --log] file path or url**: To write the logs to a file or a syslog server instead of displaying on the console. 
+The format of the server url is `tcp://192.168.0.1:514` or `udp://localhost:514`.
+For custom log forwarding, the prefix `temp:` can be used (e.g. `temp:/t/msg.log`) to create unique log output that can be fed 
+into a command or http hook by referencing it with `{{ tempDir }}/...` or `{{ tempFile "msg.log" }}` in the configuration file.
+* **[-w | --wait]**: Wait at the very end of the execution for the user to press enter. 
+This is only useful in Windows when resticprofile is started from explorer and the console window closes automatically at the end.
 * **[resticprofile OR restic command]**: Like snapshots, backup, check, prune, forget, mount, etc.
 * **[additional flags]**: Any additional flags to pass to the restic command line

--- a/logger_test.go
+++ b/logger_test.go
@@ -1,0 +1,99 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/creativeprojects/clog"
+	"github.com/creativeprojects/resticprofile/constants"
+	"github.com/creativeprojects/resticprofile/term"
+	"github.com/creativeprojects/resticprofile/util"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func readTail(t *testing.T, filename string, count int) (lines []string) {
+	file, e := os.Open(filename)
+	require.NoError(t, e)
+	defer file.Close()
+	for s := bufio.NewScanner(file); s.Scan(); require.NoError(t, s.Err()) {
+		lines = append(lines, s.Text())
+	}
+	if len(lines) < count {
+		count = len(lines)
+	}
+	return lines[len(lines)-count:]
+}
+
+func TestFileHandlerWithTemporaryDirMarker(t *testing.T) {
+	util.ClearTempDir()
+	defer util.ClearTempDir()
+
+	logFile := filepath.Join(util.MustGetTempDir(), "sub", "file.log")
+	assert.NoFileExists(t, logFile)
+
+	handler, _, err := getFileHandler(commandLineFlags{
+		log: filepath.Join(constants.TemporaryDirMarker, "sub", "file.log"),
+	})
+	require.NoError(t, err)
+	assert.FileExists(t, logFile)
+
+	assert.NoError(t, handler.Close())
+	util.ClearTempDir()
+	assert.NoFileExists(t, logFile)
+}
+
+func TestFileHandler(t *testing.T) {
+	logFile := filepath.Join(t.TempDir(), "file.log")
+	handler, writer, err := getFileHandler(commandLineFlags{log: logFile})
+	require.NoError(t, err)
+	defer handler.Close()
+
+	require.Implements(t, (*term.Flusher)(nil), writer)
+	flusher := writer.(term.Flusher)
+
+	log := func(line string) {
+		assert.NoError(t, handler.LogEntry(clog.LogEntry{Level: clog.LevelInfo, Format: line}))
+	}
+
+	// output is accessible while handler is not closed
+	{
+		log("log-line-1")
+		assert.NoError(t, flusher.Flush())
+
+		lines := readTail(t, logFile, 1)
+		require.NotEmpty(t, lines)
+		assert.Regexp(t, `^.+\slog-line-1$`, lines[0])
+	}
+
+	// output is buffered
+	{
+		log("log-line-2")
+		assert.Regexp(t, `^.+\slog-line-1$`, readTail(t, logFile, 1)[0])
+
+		assert.NoError(t, flusher.Flush())
+		assert.Regexp(t, `^.+\slog-line-2$`, readTail(t, logFile, 1)[0])
+	}
+
+	// output is auto-flushed
+	{
+		log("log-line-3")
+		assert.Regexp(t, `^.+\slog-line-2$`, readTail(t, logFile, 1)[0])
+
+		time.Sleep(300 * time.Millisecond)
+		assert.Regexp(t, `^.+\slog-line-3$`, readTail(t, logFile, 1)[0])
+	}
+
+	// output is formatted as expected
+	{
+		lines := readTail(t, logFile, 10)
+		require.Len(t, lines, 3)
+		for i := 0; i < 3; i++ {
+			assert.Regexp(t, fmt.Sprintf(`^.+\slog-line-%d$`, i+1), lines[i])
+		}
+	}
+}

--- a/main.go
+++ b/main.go
@@ -22,6 +22,7 @@ import (
 	"github.com/creativeprojects/resticprofile/restic"
 	"github.com/creativeprojects/resticprofile/term"
 	"github.com/creativeprojects/resticprofile/util/bools"
+	"github.com/creativeprojects/resticprofile/util/shutdown"
 	"github.com/mackerelio/go-osstat/memory"
 	"github.com/spf13/pflag"
 )
@@ -48,6 +49,9 @@ func main() {
 			os.Exit(exitCode)
 		}
 	}()
+
+	// run shutdown hooks just before returning an exit code
+	defer shutdown.RunHooks()
 
 	flagset, flags, flagErr := loadFlags(os.Args[1:])
 	if flagErr != nil && flagErr != pflag.ErrHelp {

--- a/schedule/handler_darwin_test.go
+++ b/schedule/handler_darwin_test.go
@@ -4,10 +4,12 @@ package schedule
 
 import (
 	"bytes"
+	"path"
 	"testing"
 
 	"github.com/creativeprojects/resticprofile/calendar"
 	"github.com/creativeprojects/resticprofile/config"
+	"github.com/creativeprojects/resticprofile/constants"
 	"github.com/spf13/afero"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -130,23 +132,32 @@ func TestLaunchdJobLog(t *testing.T) {
 	fixtures := []struct {
 		log      string
 		expected string
+		noLogArg bool
 	}{
-		{"", "local.resticprofile.profile.backup.log"},
-		{"udp://localhost:123", "local.resticprofile.profile.backup.log"},
-		{"tcp://127.0.0.1:123", "local.resticprofile.profile.backup.log"},
-		{"other file", "other file"},
+		{log: path.Join(constants.TemporaryDirMarker, "file"), expected: "local.resticprofile.profile.backup.log"},
+		{log: "", expected: "local.resticprofile.profile.backup.log", noLogArg: true},
+		{log: "udp://localhost:123", expected: "local.resticprofile.profile.backup.log"},
+		{log: "tcp://127.0.0.1:123", expected: "local.resticprofile.profile.backup.log"},
+		{log: "other file", expected: "other file", noLogArg: true},
 	}
 
 	for _, fixture := range fixtures {
 		t.Run(fixture.log, func(t *testing.T) {
 			handler := NewHandler(SchedulerLaunchd{})
+			args := []string{"--log", fixture.log}
 			cfg := &config.ScheduleConfig{
-				Title:    "profile",
-				SubTitle: "backup",
-				Log:      fixture.log,
+				Title:     "profile",
+				SubTitle:  "backup",
+				Log:       fixture.log,
+				Arguments: args,
 			}
 			launchdJob := handler.getLaunchdJob(cfg, []*calendar.Event{})
 			assert.Equal(t, fixture.expected, launchdJob.StandardOutPath)
+			if fixture.noLogArg {
+				assert.NotSubset(t, launchdJob.ProgramArguments, args)
+			} else {
+				assert.Subset(t, launchdJob.ProgramArguments, args)
+			}
 		})
 	}
 }

--- a/schedule_jobs.go
+++ b/schedule_jobs.go
@@ -8,8 +8,6 @@ import (
 	"github.com/creativeprojects/clog"
 	"github.com/creativeprojects/resticprofile/config"
 	"github.com/creativeprojects/resticprofile/constants"
-	"github.com/creativeprojects/resticprofile/dial"
-	"github.com/creativeprojects/resticprofile/platform"
 	"github.com/creativeprojects/resticprofile/schedule"
 )
 
@@ -40,11 +38,7 @@ func scheduleJobs(handler schedule.Handler, profileName string, configs []*confi
 		}
 
 		if scheduleConfig.Log != "" {
-			// On darwin, we only use --log for url target
-			// On the other platforms, we send any target to --log
-			if !platform.IsDarwin() || dial.IsURL(scheduleConfig.Log) {
-				args = append(args, "--log", scheduleConfig.Log)
-			}
+			args = append(args, "--log", scheduleConfig.Log)
 		}
 
 		if scheduleConfig.GetLockMode() == config.ScheduleLockModeDefault {

--- a/schedule_jobs_test.go
+++ b/schedule_jobs_test.go
@@ -41,19 +41,14 @@ func TestArgumentsOnScheduleJobNoLog(t *testing.T) {
 
 func TestArgumentsOnScheduleJobLogFile(t *testing.T) {
 	handler := getMockHandler(t)
-	handler.On("CreateJob",
+	handler.EXPECT().CreateJob(
 		mock.AnythingOfType("*config.ScheduleConfig"),
 		mock.AnythingOfType("[]*calendar.Event"),
 		mock.AnythingOfType("string")).
-		Return(func(scheduleConfig *config.ScheduleConfig, events []*calendar.Event, permission string) error {
-			if platform.IsDarwin() {
-				// on mac os, we use the launchd output redirection
-				assert.Equal(t, []string{"--no-ansi", "--config", "", "--name", "profile", "backup"}, scheduleConfig.Arguments)
-			} else {
-				assert.Equal(t, []string{"--no-ansi", "--config", "", "--name", "profile", "--log", "/path/to/file", "backup"}, scheduleConfig.Arguments)
-			}
-			return nil
-		})
+		Run(func(scheduleConfig *config.ScheduleConfig, events []*calendar.Event, permission string) {
+			assert.Equal(t, []string{"--no-ansi", "--config", "", "--name", "profile", "--log", "/path/to/file", "backup"}, scheduleConfig.Arguments)
+		}).
+		Return(nil)
 
 	scheduleConfig := &config.ScheduleConfig{
 		Title:    "profile",

--- a/util/shutdown/hook.go
+++ b/util/shutdown/hook.go
@@ -1,0 +1,52 @@
+package shutdown
+
+import (
+	"sync"
+
+	"golang.org/x/exp/slices"
+)
+
+var (
+	lock  sync.Mutex
+	hooks []hookFunc
+)
+
+type hookFunc struct {
+	fn   func()
+	tags []string
+}
+
+// AddHook add a func to run when RunHooks is invoked. Hooks are run in FIFO order
+func AddHook(hook func(), tag ...string) {
+	if hook != nil {
+		lock.Lock()
+		defer lock.Unlock()
+
+		hooks = append(hooks, hookFunc{fn: hook, tags: append([]string{}, tag...)})
+	}
+}
+
+// ContainsHook returns true if a hook with the specified hook tag was added
+func ContainsHook(tag ...string) bool {
+	lock.Lock()
+	defer lock.Unlock()
+
+	return slices.ContainsFunc(hooks, func(fn hookFunc) bool {
+		return slices.Equal(fn.tags, tag)
+	})
+}
+
+// RunHooks runs all hooks and clears the hooks list
+func RunHooks() {
+	lock.Lock()
+	defer lock.Unlock()
+
+	runHook := func(hook func()) { hook() }
+
+	// Running hooks with defer to ensure all are started even if one panics
+	// Hooks are started in FIFO order but defer is LIFO, reverse for loop is needed
+	for i := len(hooks); i > 0; i-- {
+		defer runHook(hooks[i-1].fn)
+	}
+	hooks = nil
+}

--- a/util/shutdown/hook_test.go
+++ b/util/shutdown/hook_test.go
@@ -1,0 +1,63 @@
+package shutdown
+
+import (
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestAddAndRunInOrder(t *testing.T) {
+	n := 2
+	AddHook(func() { n += 5 })
+	AddHook(func() { n *= 10 })
+	AddHook(nil)
+	AddHook(func() { n += 2 })
+	AddHook(func() { n *= 2 })
+
+	for i := 0; i < 3; i++ {
+		RunHooks()
+		assert.Equal(t, 144, n)
+	}
+	assert.Empty(t, hooks)
+}
+
+func TestCanPanicAndRunOthers(t *testing.T) {
+	n := 0
+	AddHook(func() { n += 1 })
+	AddHook(func() { panic(nil) })
+	AddHook(func() { n += 1 })
+
+	assert.Panics(t, RunHooks)
+	assert.Equal(t, 2, n)
+	assert.Empty(t, hooks)
+}
+
+func TestContainsHook(t *testing.T) {
+	f0 := func() {}
+	f1 := func() {}
+	f2 := func() {}
+
+	t.Run("empty-tag", func(t *testing.T) {
+		RunHooks()
+		assert.False(t, ContainsHook())
+		AddHook(f0)
+		assert.True(t, ContainsHook())
+	})
+
+	t.Run("tagged-hook", func(t *testing.T) {
+		RunHooks()
+		AddHook(f1, "f1", "extra")
+		AddHook(f2, "f2")
+		assert.False(t, ContainsHook("f1"))
+		assert.True(t, ContainsHook("f1", "extra"))
+		assert.True(t, ContainsHook("f2"))
+	})
+
+	t.Run("re-tagged-hook", func(t *testing.T) {
+		RunHooks()
+		tags := []string{"f1", "extra"}
+		AddHook(f1, tags...)
+		assert.True(t, ContainsHook(tags...))
+		tags[0] = "f2"
+		assert.False(t, ContainsHook(tags...))
+	})
+}

--- a/util/tempdir.go
+++ b/util/tempdir.go
@@ -1,0 +1,88 @@
+package util
+
+import (
+	"fmt"
+	"os"
+	"sync"
+
+	"github.com/creativeprojects/clog"
+	"github.com/creativeprojects/resticprofile/util/shutdown"
+)
+
+var (
+	tempDirInitializer sync.Once
+	tempDir            string
+	tempDirErr         error
+)
+
+const (
+	tempDirPattern = "resticprofile*"
+	tempDirHookTag = "tempDir-cleanup-hook"
+)
+
+// TempDir returns the path to a temporary directory that is stable within the same process and cleaned when shutdown.RunHooks is invoked
+func TempDir() (string, error) {
+	tempDirInitializer.Do(func() {
+		tempDir, tempDirErr = createTempDir("")
+
+		if !shutdown.ContainsHook(tempDirHookTag) {
+			shutdown.AddHook(func() {
+				removeTempDir(tempDir, tempDirErr)
+				tempDir = ""
+				tempDirErr = fmt.Errorf("illegal state: temp directory has been removed")
+			}, tempDirHookTag)
+		}
+	})
+
+	return tempDir, tempDirErr
+}
+
+// MustGetTempDir returns the dir from TempDir or panics if an error occurred
+func MustGetTempDir() string {
+	if dir, err := TempDir(); err == nil {
+		return dir
+	} else {
+		panic(err)
+	}
+}
+
+// ClearTempDir removes the temporary directory (if present) and resets the state.
+// This is not safe for concurrent use and is meant for cleanup in unit tests only.
+func ClearTempDir() {
+	removeTempDir(tempDir, tempDirErr)
+	tempDir = ""
+	tempDirErr = nil
+	tempDirInitializer = sync.Once{}
+}
+
+func createTempDir(path string) (tempDir string, tempDirErr error) {
+	if temp, tempErr := os.MkdirTemp(path, tempDirPattern); tempErr == nil {
+		tempDir = temp
+	} else {
+		cacheDir, err := os.UserCacheDir()
+		if err == nil {
+			if temp, err = os.MkdirTemp(cacheDir, tempDirPattern); err == nil {
+				tempDir = temp
+			}
+		}
+		if err != nil {
+			clog.Errorf("failed creating temp dir in temp: %q and cache: %q", tempErr.Error(), err.Error())
+			tempDirErr = err
+		}
+	}
+
+	if len(tempDir) > 0 {
+		clog.Tracef("temporary directory created: %s", tempDir)
+	}
+	return
+}
+
+func removeTempDir(tempDir string, tempDirErr error) {
+	if len(tempDir) > 0 && tempDirErr == nil {
+		tempDirErr = os.RemoveAll(tempDir)
+		if tempDirErr != nil {
+			clog.Warningf("failed removing temporary directory %q: %s", tempDir, tempDirErr.Error())
+		}
+	}
+	return
+}

--- a/util/tempdir_test.go
+++ b/util/tempdir_test.go
@@ -1,0 +1,101 @@
+package util
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/creativeprojects/resticprofile/util/shutdown"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCreateTempDir(t *testing.T) {
+	tempDirPrefix := tempDirPattern[:len(tempDirPattern)-1]
+
+	t.Run("create-os.TempDir", func(t *testing.T) {
+		dir, err := createTempDir("")
+		defer removeTempDir(dir, err)
+
+		assert.NoError(t, err)
+		assert.Equal(t, filepath.Clean(os.TempDir()), filepath.Dir(dir))
+		assert.True(t, strings.HasPrefix(filepath.Base(dir), tempDirPrefix))
+		assert.NotEqual(t, filepath.Base(dir), tempDirPrefix)
+	})
+
+	t.Run("create-UserCacheDir-fallback", func(t *testing.T) {
+		dir, err := createTempDir("non-existing-path")
+		defer removeTempDir(dir, err)
+		assert.NoError(t, err)
+
+		cdir, err := os.UserCacheDir()
+		require.NoError(t, err)
+
+		assert.Equal(t, filepath.Clean(cdir), filepath.Dir(dir))
+		assert.True(t, strings.HasPrefix(filepath.Base(dir), tempDirPrefix))
+		assert.NotEqual(t, filepath.Base(dir), tempDirPrefix)
+	})
+}
+
+func TestRemoveTempDir(t *testing.T) {
+	dir, err := createTempDir("")
+	defer removeTempDir(dir, err)
+
+	assert.NoError(t, err)
+	assert.DirExists(t, dir)
+
+	removeTempDir(dir, err)
+	assert.NoDirExists(t, dir)
+
+	removeTempDir(dir, err)
+	assert.NoDirExists(t, dir)
+
+	removeTempDir("", err)
+}
+
+func TestTempDir(t *testing.T) {
+	defer ClearTempDir()
+
+	t.Run("stable-get", func(t *testing.T) {
+		ClearTempDir()
+		dir := MustGetTempDir()
+		dir2 := MustGetTempDir()
+
+		assert.DirExists(t, dir)
+		assert.Equal(t, dir, dir2)
+	})
+
+	t.Run("can-clear", func(t *testing.T) {
+		ClearTempDir()
+		dir := MustGetTempDir()
+		assert.NoError(t, os.WriteFile(filepath.Join(dir, "test.file"), []byte("data"), 0700))
+
+		ClearTempDir()
+		dir2 := MustGetTempDir()
+
+		assert.NotEqual(t, dir, dir2)
+		assert.NoDirExists(t, dir)
+		assert.DirExists(t, dir2)
+	})
+
+	t.Run("cleared-on-shutdown", func(t *testing.T) {
+		ClearTempDir()
+		dir := MustGetTempDir()
+		assert.DirExists(t, dir)
+
+		shutdown.RunHooks()
+		assert.NoDirExists(t, dir)
+
+		dir, err := TempDir()
+		assert.Empty(t, dir)
+		assert.ErrorContains(t, err, "illegal state: temp directory has been removed")
+
+		ClearTempDir()
+		dir = MustGetTempDir()
+		assert.DirExists(t, dir)
+
+		shutdown.RunHooks()
+		assert.NoDirExists(t, dir)
+	})
+}


### PR DESCRIPTION
*PR for*: 
- #168 

**Implements**:
* Log output on Windows uses CRLF
* Non-locking log appender (to support read while writing on a locking FS)
* Log output is flushed just before calling hooks
* Template functions for temp files (and dir) to be used in config files
* Temp files are guaranteed to exist and are writable by the user running resticprofile
* TempDir util func for a temp dir that is auto-removed when resticprofile ends
* Temp dir support for the log flag and the `schedule-log` config

**Example**:

```yaml
global:
  shell: powershell

default:
  repository: "local:test-repo"
  ...
  run-finally:
    - gc "{{ tempFile "rp-run.log" }}" > ".\resticprofile-last.log"
  backup:
    schedule: hourly
    schedule-log: '{{ tempFile "rp-run.log" }}'
```

Use with schedule
```shell
resticprofile schedule backup
```

Test via CLI
```shell
resticprofile --log "temp:/t/rp-run.log" backup
```