### PR TITLE
Enhanced: Catch any --help & --dry-run (http only)

### DIFF
--- a/commands.go
+++ b/commands.go
@@ -184,12 +184,7 @@ func isOwnCommand(command string, configurationLoaded bool) bool {
 func runOwnCommand(configuration *config.Config, commandName string, flags commandLineFlags, args []string) error {
 	for _, command := range ownCommands {
 		if command.name == commandName {
-			if help := slices.Contains(args, "--help") || slices.Contains(args, "-h"); help && !command.hide {
-				args = append([]string{command.name}, args...)
-				return displayHelpCommand(os.Stdout, configuration, flags, args)
-			} else {
-				return command.action(os.Stdout, configuration, flags, args)
-			}
+			return command.action(os.Stdout, configuration, flags, args)
 		}
 	}
 	return fmt.Errorf("command not found: %v", commandName)

--- a/commands_display.go
+++ b/commands_display.go
@@ -227,7 +227,7 @@ func displayResticHelp(output io.Writer, configuration *config.Config, flags com
 	}
 }
 
-func displayHelpCommand(output io.Writer, configuration *config.Config, flags commandLineFlags, args []string) error {
+func displayHelpCommand(output io.Writer, configuration *config.Config, flags commandLineFlags, _ []string) error {
 	out, closer := displayWriter(output, flags)
 	defer closer()
 
@@ -236,11 +236,11 @@ func displayHelpCommand(output io.Writer, configuration *config.Config, flags co
 	}
 
 	validCommandName := regexp.MustCompile(`^\w{2,}[-\w]*$`).MatchString
+	notHelp := collect.Not(collect.In("help"))
 
-	helpForCommand := collect.First(args, validCommandName)
+	helpForCommand := collect.First(flags.resticArgs, collect.With(validCommandName, notHelp))
 	if helpForCommand == nil {
-		commandArgs := collect.All(flags.resticArgs, collect.Not(collect.In("help")))
-		helpForCommand = collect.First(commandArgs, validCommandName)
+		helpForCommand = collect.First(flags.resticArgs, validCommandName)
 	}
 
 	if helpForCommand == nil {

--- a/flags.go
+++ b/flags.go
@@ -8,7 +8,9 @@ import (
 	"github.com/creativeprojects/resticprofile/constants"
 	"github.com/creativeprojects/resticprofile/platform"
 	"github.com/creativeprojects/resticprofile/term"
+	"github.com/creativeprojects/resticprofile/util/collect"
 	"github.com/spf13/pflag"
+	"golang.org/x/exp/slices"
 )
 
 type commandLineFlags struct {
@@ -95,6 +97,11 @@ func loadFlags(args []string) (*pflag.FlagSet, commandLineFlags, error) {
 	// if there are no further arguments, no further parsing is needed
 	if len(flags.resticArgs) == 0 {
 		return flagset, flags, err
+	}
+
+	// handle explicit help request in command args (works with restic and own commands)
+	if slices.ContainsFunc(flags.resticArgs, collect.In("--help", "-h")) {
+		flags.help = true
 	}
 
 	// parse first postitional argument as <profile>.<command> if the profile was not set via name

--- a/util/collect/collect.go
+++ b/util/collect/collect.go
@@ -24,6 +24,18 @@ func In[E comparable](values ...E) (condition func(item E) bool) {
 	return func(item E) bool { return slices.Contains(values, item) }
 }
 
+// With returns a new condition that is true when all conditions match
+func With[C ~func(t T) bool, T any](conditions ...C) (condition C) {
+	return func(item T) bool {
+		for _, c := range conditions {
+			if !c(item) {
+				return false
+			}
+		}
+		return true
+	}
+}
+
 // From translates a slice into another using a mapper func (T) => (R).
 // Empty or nil input returns nil output
 func From[I ~[]T, T, R any](input I, mapper func(t T) R) (output []R) {

--- a/util/collect/collect.go
+++ b/util/collect/collect.go
@@ -1,5 +1,7 @@
 package collect
 
+import "golang.org/x/exp/slices"
+
 // All collects all items from input that satisfy the condition
 // Empty or nil input returns nil output
 func All[I ~[]T, T any](input I, condition func(t T) bool) (output []T) {
@@ -15,6 +17,11 @@ func All[I ~[]T, T any](input I, condition func(t T) bool) (output []T) {
 func Not[T any, C func(t T) bool](condition C) C {
 	not := func(t T) bool { return !condition(t) }
 	return not
+}
+
+// In returns a new condition that is true as one of the values matches
+func In[E comparable](values ...E) (condition func(item E) bool) {
+	return func(item E) bool { return slices.Contains(values, item) }
 }
 
 // From translates a slice into another using a mapper func (T) => (R).

--- a/util/collect/collect_test.go
+++ b/util/collect/collect_test.go
@@ -36,6 +36,16 @@ func TestIn(t *testing.T) {
 	assert.True(t, isIn("c"))
 }
 
+func TestWith(t *testing.T) {
+	isIn := With(Not(In("a", "c")), In("a", "b", "c"))
+	assert.False(t, isIn(""))
+	assert.False(t, isIn("d"))
+	assert.False(t, isIn("A"))
+	assert.False(t, isIn("a"))
+	assert.True(t, isIn("b"))
+	assert.False(t, isIn("c"))
+}
+
 func TestFrom(t *testing.T) {
 	input := []string{"1", "2", "3"}
 	expected := []int{1, 2, 3}

--- a/util/collect/collect_test.go
+++ b/util/collect/collect_test.go
@@ -26,6 +26,16 @@ func TestAll(t *testing.T) {
 	assert.Nil(t, All([]int{3}, even))
 }
 
+func TestIn(t *testing.T) {
+	isIn := In("a", "b", "c")
+	assert.False(t, isIn(""))
+	assert.False(t, isIn("d"))
+	assert.False(t, isIn("A"))
+	assert.True(t, isIn("a"))
+	assert.True(t, isIn("b"))
+	assert.True(t, isIn("c"))
+}
+
 func TestFrom(t *testing.T) {
 	input := []string{"1", "2", "3"}
 	expected := []int{1, 2, 3}

--- a/wrapper.go
+++ b/wrapper.go
@@ -59,6 +59,9 @@ func newResticWrapper(
 	if global == nil {
 		global = config.NewGlobal()
 	}
+
+	senderDryRun := dryRun || slices.ContainsFunc(moreArgs, collect.In("--dry-run", "-n"))
+
 	return &resticWrapper{
 		resticBinary:  resticBinary,
 		dryRun:        dryRun,
@@ -71,7 +74,7 @@ func newResticWrapper(
 		sigChan:       c,
 		stdin:         os.Stdin,
 		progress:      make([]monitor.Receiver, 0),
-		sender:        hook.NewSender(global.CACertificates, "resticprofile/"+version, global.SenderTimeout, dryRun),
+		sender:        hook.NewSender(global.CACertificates, "resticprofile/"+version, global.SenderTimeout, senderDryRun),
 		startTime:     time.Unix(0, 0),
 		executionTime: 0,
 		doneTryUnlock: false,
@@ -319,7 +322,7 @@ func (r *resticWrapper) validArgumentsFilter(validArgs []string) argumentsFilter
 
 func (r *resticWrapper) getShell() (shell []string) {
 	if r.global != nil {
-		shell = collect.All(r.global.ShellBinary, func(s string) bool { return s != "auto" })
+		shell = collect.All(r.global.ShellBinary, collect.Not(collect.In("auto")))
 	}
 	return
 }


### PR DESCRIPTION
Small followup on #157:

* Consider command args `--dry-run` and `-n` to enable dry-run in http hook
* Catch any `--help` and `-h` arg (no matter at what position it was specified)

E.g. dry-run for http hook is triggered in all of the following cases: 

```shell
# dry-run for resticprofile
resticprofile --dry-run backup

# dry-run for restic
resticprofile backup --dry-run
resticprofile backup -n
```

All of the following cases redirect to resticprofile's help command:

```shell
resticprofile --help backup
resticprofile -h backup
resticprofile help backup
resticprofile backup --help
resticprofile backup -h
```
