### PR TITLE
Build option to disable self update

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -89,6 +89,10 @@ build: prepare
 	@echo "[*] $@"
 	$(GOBUILD) -o $(BINARY) -v -ldflags "-X 'main.commit=${BUILD_COMMIT}' -X 'main.date=${BUILD_DATE}' -X 'main.builtBy=make'"
 
+build-no-selfupdate: prepare
+	@echo "[*] $@"
+	$(GOBUILD) -o $(BINARY) -v -tags no_self_update -ldflags "-X 'main.commit=${BUILD_COMMIT}' -X 'main.date=${BUILD_DATE}' -X 'main.builtBy=make'"
+
 build-mac: prepare
 	@echo "[*] $@"
 	GOOS="darwin" GOARCH="amd64" $(GOBUILD) -o $(BINARY_DARWIN) -v -ldflags "-X 'main.commit=${BUILD_COMMIT}' -X 'main.date=${BUILD_DATE}' -X 'main.builtBy=make'"

--- a/complete.go
+++ b/complete.go
@@ -30,7 +30,7 @@ type Completer struct {
 	enableProfilePrefixes bool
 }
 
-func (c *Completer) init(args []string) {
+func (c *Completer) init(args []string, ownCommands []ownCommand) {
 	var initArgs []string
 	nameFlagFound := false
 	nameFlagMatcher := regexp.MustCompile("^-{1,2}(n|name)(=.*|$)")
@@ -46,7 +46,7 @@ func (c *Completer) init(args []string) {
 
 	c.flags, _, _ = loadFlags(initArgs)
 	c.flagsInArgs = nil
-	c.ownCommands = getOwnCommands()
+	c.ownCommands = ownCommands
 	c.profiles = nil
 	c.enableProfilePrefixes = !nameFlagFound
 }
@@ -258,7 +258,7 @@ func (c *Completer) isOwnCommand(command string, configurationLoaded bool) bool 
 // To get completions for a specific element use "__POS:{FOLLOWING-ARG-INDEX}" in args.
 func (c *Completer) Complete(args []string) (completions []string) {
 	args = append([]string{}, args...)
-	c.init(args)
+	c.init(args, c.ownCommands)
 
 	lookupFlag := func(word string) (flag *pflag.Flag) {
 		if strings.HasPrefix(word, "-") {

--- a/complete_test.go
+++ b/complete_test.go
@@ -13,7 +13,7 @@ import (
 
 func TestCompleter(t *testing.T) {
 	completer := &Completer{}
-	completer.init(nil)
+	completer.init(nil, ownCommands.All())
 
 	expectedProfiles := func() []string {
 		return []string{"default", "full-backup", "linux", "no-cache", "root", "src", "stdin"}
@@ -168,7 +168,7 @@ func TestCompleter(t *testing.T) {
 
 			t.Run("CommandsWithProfile", func(t *testing.T) {
 				var commands []string
-				for _, command := range getOwnCommands() {
+				for _, command := range ownCommands.All() {
 					if command.needConfiguration && !command.hide && !command.hideInCompletion {
 						commands = append(commands, command.name)
 					}
@@ -198,7 +198,7 @@ func TestCompleter(t *testing.T) {
 		var commands []string
 		commandValues := map[string][]string{}
 
-		for _, command := range getOwnCommands() {
+		for _, command := range ownCommands.All() {
 			if !command.hide && !command.hideInCompletion {
 				commands = append(commands, command.name)
 			}

--- a/flags.go
+++ b/flags.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"os"
 	"strings"
 	"time"
 
@@ -43,10 +42,6 @@ func loadFlags(args []string) (*pflag.FlagSet, commandLineFlags, error) {
 
 	flags := commandLineFlags{}
 
-	flagset.Usage = func() {
-		_ = displayHelpCommand(os.Stdout, nil, flags, args)
-	}
-
 	flagset.BoolVarP(&flags.help, "help", "h", false, "display this help")
 	flagset.BoolVarP(&flags.quiet, "quiet", "q", constants.DefaultQuietFlag, "display only warnings and errors")
 	flagset.BoolVarP(&flags.verbose, "verbose", "v", constants.DefaultVerboseFlag, "display some debugging information")
@@ -75,10 +70,6 @@ func loadFlags(args []string) (*pflag.FlagSet, commandLineFlags, error) {
 		_ = flagset.MarkHidden(constants.FlagPort)
 	}
 
-	// Deprecated since 0.7.0
-	flagset.BoolVar(&flags.selfUpdate, "self-update", false, "auto update of resticprofile (does not update restic)")
-	_ = flagset.MarkHidden("self-update")
-
 	// stop at the first non flag found; the rest will be sent to the restic command line
 	flagset.SetInterspersed(false)
 
@@ -104,7 +95,7 @@ func loadFlags(args []string) (*pflag.FlagSet, commandLineFlags, error) {
 		flags.help = true
 	}
 
-	// parse first postitional argument as <profile>.<command> if the profile was not set via name
+	// parse first positional argument as <profile>.<command> if the profile was not set via name
 	nameFlag := flagset.Lookup("name")
 	if (nameFlag == nil || !nameFlag.Changed) && strings.Contains(flags.resticArgs[0], ".") {
 		// split first argument at `.`

--- a/flags_test.go
+++ b/flags_test.go
@@ -3,9 +3,9 @@ package main
 import (
 	"testing"
 
+	"github.com/creativeprojects/resticprofile/constants"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"github.com/creativeprojects/resticprofile/constants"
 )
 
 func TestUnknownShortFlag(t *testing.T) {

--- a/own_commands.go
+++ b/own_commands.go
@@ -1,0 +1,70 @@
+package main
+
+import (
+	"fmt"
+	"io"
+	"os"
+
+	"github.com/creativeprojects/resticprofile/config"
+)
+
+type commandRequest struct {
+	ownCommands *OwnCommands
+	config      *config.Config
+	flags       commandLineFlags
+	args        []string
+}
+
+type ownCommand struct {
+	name              string
+	description       string
+	longDescription   string
+	action            func(io.Writer, commandRequest) error
+	needConfiguration bool              // true if the action needs a configuration file loaded
+	hide              bool              // don't display the command in help and completion
+	hideInCompletion  bool              // don't display the command in completion
+	flags             map[string]string // own command flags should be simple enough to be handled manually for now
+}
+
+type OwnCommands struct {
+	commands []ownCommand
+}
+
+func NewOwnCommands() *OwnCommands {
+	return &OwnCommands{
+		commands: make([]ownCommand, 0, 20),
+	}
+}
+
+func (o *OwnCommands) Register(commands []ownCommand) {
+	o.commands = append(o.commands, commands...)
+}
+
+func (o *OwnCommands) Exists(command string, configurationLoaded bool) bool {
+	for _, commandDef := range o.commands {
+		if commandDef.name == command && commandDef.needConfiguration == configurationLoaded {
+			return true
+		}
+	}
+	return false
+}
+
+func (o *OwnCommands) All() []ownCommand {
+	ownCommands := make([]ownCommand, len(o.commands))
+	copy(ownCommands, o.commands)
+	return ownCommands
+}
+
+func (o *OwnCommands) Run(configuration *config.Config, commandName string, flags commandLineFlags, args []string) error {
+	for _, command := range o.commands {
+		if command.name == commandName {
+			return command.action(os.Stdout, commandRequest{
+				ownCommands: o,
+				config:      configuration,
+				flags:       flags,
+				args:        args,
+			})
+		}
+	}
+	return fmt.Errorf("command not found: %v", commandName)
+}

--- a/update_test.go
+++ b/update_test.go
@@ -1,3 +1,5 @@
+//go:build !no_self_update
+
 package main
 
 import (


### PR DESCRIPTION
This is mostly moving code around, except:
- creation of a `OwnCommands` struct so we can register and keep a list of commands
- pass `ownCommands` slice to `Completer` to avoid using a global reference directly (doesn't make a big difference but is more future proof)
- add a `no_self_update` tag to build resticprofile without the self updater

Fixes #170 
