### PR TITLE
Add variables `.OS` and `.Arch` to all templates

### DIFF
--- a/monitor/hook/context.go
+++ b/monitor/hook/context.go
@@ -1,6 +1,9 @@
 package hook
 
+import "github.com/creativeprojects/resticprofile/util/templates"
+
 type Context struct {
+	templates.DefaultData
 	ProfileName    string
 	ProfileCommand string
 	Error          ErrorContext

--- a/monitor/hook/sender.go
+++ b/monitor/hook/sender.go
@@ -9,15 +9,16 @@ import (
 	"io"
 	"net/http"
 	"os"
+	"path/filepath"
 	"regexp"
 	"strings"
 	"text/tabwriter"
-	"text/template"
 	"time"
 
 	"github.com/creativeprojects/clog"
 	"github.com/creativeprojects/resticprofile/config"
 	"github.com/creativeprojects/resticprofile/constants"
+	"github.com/creativeprojects/resticprofile/util/templates"
 )
 
 type Sender struct {
@@ -216,10 +217,11 @@ func resolve(body string, ctx Context) string {
 }
 
 func loadBodyTemplate(filename string, ctx Context) (string, error) {
-	tmpl, err := template.ParseFiles(filename)
+	tmpl, err := templates.New(filepath.Base(filename)).ParseFiles(filename)
 	if err != nil {
 		return "", err
 	}
+	ctx.InitDefaults()
 	buffer := &bytes.Buffer{}
 	err = tmpl.Execute(buffer, ctx)
 	if err != nil {

--- a/systemd/generate.go
+++ b/systemd/generate.go
@@ -64,6 +64,7 @@ var (
 
 // templateInfo to create systemd unit
 type templateInfo struct {
+	templates.DefaultData
 	JobDescription   string
 	TimerDescription string
 	WorkingDirectory string
@@ -123,6 +124,7 @@ func Generate(config Config) error {
 	}
 
 	info := templateInfo{
+		DefaultData:      templates.NewDefaultData(nil),
 		JobDescription:   config.JobDescription,
 		TimerDescription: config.TimerDescription,
 		WorkingDirectory: config.WorkingDirectory,

--- a/util/templates/data.go
+++ b/util/templates/data.go
@@ -1,0 +1,76 @@
+package templates
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"time"
+)
+
+// DefaultData provides default variables for templates
+type DefaultData struct {
+	Now        time.Time
+	CurrentDir string
+	TempDir    string
+	BinaryDir  string
+	Hostname   string
+	OS         string
+	Arch       string
+	Env        map[string]string
+}
+
+// InitDefaults initializes DefaultData if not yet initialized
+func (d *DefaultData) InitDefaults() {
+	if d.Now.IsZero() {
+		*d = NewDefaultData(nil)
+	}
+}
+
+// NewDefaultData returns an initialized DefaultData
+func NewDefaultData(env map[string]string) (data DefaultData) {
+	data = DefaultData{
+		Now:      time.Now(),
+		TempDir:  filepath.ToSlash(os.TempDir()),
+		OS:       runtime.GOOS,
+		Arch:     runtime.GOARCH,
+		Hostname: "localhost",
+		Env:      formatEnv(env),
+	}
+
+	if cwd, err := os.Getwd(); err == nil {
+		data.CurrentDir = filepath.ToSlash(cwd)
+	}
+
+	if binary, err := os.Executable(); err == nil {
+		data.BinaryDir = filepath.ToSlash(filepath.Dir(binary))
+	}
+
+	if hostname, err := os.Hostname(); err == nil {
+		data.Hostname = hostname
+	}
+
+	for _, envValue := range os.Environ() {
+		kv := strings.SplitN(envValue, "=", 2)
+		key, value := strings.ToUpper(strings.TrimSpace(kv[0])), kv[1]
+		if _, contains := data.Env[key]; !contains && key != "" {
+			data.Env[key] = value
+		}
+	}
+
+	return data
+}
+
+func formatEnv(env map[string]string) map[string]string {
+	if env == nil {
+		env = make(map[string]string)
+	} else {
+		for name, v := range env {
+			if un := strings.ToUpper(name); un != name {
+				delete(env, name)
+				env[un] = v
+			}
+		}
+	}
+	return env
+}

--- a/util/templates/data_test.go
+++ b/util/templates/data_test.go
@@ -1,0 +1,79 @@
+package templates
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/creativeprojects/resticprofile/util/collect"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestBinaryDir(t *testing.T) {
+	binary, err := os.Executable()
+	require.NoError(t, err)
+	binaryDir := filepath.ToSlash(filepath.Dir(binary))
+	assert.Equal(t, binaryDir, NewDefaultData(nil).BinaryDir)
+}
+
+func TestCurrentDir(t *testing.T) {
+	dir, err := os.Getwd()
+	require.NoError(t, err)
+	assert.Equal(t, filepath.ToSlash(dir), NewDefaultData(nil).CurrentDir)
+}
+
+func TestTempDir(t *testing.T) {
+	assert.Equal(t, filepath.ToSlash(os.TempDir()), NewDefaultData(nil).TempDir)
+}
+
+func TestHostname(t *testing.T) {
+	hostname, err := os.Hostname()
+	require.NoError(t, err)
+	assert.Equal(t, hostname, NewDefaultData(nil).Hostname)
+}
+
+func TestTime(t *testing.T) {
+	assert.Equal(t, time.Now().Truncate(time.Second), NewDefaultData(nil).Now.Truncate(time.Second))
+}
+
+func TestEmptyInit(t *testing.T) {
+	var data DefaultData
+
+	now := time.Now().Truncate(time.Second)
+	assert.NotEqual(t, now, data.Now.Truncate(time.Second))
+
+	data.InitDefaults()
+	assert.Equal(t, now, data.Now.Truncate(time.Second))
+}
+
+func TestOsAndArch(t *testing.T) {
+	assert.Equal(t, runtime.GOOS, NewDefaultData(nil).OS)
+	assert.Equal(t, runtime.GOARCH, NewDefaultData(nil).Arch)
+}
+
+func TestEnv(t *testing.T) {
+	osEnvKeys := collect.From(os.Environ(), func(s string) string {
+		return strings.SplitN(s, "=", 2)[0]
+	})
+
+	customEnv := map[string]string{
+		"path":      "my-test-path",
+		"__test_k1": "v1",
+		"__TEST_K2": "v2",
+	}
+
+	env := NewDefaultData(customEnv).Env
+
+	for _, key := range osEnvKeys {
+		if key != "" && key != "PATH" {
+			assert.Equal(t, os.Getenv(key), env[strings.ToUpper(key)], "key = %s", key)
+		}
+	}
+	for key := range customEnv {
+		assert.Equal(t, customEnv[key], env[strings.ToUpper(key)], "key = %s", key)
+	}
+}


### PR DESCRIPTION
Small PR to add GOOS (`{{ .OS }}`) and GOARCH (`{{ .Arch }}`) to all templates. Also refactored template default data to allow reuse across template data structs.

The primary purpose for this is to allow the creation of reusable configuration, e.g. OS (and/or ARCH) specific `parents`, `mixins` or `includes` where the variables can be used to select what works in a certain context.