### PR TITLE
New option to specify Prometheus Pushgateway job name

### DIFF
--- a/config/profile.go
+++ b/config/profile.go
@@ -89,6 +89,7 @@ type Profile struct {
 	StatusFile              string                            `mapstructure:"status-file" description:"Path to the status file to update with a summary of last restic command result"`
 	PrometheusSaveToFile    string                            `mapstructure:"prometheus-save-to-file" description:"Path to the prometheus metrics file to update with a summary of the last restic command result"`
 	PrometheusPush          string                            `mapstructure:"prometheus-push" format:"uri" description:"URL of the prometheus push gateway to send the summary of the last restic command result to"`
+	PrometheusPushJob       string                            `mapstructure:"prometheus-push-job" description:"Prometheus push gateway job name. $command placeholder is replaced with restic command"`
 	PrometheusLabels        map[string]string                 `mapstructure:"prometheus-labels" description:"Additional prometheus labels to set"`
 	Environment             map[string]ConfidentialValue      `mapstructure:"env" description:"Additional environment variables to set in any child process"`
 	Init                    *InitSection                      `mapstructure:"init"`

--- a/docs/content/status/prometheus/index.md
+++ b/docs/content/status/prometheus/index.md
@@ -129,6 +129,12 @@ resticprofile_build_info{goversion="go1.19",version="0.19.0"} 1
 
 ```
 
+## Prometheus Pushgateway
+
+Prometheus Pushgateway uses the job label as a grouping key. All metrics with the same grouping key get replaced when pushed. To prevent metrics from multiple profiles getting overwritten by each other, the default job label is set to `<profile_name>.<command>` (e.g. `root.backup`).
+
+If you need more control over the job label, you can use the `prometheus-push-job` property. This property can contain the `$command` placeholder, which is replaced with the name of the executed command.
+
 ## User defined labels
 
 You can add your own prometheus labels. Please note they will be applied to **all** the metrics.


### PR DESCRIPTION
Hi,

First of all, thanks for the project, it is very helpful!

I tried the Prometheus Pushgateway feature for monitoring and noticed an issue in case you work with multiple profiles.
When running multiple backups in a row, only the last backup metrics are returned from the Pushgateway.
That's the behavior of the Pushgateway to group all metrics by the job name specified in the URL (or any other labels in the URL, details are on https://github.com/prometheus/pushgateway#api).

To prevent such issues, I propose adding an option to specify the name of the Pushgateway job (currently, this is always set to the command, e.g. `backup`). This way, it is possible to prevent metrics from profile A interfering with metrics from profile B.

Example configuration:
```yaml
version: "2"

mixins:
  prom:
    prometheus-push: http://prometheus-pushgateway.monitoring:9091/
    prometheus-push-job: "${COMMAND}-{{ .Profile.Name }}"

profiles:
  default:
    repository: /backups/root
    use:
      - prom
    backup:
      extended-status: true
      source:
        - /

  documents:
    repository: /backups/documents
    use:
      - prom
    backup:
      extended-status: true
      source:
        - /user/documents
```

If you're good with the approach, I can also update the documentation.

Thanks!