### PR TITLE
Allow to set a base-dir inside the profile (#183)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -221,6 +221,7 @@ generate-config-reference: build
 	LAYOUT_NOTICE_END="{{% /notice %}}" \
 	LAYOUT_HINT_START="{{% notice hint %}}" \
 	LAYOUT_HINT_END="{{% /notice %}}" \
+	LAYOUT_UPLINK="[go to top](#topbar)" \
 	$(abspath $(BINARY)) generate --config-reference > $(CONFIG_REFERENCE_DIR)/index.md
 
 syslog:

--- a/config/config.go
+++ b/config/config.go
@@ -321,9 +321,11 @@ func (c *Config) DisplayConfigurationIssues() {
 		}
 		sort.Strings(msg)
 		msg = append([]string{
-			"the configuration contains relative 'path' items which may lead to unstable results in restic " +
-				"commands that select snapshots. Consider using absolute paths in 'path' (and 'source') or use " +
-				"'tag' instead of 'path' (path = false) to select snapshots for restic commands. Affected paths:",
+			"the configuration contains relative \"path\" items which may lead to unstable results in restic " +
+				"commands that select snapshots. Consider using absolute paths in \"path\" (and \"source\"), " +
+				"set \"base-dir\" in the profile or use \"tag\" instead of \"path\" (path = false) to select " +
+				"snapshots for restic commands.",
+			"Affected paths are:",
 		}, msg...)
 		clog.Info(strings.Join(msg, fmt.Sprintln()))
 	}

--- a/config/config.go
+++ b/config/config.go
@@ -339,6 +339,11 @@ func (c *Config) DisplayConfigurationIssues() {
 	}
 
 	// Reset issues
+	c.ClearConfigurationIssues()
+}
+
+// ClearConfigurationIssues removes all configuration issues
+func (c *Config) ClearConfigurationIssues() {
 	c.issues.changedPaths = nil
 	c.issues.failedSection = nil
 }
@@ -524,6 +529,8 @@ func (c *Config) loadGroups() (err error) {
 
 // GetProfile in configuration. If the profile is not found, it returns errNotFound
 func (c *Config) GetProfile(profileKey string) (profile *Profile, err error) {
+	c.ClearConfigurationIssues()
+
 	if c.sourceTemplates != nil {
 		err = c.reloadTemplates(newTemplateData(c.configFile, profileKey, ""))
 		if err != nil {

--- a/config/path.go
+++ b/config/path.go
@@ -16,7 +16,9 @@ type pathFix func(string) string
 // fixPath applies all the path fixing callbacks one by one
 func fixPath(value string, callbacks ...pathFix) string {
 	for _, callback := range callbacks {
-		value = callback(value)
+		if callback != nil {
+			value = callback(value)
+		}
 	}
 	return value
 }

--- a/config/profile_test.go
+++ b/config/profile_test.go
@@ -564,7 +564,7 @@ func TestPathAndTagInRetention(t *testing.T) {
             version = ` + fmt.Sprintf("%d", version) + `
 
             [` + prefix + `profile]
-            base-dir = "` + baseDir + `"
+            base-dir = "` + filepath.ToSlash(baseDir) + `"
             [` + prefix + `profile.backup]
             ` + tag + `
             source = ["` + sourcePattern + `"]
@@ -575,6 +575,7 @@ func TestPathAndTagInRetention(t *testing.T) {
 		profile, err := getResolvedProfile("toml", config, "profile")
 		require.NoError(t, err)
 		require.NotNil(t, profile)
+		profile.SetRootPath(examples) // ensure relative paths are converted to absolute paths
 
 		return profile
 	}

--- a/config/profile_test.go
+++ b/config/profile_test.go
@@ -295,11 +295,13 @@ func TestEnvironmentInProfileRepo(t *testing.T) {
 		require.NoError(t, err)
 		repoPath := filepath.ToSlash(filepath.Join(homeDir, testVar))
 
-		profile.SetRootPath("/any")
+		profile.ResolveConfiguration()
 		assert.Equal(t, repoPath, filepath.ToSlash(profile.Repository.Value()))
-		assert.Equal(t, repoPath+".key", filepath.ToSlash(profile.PasswordFile))
 		assert.Equal(t, repoPath, filepath.ToSlash(profile.Init.FromRepository.Value()))
 		assert.Equal(t, repoPath, filepath.ToSlash(profile.Copy.Repository.Value()))
+
+		profile.SetRootPath("any")
+		assert.Equal(t, repoPath+".key", filepath.ToSlash(profile.PasswordFile))
 	})
 }
 
@@ -339,15 +341,18 @@ from-password-file = "key"
 
 		profile.ResolveConfiguration()
 		assert.Equal(t, homeDir, profile.BaseDir)
+		assert.Equal(t, "local-repo", profile.Repository.Value())
 
 		profile.SetRootPath("/wd")
 		assert.Equal(t, "status", profile.StatusFile)
-		assert.Equal(t, "local-repo", profile.Repository.Value())
 		assert.Equal(t, "prom", profile.PrometheusSaveToFile)
 		assert.Equal(t, "/wd/key", profile.PasswordFile)
 		assert.Equal(t, "/wd/lock", profile.Lock)
 		assert.Equal(t, "", profile.CacheDir)
-		assert.ElementsMatch(t, []string{"backup", "root"}, profile.GetBackupSource())
+		assert.ElementsMatch(t, []string{
+			filepath.Join(homeDir, "backup"),
+			filepath.Join(homeDir, "root"),
+		}, profile.GetBackupSource())
 		assert.ElementsMatch(t, []string{"/wd/exclude"}, profile.Backup.ExcludeFile)
 		assert.ElementsMatch(t, []string{"/wd/include"}, profile.Backup.FilesFrom)
 		assert.ElementsMatch(t, []string{"exclude"}, profile.Backup.Exclude)

--- a/contrib/templates/config-reference.gomd
+++ b/contrib/templates/config-reference.gomd
@@ -47,6 +47,13 @@ date: {{ .Now.Format "2006-01-02T15:04:05Z07:00" }}
     {{ $layoutHeadings = .Env.LAYOUT_HEADINGS_START -}}
 {{- end }}
 
+{{- $layoutUpLink := "" -}}
+{{- if .Env.LAYOUT_UPLINK -}}
+    {{ $layoutUpLink = .Env.LAYOUT_UPLINK -}}
+{{- else if not .Env.LAYOUT_NO_HEADLINE -}}
+    {{ $layoutUpLink = "[up](#resticprofile-configuration-reference)" -}}
+{{- end }}
+
 {{- $webBaseUrl := "https://creativeprojects.github.io/resticprofile" -}}
 {{- $configWebUrl := "{base}/configuration" | replace "{base}" $webBaseUrl -}}
 
@@ -227,6 +234,8 @@ Most **restic** command flags defined in profile sections below can also be set 
 They will be inherited in all sections that define these flags and ignored in all others.
 {{ $layoutNoticeEnd }}
 
+{{ $layoutUpLink }}
+
 {{ range .ProfileSections -}}{{ $layoutHeadings -}}### Section profile.**{{.Name}}**
 
 {{ if .IsCommandSection -}}
@@ -259,6 +268,8 @@ They will be inherited in all sections that define these flags and ignored in al
 Flags declared for the **restic** command line in section *[profile](#section-profile)*
 can be overridden in this section.
 {{ $layoutHintEnd }}
+
+{{ $layoutUpLink }}
 {{ end }}
 
 {{ $layoutHeadings -}}## Nested profile sections
@@ -277,6 +288,8 @@ configuration, see [HTTP Hooks]({{- $configWebUrl -}}/http_hooks/) as an example
 {{- end }}
 {{- end }}
 
+{{ $layoutUpLink }}
+
 {{ $layoutHeadings -}}## Section **groups**
 
 Config file format v1 uses a simplified groups section. Every named item below `groups`
@@ -287,6 +300,8 @@ following the format described below (see [Configuration v2]({{- $configWebUrl -
 for details):
 
 {{ template "printPropertyTable" .Group | properties }}
+
+{{ $layoutUpLink }}
 
 {{ $layoutHeadings -}}# Value types
 
@@ -327,6 +342,8 @@ in `[type]`.
 **Type**: `key` => `value`
 : Is a value that is configuration structure of `string` keys and values of any type.
 
+{{ $layoutUpLink }}
+
 {{ $layoutHeadings -}}# JSON schema
 
 resticprofile provides a JSON schema for v1 & v2 configuration files. The schema may be
@@ -348,3 +365,5 @@ Available URLs:
   * {{ $webBaseUrl }}/jsonschema/config-2-restic-{{ $v | replace "." "-" }}.json
   * {{ $webBaseUrl }}/jsonschema/config-1-restic-{{ $v | replace "." "-" }}.json
 {{- end }}
+
+{{ $layoutUpLink }}

--- a/docs/content/configuration/_index.md
+++ b/docs/content/configuration/_index.md
@@ -163,15 +163,9 @@ If you have any doubt on what it's running, you can try a `--dry-run`:
 ```shell
 $ resticprofile --dry-run backup
 2022/05/18 17:14:07 profile 'default': starting 'backup'
-2022/05/18 17:14:07 dry-run: /usr/bin/restic backup --password-file key --repo local:/backup --verbose /home
+2022/05/18 17:14:07 dry-run: /usr/bin/restic backup --password-file password.txt --repo local:/backup --verbose /home
 2022/05/18 17:14:07 profile 'default': finished 'backup'
 ```
-
-## Path resolution in configuration
-
-All files path in the configuration are resolved from the configuration path. The big **exception** being `source` in `backup` section where it's resolved from the current path where you started resticprofile.
-
-Using the basic configuration from earlier, and taking into account that the configuration file is saved in the directory `/opt/resticprofile`, the password key file `password.txt` is expected to be found at `/opt/resticprofile/password.txt` no matter your current directory.
 
 ## More information
 

--- a/docs/content/configuration/include/_index.md
+++ b/docs/content/configuration/include/_index.md
@@ -77,7 +77,7 @@ The HCL format is special in that it cannot be mixed with other formats.
 
 Included files cannot include nested files. Specifying `includes` inside an included file has no effect.
 
-Within included files, the current [configuration path]({{< ref "/configuration/#path-resolution-in-configuration" >}}) is not changed. Path resolution remains relative to the path of the main configuration file.
+Within included files, the current [configuration path]({{< ref "/configuration/path/#how-paths-inside-the-configuration-are-resolved" >}}) is not changed. Path resolution remains relative to the path of the main configuration file.
 
 ## Configuration Merging
 
@@ -89,7 +89,7 @@ Configuration files are loaded and applied in a fixed order:
 2. `includes` are iterated in declaration order:
    * Every item may be a single file path or glob expression
    * Glob expressions are resolved and iterated in alphabetical order
-   * All paths are resolved relative to [configuration path]({{< ref "/configuration/#path-resolution-in-configuration" >}})
+   * All paths are resolved relative to [configuration path]({{< ref "/configuration/path/#how-paths-inside-the-configuration-are-resolved" >}})
 
 Configuration files are loaded in the following order when assuming `/etc/resticprofile/profiles.conf` with `includes = ["first.conf", "conf.d/*.conf", "last.conf"]`:
 ```

--- a/docs/content/configuration/path/_index.md
+++ b/docs/content/configuration/path/_index.md
@@ -4,6 +4,99 @@ date: 2022-04-24T09:44:41+01:00
 weight: 10
 ---
 
+## How paths inside the configuration are resolved
+
+All file paths in the configuration are resolved relative to the configuration path, the path where 
+the configuration file was loaded from. 
+
+The big **exceptions** are `source` in the `backup` section, `status-file` & `prometheus-save-to-file` and the 
+restic `repository` (if it is a file). These paths are taken as specified, which means they are resolved 
+from the current working directory where you started resticprofile from. The profile flag `base-dir` 
+allows to set the working directory that resticprofile will change into so that profiles do no longer
+depend on the path where you started resticprofile from.
+
+For the following configuration example, when assuming it is stored in `/opt/resticprofile/profiles.*` and 
+resticprofile is started from `/home/user/`, the individual paths are resolved to:
+* **repository**: `local:/home/user/backup`
+* **password-file**: `/opt/resticprofile/password.txt`
+* **backup.source**: `/home/user/files`
+
+
+{{< tabs groupId="config-with-json" >}}
+{{% tab name="toml" %}}
+
+```toml
+# indentation is not needed but it makes it easier to read ;)
+#
+version = "1"
+
+[default]
+  base-dir = ""
+  repository = "local:backup"
+  password-file = "password.txt"
+
+  [default.backup]
+    source = [ "files" ]
+```
+
+{{% /tab %}}
+{{% tab name="yaml" %}}
+
+```yaml
+version: "1"
+
+default:
+  base-dir: ""
+  repository: "local:backup"
+  password-file: "password.txt"
+
+  backup:
+    source:
+    - "files"
+```
+
+{{% /tab %}}
+{{% tab name="hcl" %}}
+
+```hcl
+default {
+    base-dir = ""
+    repository = "local:backup"
+    password-file = "password.txt"
+
+    backup = {
+        source = [ "files" ]
+    }
+}
+```
+
+{{% /tab %}}
+{{% tab name="json" %}}
+
+```json
+{
+  "version": "1",
+  "default": {
+    "base-dir": "",
+    "repository": "local:backup",
+    "password-file": "password.txt",
+    "backup": {
+      "source": [
+        "files"
+      ]
+    }
+  }
+}
+```
+
+{{% /tab %}}
+{{% /tabs %}}
+
+{{% notice hint %}}
+Set `base-dir` to an absolute path to resolve `files` and `local:backup` relative to it
+{{% /notice %}}
+
+## How the configuration file is resolved
 
 The default name for the configuration file is `profiles`, without an extension.
 You can change the name and its path with the `--config` or `-c` option on the command line.
@@ -15,7 +108,7 @@ If you set a filename with no extension instead, resticprofile will load the fir
 - .json
 - .hcl
 
-## macOS X
+### macOS X
 
 resticprofile will search for your configuration file in these folders:
 - _current directory_
@@ -32,7 +125,7 @@ resticprofile will search for your configuration file in these folders:
 - /opt/local/etc/resticprofile/
 - ~/ ($HOME directory)
 
-## Other unixes (Linux and BSD)
+### Other unixes (Linux and BSD)
 
 resticprofile will search for your configuration file in these folders:
 - _current directory_
@@ -49,7 +142,7 @@ resticprofile will search for your configuration file in these folders:
 - /opt/local/etc/resticprofile/
 - ~/ ($HOME directory)
 
-## Windows
+### Windows
 
 resticprofile will search for your configuration file in these folders:
 - _current directory_

--- a/docs/content/configuration/path/_index.md
+++ b/docs/content/configuration/path/_index.md
@@ -7,13 +7,15 @@ weight: 10
 ## How paths inside the configuration are resolved
 
 All file paths in the configuration are resolved relative to the configuration path, the path where 
-the configuration file was loaded from. 
+the main configuration file was loaded from. 
 
-The big **exceptions** are `source` in the `backup` section, `status-file` & `prometheus-save-to-file` and the 
+The big **exceptions** are `source` in the `backup` section, `status-file`, `prometheus-save-to-file` and the 
 restic `repository` (if it is a file). These paths are taken as specified, which means they are resolved 
-from the current working directory where you started resticprofile from. The profile flag `base-dir` 
-allows to set the working directory that resticprofile will change into so that profiles do no longer
-depend on the path where you started resticprofile from.
+from the current working directory where you started resticprofile from. 
+
+You can influence this behaviour with profile flag `base-dir`. It allows to set the working directory 
+that resticprofile will change into so that profiles do no longer depend on the path where you started 
+resticprofile from.
 
 For the following configuration example, when assuming it is stored in `/opt/resticprofile/profiles.*` and 
 resticprofile is started from `/home/user/`, the individual paths are resolved to:
@@ -36,6 +38,7 @@ version = "1"
   password-file = "password.txt"
 
   [default.backup]
+    source-base = ""
     source = [ "files" ]
 ```
 
@@ -51,6 +54,7 @@ default:
   password-file: "password.txt"
 
   backup:
+    source-base: ""
     source:
     - "files"
 ```
@@ -65,6 +69,7 @@ default {
     password-file = "password.txt"
 
     backup = {
+        source-base = ""
         source = [ "files" ]
     }
 }
@@ -81,6 +86,7 @@ default {
     "repository": "local:backup",
     "password-file": "password.txt",
     "backup": {
+      "source-base": "",
       "source": [
         "files"
       ]
@@ -93,7 +99,8 @@ default {
 {{% /tabs %}}
 
 {{% notice hint %}}
-Set `base-dir` to an absolute path to resolve `files` and `local:backup` relative to it
+Set `base-dir` to an absolute path to resolve `files` and `local:backup` relative to it.
+Set `source-base` if you need a separate base path for backup sources.
 {{% /notice %}}
 
 ## How the configuration file is resolved

--- a/docs/content/configuration/variables/index.md
+++ b/docs/content/configuration/variables/index.md
@@ -23,7 +23,8 @@ The list of pre-defined variables is:
 |-------------------|--------------------------------------------------|------------------------------------------------------------------|
 | **.Profile.Name** | string                                           | Profile name                                                     |
 | **.Now**          | [time.Time](https://golang.org/pkg/time/) object | Now object: see explanation bellow                               |
-| **.CurrentDir**   | string                                           | Current directory at the time resticprofile was started          |
+| **.StartupDir**   | string                                           | Current directory at the time resticprofile was started          |
+| **.CurrentDir**   | string                                           | Current directory at the time a profile is executed              |
 | **.ConfigDir**    | string                                           | Directory where the configuration was loaded from                |
 | **.TempDir**      | string                                           | OS temporary directory (might not exist)                         |
 | **.BinaryDir**    | string                                           | Directory where resticprofile was started from (since `v0.18.0`) |

--- a/integration_test.go
+++ b/integration_test.go
@@ -63,7 +63,7 @@ func TestFromConfigFileToCommandLine(t *testing.T) {
 			[]string{"--option"},
 			`["backup" "--exclude=/**/.git" "--password-file=examples/key" "--repo=rest:http://user:password@localhost:8000/path" "--option" "/source"]`,
 			`["backup" "--exclude=/**/.git" "--password-file=examples/key" "--repo=rest:http://user:password@localhost:8000/path" "--option" "/source"]`,
-			`["backup" "--exclude=/**/.git" "--password-file=examples\\key" "--repo=rest:http://user:password@localhost:8000/path" "--option" "/source"]`,
+			`["backup" "--exclude=/**/.git" "--password-file=examples\\key" "--repo=rest:http://user:password@localhost:8000/path" "--option" "\\source"]`,
 		},
 		{
 			"glob1",
@@ -71,7 +71,7 @@ func TestFromConfigFileToCommandLine(t *testing.T) {
 			[]string{},
 			`["backup" "--exclude=[aA]*" "--password-file=examples/key" "--repo=rest:http://user:password@localhost:8000/path" "/source"]`,
 			`["backup" "--exclude=[aA]*" "--password-file=examples/key" "--repo=rest:http://user:password@localhost:8000/path" "/source"]`,
-			`["backup" "--exclude=[aA]*" "--password-file=examples\\key" "--repo=rest:http://user:password@localhost:8000/path" "/source"]`,
+			`["backup" "--exclude=[aA]*" "--password-file=examples\\key" "--repo=rest:http://user:password@localhost:8000/path" "\\source"]`,
 		},
 		{
 			"glob2",
@@ -87,7 +87,7 @@ func TestFromConfigFileToCommandLine(t *testing.T) {
 			[]string{"some path"},
 			`["backup" "--exclude=My\\ Documents" "--password-file=examples/different\\ key" "--repo=rest:http://user:password@localhost:8000/path" "some" "path" "/source dir"]`,
 			`["backup" "--exclude=My Documents" "--password-file=examples/different key" "--repo=rest:http://user:password@localhost:8000/path" "some path" "/source dir"]`,
-			`["backup" "--exclude=My Documents" "--password-file=examples\\different key" "--repo=rest:http://user:password@localhost:8000/path" "some path" "/source dir"]`,
+			`["backup" "--exclude=My Documents" "--password-file=examples\\different key" "--repo=rest:http://user:password@localhost:8000/path" "some path" "\\source dir"]`,
 		},
 		{
 			"quotes",
@@ -95,7 +95,7 @@ func TestFromConfigFileToCommandLine(t *testing.T) {
 			[]string{"quo'te", "quo\"te"},
 			`["backup" "--exclude=MyDocuments --exclude=My\"Documents --password-file=examples/key --repo=rest:http://user:password@localhost:8000/path quote" "quote /source'dir /sourcedir"]`,
 			`["backup" "--exclude=My'Documents" "--exclude=My\"Documents" "--password-file=examples/key" "--repo=rest:http://user:password@localhost:8000/path" "quo'te" "quo\"te" "/source'dir" "/source\"dir"]`,
-			`["backup" "--exclude=My'Documents" "--exclude=My\"Documents" "--password-file=examples\\key" "--repo=rest:http://user:password@localhost:8000/path" "quo'te" "quo\"te" "/source'dir" "/source\"dir"]`,
+			`["backup" "--exclude=My'Documents" "--exclude=My\"Documents" "--password-file=examples\\key" "--repo=rest:http://user:password@localhost:8000/path" "quo'te" "quo\"te" "\\source'dir" "\\source\"dir"]`,
 		},
 		{
 			"mixed",
@@ -103,7 +103,7 @@ func TestFromConfigFileToCommandLine(t *testing.T) {
 			[]string{"/path/with space; echo foo"},
 			`["backup" "--password-file=examples/key" "--repo=rest:http://user:password@localhost:8000/path" "/path/with" "space"]` + "\n" + `foo /Côte dIvoire /path/with\ space;\ echo\ foo`,
 			`["backup" "--password-file=examples/key" "--repo=rest:http://user:password@localhost:8000/path" "/path/with space; echo foo" "/Côte d'Ivoire" "/path/with space; echo foo'"]`,
-			`["backup" "--password-file=examples\\key" "--repo=rest:http://user:password@localhost:8000/path" "/path/with space; echo foo" "/Côte d'Ivoire" "/path/with space; echo foo'"]`,
+			`["backup" "--password-file=examples\\key" "--repo=rest:http://user:password@localhost:8000/path" "/path/with space; echo foo" "\\Côte d'Ivoire" "\\path\\with space; echo foo'"]`,
 		},
 		{
 			"mixed",
@@ -111,7 +111,7 @@ func TestFromConfigFileToCommandLine(t *testing.T) {
 			[]string{},
 			`["backup" "--password-file=examples/key" "--repo=rest:http://user:password@localhost:8000/path" "/Côte dIvoire /path/with\\ space;\\ echo\\ foo"]`,
 			`["backup" "--password-file=examples/key" "--repo=rest:http://user:password@localhost:8000/path" "/Côte d'Ivoire" "/path/with space; echo foo'"]`,
-			`["backup" "--password-file=examples\\key" "--repo=rest:http://user:password@localhost:8000/path" "/Côte d'Ivoire" "/path/with space; echo foo'"]`,
+			`["backup" "--password-file=examples\\key" "--repo=rest:http://user:password@localhost:8000/path" "\\Côte d'Ivoire" "\\path\\with space; echo foo'"]`,
 		},
 		{
 			"fix",

--- a/main.go
+++ b/main.go
@@ -335,6 +335,24 @@ func runProfile(
 		return fmt.Errorf("cannot load profile '%s'", profileName)
 	}
 
+	if len(profile.BaseDir) > 0 {
+		if current, err := os.Getwd(); err == nil {
+			defer func(dir string) {
+				if e := os.Chdir(dir); e != nil {
+					panic(fmt.Errorf("failed restoring working directory %q: %w", dir, e))
+				}
+			}(current)
+		} else {
+			return fmt.Errorf("changing base directory not allowed as current directory is unknown in profile %q; cause: %w", profileName, err)
+		}
+
+		if err = os.Chdir(profile.BaseDir); err == nil {
+			clog.Infof("profile '%s': base directory is %q", profileName, profile.BaseDir)
+		} else {
+			return fmt.Errorf("cannot change to base directory %q in profile %q; cause: %w", profile.BaseDir, profileName, err)
+		}
+	}
+
 	displayProfileDeprecationNotices(profile)
 	c.DisplayConfigurationIssues()
 

--- a/main_test.go
+++ b/main_test.go
@@ -1,0 +1,89 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/creativeprojects/resticprofile/config"
+	"github.com/creativeprojects/resticprofile/constants"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGetProfile(t *testing.T) {
+	baseDir, _ := filepath.Abs(t.TempDir())
+	baseDir, err := filepath.EvalSymlinks(baseDir)
+	require.NoError(t, err)
+	baseDir = filepath.ToSlash(baseDir)
+
+	c, err := config.Load(strings.NewReader(`
+		[default]
+		 repository = "test-repo"
+		 tag = ["{{ .CurrentDir }}", "{{ .StartupDir }}"]
+		[with-base]
+		 inherit = "default"
+		 base-dir = "`+baseDir+`"
+		[with-invalid-base]
+		 inherit = "default"
+		 base-dir = "~/some-dir-not-exists"
+	`), "toml")
+	require.NoError(t, err)
+
+	getWd := func(t *testing.T) string {
+		dir, err := os.Getwd()
+		require.NoError(t, err)
+		return filepath.ToSlash(dir)
+	}
+
+	cwd := getWd(t)
+
+	getProf := func(t *testing.T, name string) (profile *config.Profile, cleanup func()) {
+		var err error
+		profile, cleanup, err = openProfile(c, name)
+		require.NoError(t, err)
+		require.NotNil(t, cleanup)
+		require.NotNil(t, profile)
+		return
+	}
+
+	t.Run("default", func(t *testing.T) {
+		profile, cleanup := getProf(t, "default")
+		assert.Equal(t, "test-repo", profile.Repository.Value())
+		assert.Equal(t, []any{cwd, cwd}, profile.OtherFlags[constants.ParameterTag])
+
+		assert.Equal(t, cwd, getWd(t))
+		cleanup()
+		assert.Equal(t, cwd, getWd(t))
+	})
+
+	t.Run("with-base-dir", func(t *testing.T) {
+		profile, cleanup := getProf(t, "with-base")
+		assert.Equal(t, "test-repo", profile.Repository.Value())
+		assert.Equal(t, []any{baseDir, cwd}, profile.OtherFlags[constants.ParameterTag])
+
+		assert.Equal(t, baseDir, getWd(t))
+		cleanup()
+		assert.Equal(t, cwd, getWd(t))
+	})
+
+	t.Run("load-error", func(t *testing.T) {
+		profile, cleanup, err := openProfile(c, "unknown")
+		require.NotNil(t, cleanup)
+		defer cleanup()
+
+		assert.Nil(t, profile)
+		assert.EqualError(t, err, "cannot load profile 'unknown': not found")
+	})
+
+	t.Run("with-base-dir-error", func(t *testing.T) {
+		profile, cleanup, err := openProfile(c, "with-invalid-base")
+		require.NotNil(t, cleanup)
+		defer cleanup()
+
+		require.NotNil(t, profile)
+		dir := filepath.FromSlash(profile.BaseDir)
+		assert.ErrorContains(t, err, `cannot change to base directory "`+dir+`" in profile "with-invalid-base": chdir `+dir+`: `)
+	})
+}

--- a/util/templates/data_test.go
+++ b/util/templates/data_test.go
@@ -23,7 +23,13 @@ func TestBinaryDir(t *testing.T) {
 func TestCurrentDir(t *testing.T) {
 	dir, err := os.Getwd()
 	require.NoError(t, err)
-	assert.Equal(t, filepath.ToSlash(dir), NewDefaultData(nil).CurrentDir)
+	defer func(d string) { _ = os.Chdir(d) }(dir)
+
+	require.NoError(t, os.Chdir(t.TempDir()))
+	currentDir, _ := os.Getwd()
+
+	assert.Equal(t, filepath.ToSlash(dir), NewDefaultData(nil).StartupDir)
+	assert.Equal(t, filepath.ToSlash(currentDir), NewDefaultData(nil).CurrentDir)
 }
 
 func TestTempDir(t *testing.T) {


### PR DESCRIPTION
Implements #183 by changing the current directory when the option is set.

Also updated path documentation (moved description of the configuration path from "configuration/" to "configuration/path" and improved it)