### PR TITLE
Global json schema (auto versioning)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,6 +32,7 @@ RESTIC_GEN=$(BUILD)restic-generator
 RESTIC_DIR=$(BUILD)restic-
 RESTIC_CMD=$(BUILD)restic-commands.json
 
+CONTRIB_DIR=contrib
 JSONSCHEMA_DIR=docs/static/jsonschema
 CONFIG_REFERENCE_DIR=docs/content/configuration/reference
 
@@ -192,6 +193,8 @@ generate-jsonschema: build
 	@echo "[*] $@"
 
 	mkdir -p $(JSONSCHEMA_DIR) || echo "$(JSONSCHEMA_DIR) exists"
+
+	$(abspath $(BINARY)) generate --config-reference $(CONTRIB_DIR)/templates/config-schema.gojson > $(JSONSCHEMA_DIR)/config.json
 
 	$(abspath $(BINARY)) generate --json-schema v1 > $(JSONSCHEMA_DIR)/config-1.json
 	$(abspath $(BINARY)) generate --json-schema v2 > $(JSONSCHEMA_DIR)/config-2.json

--- a/commands.go
+++ b/commands.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"path/filepath"
 	"regexp"
 	"sort"
 	"strconv"
@@ -235,8 +236,12 @@ func generateConfigReference(output io.Writer, args []string) (err error) {
 	}
 
 	data := config.NewTemplateInfoData(resticVersion)
-	tpl := templates.New("config-reference", data.GetFuncs())
+	name := "config-reference"
+	if len(args) > 0 {
+		name = filepath.Base(args[0])
+	}
 
+	tpl := templates.New(name, data.GetFuncs())
 	if len(args) > 0 {
 		tpl, err = tpl.ParseFiles(args...)
 	} else {

--- a/commands_test.go
+++ b/commands_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"bytes"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
@@ -293,6 +294,20 @@ func TestGenerateCommand(t *testing.T) {
 		assert.Contains(t, ref, "| **ionice-class** |")
 		assert.Contains(t, ref, "| **check-after** |")
 		assert.Contains(t, ref, "| **continue-on-error** |")
+	})
+
+	t.Run("--config-reference config-schema.gojson", func(t *testing.T) {
+		buffer.Reset()
+		assert.NoError(t, generateCommand(buffer, commandRequest{args: []string{"--config-reference", "contrib/templates/config-schema.gojson"}}))
+		ref := buffer.String()
+		assert.Contains(t, ref, `"$schema"`)
+		assert.Contains(t, ref, "/jsonschema/config-1.json")
+		assert.Contains(t, ref, "/jsonschema/config-2.json")
+
+		decoder := json.NewDecoder(strings.NewReader(ref))
+		content := make(map[string]any)
+		assert.NoError(t, decoder.Decode(&content))
+		assert.Contains(t, content, `$schema`)
 	})
 
 	t.Run("--json-schema", func(t *testing.T) {

--- a/config/checkdoc/main.go
+++ b/config/checkdoc/main.go
@@ -18,12 +18,12 @@ const (
 	configTag      = "```"
 	checkdocIgnore = "<!-- checkdoc-ignore -->"
 	goTemplate     = "{{"
-	replaceURL     = "http://localhost:1313/resticprofile/jsonschema/config-$1.json"
+	replaceURL     = "http://localhost:1313/resticprofile/jsonschema/config$1.json"
 )
 
 var (
-	urlPattern = regexp.MustCompile(`{{< [^>}]+config-(\d)\.json"[^>}]+ >}}`)
-	_          = regexp.MustCompile(`{{< [^>}]+config-(\d)\.json"[^>}]+ >}}`) // Remove this when VS Code fixed the syntax highlighting issues
+	urlPattern = regexp.MustCompile(`{{< [^>}]+config(-\d)?\.json"[^>}]+ >}}`)
+	_          = regexp.MustCompile(`{{< [^>}]+config(-\d)?\.json"[^>}]+ >}}`) // Remove this when VS Code fixed the syntax highlighting issues
 )
 
 var (

--- a/config/global.go
+++ b/config/global.go
@@ -16,7 +16,7 @@ type Global struct {
 	DefaultCommand       string        `mapstructure:"default-command" default:"snapshots" description:"The restic or resticprofile command to use when no command was specified"`
 	Initialize           bool          `mapstructure:"initialize" default:"false" description:"Initialize a repository if missing"`
 	ResticBinary         string        `mapstructure:"restic-binary" description:"Full path of the restic executable (detected if not set)"`
-	ResticVersion        string        // not configurable at the moment. To be set after ResticBinary is known.
+	ResticVersion        string        `mapstructure:"restic-version" pattern:"^(|[0-9]+\\.[0-9]+(\\.[0-9]+)?)$" description:"Sets the restic version (detected if not set)"`
 	FilterResticFlags    bool          `mapstructure:"restic-arguments-filter" default:"true" description:"Remove unknown flags instead of passing all configured flags to restic"`
 	ResticLockRetryAfter time.Duration `mapstructure:"restic-lock-retry-after" default:"1m" description:"Time to wait before trying to get a lock on a restic repositoey - see https://creativeprojects.github.io/resticprofile/usage/locks/"`
 	ResticStaleLockAge   time.Duration `mapstructure:"restic-stale-lock-age" default:"2h" description:"The age an unused lock on a restic repository must have at least before resiticprofile attempts to unlock - see https://creativeprojects.github.io/resticprofile/usage/locks/"`

--- a/config/jsonschema/model.go
+++ b/config/jsonschema/model.go
@@ -259,7 +259,7 @@ func newSchemaBool() *schemaTypeBase {
 
 type schemaObject struct {
 	schemaTypeBase
-	AdditionalProperties bool                  `json:"additionalProperties"`
+	AdditionalProperties any                   `json:"additionalProperties,omitempty"`
 	PatternProperties    map[string]SchemaType `json:"patternProperties,omitempty"`
 	Properties           map[string]SchemaType `json:"properties,omitempty"`
 	Required             []string              `json:"required,omitempty"`
@@ -268,9 +268,10 @@ type schemaObject struct {
 
 func newSchemaObject() *schemaObject {
 	return withBaseType(&schemaObject{
-		PatternProperties: make(map[string]SchemaType),
-		Properties:        make(map[string]SchemaType),
-		DependentRequired: make(map[string][]string),
+		AdditionalProperties: false,
+		PatternProperties:    make(map[string]SchemaType),
+		Properties:           make(map[string]SchemaType),
+		DependentRequired:    make(map[string][]string),
 	}, "object")
 }
 
@@ -289,6 +290,15 @@ func (s *schemaObject) verify() (err error) {
 			break
 		} else if st == nil {
 			err = fmt.Errorf("type of %q in properties is undefined", name)
+		}
+	}
+	if err == nil {
+		switch s.AdditionalProperties.(type) {
+		case nil:
+		case bool:
+		case SchemaType:
+		default:
+			err = fmt.Errorf("additionalProperties must be nil, boolean or SchemaType")
 		}
 	}
 	if err == nil {
@@ -431,6 +441,9 @@ func internalWalkTypes(into map[SchemaType]bool, current SchemaType, callback fu
 			}
 			for name, property := range t.PatternProperties {
 				t.PatternProperties[name] = internalWalkTypes(into, property, callback)
+			}
+			if item, ok := t.AdditionalProperties.(SchemaType); ok {
+				t.AdditionalProperties = internalWalkTypes(into, item, callback)
 			}
 		case *schemaArray:
 			t.Items = internalWalkTypes(into, t.Items, callback)

--- a/config/jsonschema/model_test.go
+++ b/config/jsonschema/model_test.go
@@ -219,6 +219,12 @@ func TestVerify(t *testing.T) {
 		obj.Properties["first"] = newSchemaString()
 		assert.NoError(t, obj.verify())
 
+		assert.Equal(t, false, obj.AdditionalProperties)
+		obj.AdditionalProperties = "-"
+		assert.ErrorContains(t, obj.verify(), `additionalProperties must be nil, boolean or SchemaType`)
+		obj.AdditionalProperties = newSchemaString()
+		assert.NoError(t, obj.verify())
+
 		testBase(t, obj.base())
 	})
 

--- a/config/jsonschema/schema.go
+++ b/config/jsonschema/schema.go
@@ -411,14 +411,7 @@ func applyListAppendSchema(target SchemaType) {
 func schemaForConfigV1(profileInfo config.ProfileInfo) (object *schemaObject) {
 	object = schemaForProfile(profileInfo)
 
-	// exclude non-profile properties from profile-schema
-	profilesPattern := fmt.Sprintf(`^(?!%s).*$`, strings.Join([]string{
-		constants.SectionConfigurationGlobal,
-		constants.SectionConfigurationGroups,
-		constants.SectionConfigurationIncludes,
-		constants.ParameterVersion,
-	}, "|"))
-	object.PatternProperties[profilesPattern] = object.PatternProperties[matchAll]
+	object.AdditionalProperties = object.PatternProperties[matchAll]
 	delete(object.PatternProperties, matchAll)
 
 	object.Description = "resticprofile configuration v1"

--- a/config/jsonschema/schema_test.go
+++ b/config/jsonschema/schema_test.go
@@ -346,9 +346,9 @@ func TestSchemaForPropertySet(t *testing.T) {
 
 	t.Run("AdditionalProperties", func(t *testing.T) {
 		s := schemaForPropertySet(newMock(func(m *mocks.NamedPropertySet) { m.EXPECT().IsClosed().Return(false) }))
-		assert.True(t, s.AdditionalProperties)
+		assert.Equal(t, true, s.AdditionalProperties)
 		s = schemaForPropertySet(newMock(func(m *mocks.NamedPropertySet) { m.EXPECT().IsClosed().Return(true) }))
-		assert.False(t, s.AdditionalProperties)
+		assert.Equal(t, false, s.AdditionalProperties)
 	})
 
 	t.Run("TypedAdditionalProperty", func(t *testing.T) {
@@ -362,7 +362,7 @@ func TestSchemaForPropertySet(t *testing.T) {
 			m.EXPECT().OtherPropertyInfo().Return(pi)
 		}))
 
-		assert.False(t, s.AdditionalProperties)
+		assert.Equal(t, false, s.AdditionalProperties)
 		assert.Equal(t, newSchemaString(), s.PatternProperties[matchAll])
 	})
 

--- a/contrib/templates/config-reference.gomd
+++ b/contrib/templates/config-reference.gomd
@@ -48,6 +48,9 @@ date: {{ .Now.Format "2006-01-02T15:04:05Z07:00" }}
 {{- end }}
 
 {{- $webBaseUrl := "https://creativeprojects.github.io/resticprofile" -}}
+{{- if .Env.WEB_BASE_URL -}}
+    {{- $webBaseUrl = .Env.WEB_BASE_URL -}}
+{{- end -}}
 {{- $configWebUrl := "{base}/configuration" | replace "{base}" $webBaseUrl -}}
 
 {{ define "printCell" -}}
@@ -344,7 +347,8 @@ JSON schema URLs for a specific *restic* version:
 * `.../config-2-restic-{MAJOR}-{MINOR}.json`
 
 Available URLs:
-{{ range $v := .KnownResticVersions }}
-  * {{ $webBaseUrl }}/jsonschema/config-2-restic-{{ $v | replace "." "-" }}.json
-  * {{ $webBaseUrl }}/jsonschema/config-1-restic-{{ $v | replace "." "-" }}.json
+{{ range $version := .KnownResticVersions }}
+    {{- $version = slice ($version | split ".") 0 2 | join "." -}}
+    * {{ $webBaseUrl }}/jsonschema/config-2-restic-{{ $version | replace "." "-" }}.json
+    * {{ $webBaseUrl }}/jsonschema/config-1-restic-{{ $version | replace "." "-" }}.json
 {{- end }}

--- a/contrib/templates/config-schema.gojson
+++ b/contrib/templates/config-schema.gojson
@@ -1,0 +1,184 @@
+{{- /* ------------------------------------------------------------------------------
+
+  Template that generates a global json schema which redirects to versioned URLs
+  depending on "version" and "restic-version" properties
+
+  Usage: resticprofile generate \
+         --config-reference contrib/templates/config-schema.gojson
+
+------------------------------------------------------------------------------ */ -}}
+{{- /*gotype: github.com/creativeprojects/resticprofile/config.TemplateInfoData*/ -}}
+{{- $baseUrl := "https://creativeprojects.github.io/resticprofile/jsonschema" -}}
+{{- if .Env.SCHEMA_BASE_URL -}}
+{{- $baseUrl = .Env.SCHEMA_BASE_URL -}}
+{{- end -}}
+{{- $refBaseUrl := $baseUrl -}}
+{{- if .Env.SCHEMA_REF_BASE_URL -}}
+{{- $refBaseUrl = .Env.SCHEMA_REF_BASE_URL -}}
+{{- end -}}
+{
+    "$id": "{{ $baseUrl | js }}/config.json",
+    "$schema": "https://json-schema.org/draft-07/schema",
+    "$defs": {
+        "version-1": {
+            "oneOf": [
+                {
+                    "type": "object",
+                    "properties": {
+                        "version": {
+                            "type": "string",
+                            "const": "1"
+                        }
+                    },
+                    "required": [
+                        "version"
+                    ]
+                },
+                {
+                    "type": "object",
+                    "properties": {
+                        "version": {
+                            "type": "string",
+                            "maxLength": 0
+                        }
+                    },
+                    "required": [
+                        "version"
+                    ]
+                }
+            ]
+        },
+        "version-2": {
+            "type": "object",
+            "properties": {
+                "version": {
+                    "type": "string",
+                    "const": "2"
+                }
+            },
+            "required": [
+                "version"
+            ]
+        },
+        "no-version": {
+            "not": {
+                "type": "object",
+                "properties": {
+                    "version": {
+                    }
+                },
+                "required": [
+                    "version"
+                ]
+            }
+        },
+        "no-restic-version": {
+            "type": "object",
+            "properties": {
+                "global": {
+                    "not": {
+                        "type": "object",
+                        "properties": {
+                            "restic-version": {
+                            }
+                        },
+                        "required": [
+                            "restic-version"
+                        ]
+                    }
+                }
+            }
+        }
+    },
+    "if": {
+        "$ref": "#/$defs/no-version"
+    },
+    "then": {
+        "$ref": "{{ $refBaseUrl | js }}/config-1.json"
+    },
+    "else": {
+        "if": {
+            "$ref": "#/$defs/no-restic-version"
+        },
+        "then": {
+            "oneOf": [
+                {
+                    {{ block "noResticVersion" (list $refBaseUrl "2") -}}
+                    {{- $base := index . 0 -}}
+                    {{- $config := index . 1 -}}
+                    "allOf": [
+                        {
+                            "$ref": "#/$defs/version-{{ $config }}"
+                        },
+                        {
+                            "$ref": "{{ $base | js }}/config-{{ $config }}.json"
+                        }
+                    ]
+                    {{ end }}
+                },
+                {
+                    {{ template "noResticVersion" (list $refBaseUrl "1") }}
+                }
+            ]
+        },
+        "else": {
+            "oneOf": [
+                {{ define "schemaWithResticVersion" }}
+                {{- $base := index . 0 -}}
+                {{- $config := index . 1 -}}
+                {{- $version := index . 2 -}}
+                {
+                    "allOf": [
+                        {
+                            "$ref": "#/$defs/version-{{ $config | js }}"
+                        },
+                        {
+                            "type": "object",
+                            "properties": {
+                                "global": {
+                                    "type": "object",
+                                    "properties": {
+                                        "restic-version": {
+                                            "anyOf": [
+                                                {
+                                                    "type": "string",
+                                                    "pattern": "{{ $version | replace "." "\\." | js }}.*",
+                                                    "default": "{{ $version | js }}",
+                                                    "minLength": 3
+                                                },
+                                                {
+                                                    "type": "string",
+                                                    "const": "{{ $version | js }}"
+                                                }
+                                            ]
+                                        }
+                                    },
+                                    "required": [
+                                        "restic-version"
+                                    ]
+                                }
+                            },
+                            "required": [
+                                "global"
+                            ]
+                        },
+                        {
+                            "$ref": "{{ $base | js }}/config-{{ $config | js }}-restic-{{ $version | replace "." "-" | js }}.json"
+                        }
+                    ]
+                }
+                {{ end -}}
+                {{- /* restic major version ( assuming it is "0.$major", may need to change when restic reaches v1 ) */ -}}
+                {{ range $index, $version := .KnownResticVersions -}}
+                {{- $version = slice ($version | split ".") 0 2 | join "." -}}
+                {{- if gt $index 0 -}}{{ "," }}{{- end -}}
+                {{- template "schemaWithResticVersion" (list $refBaseUrl "2" $version) -}}
+                {{ "," }}
+                {{- template "schemaWithResticVersion" (list $refBaseUrl "1" $version) -}}
+                {{- end }}
+            ]
+        }
+    },
+    "title": "resticprofile configuration",
+    "type": "object"
+}

--- a/docs/content/configuration/getting_started/_index.md
+++ b/docs/content/configuration/getting_started/_index.md
@@ -85,7 +85,7 @@ version = "1"
 {{% tab name="yaml" %}}
 
 ```yaml
-# yaml-language-server: $schema={{< absolute "jsonschema/config-1.json" nohtml >}}
+# yaml-language-server: $schema={{< absolute "jsonschema/config.json" nohtml >}}
 
 version: "1"
 
@@ -119,7 +119,7 @@ default {
 
 ```json
 {
-  "$schema": "{{< absolute "jsonschema/config-1.json" nohtml >}}",
+  "$schema": "{{< absolute "jsonschema/config.json" nohtml >}}",
   "version": "1",
   "default": {
     "repository": "local:/backup",

--- a/docs/content/configuration/jsonschema/index.md
+++ b/docs/content/configuration/jsonschema/index.md
@@ -8,7 +8,59 @@ weight: 55
 JSON, YAML and TOML configuration files can benefit from a JSON schema that describes the 
 config structure depending on the selected *restic* and configuration file version.
 
-## Schema URLs
+## Schema URL
+
+**{{< absolute "jsonschema/config.json" >}}**
+
+This schema detects config and restic version and redirects to the corresponding [versioned URL](#versioned-urls).
+Detection requires full support for JSON Schema Draft 7. Use a versioned URL where not supported (e.g. TOML). 
+
+## Usage (vscode)
+
+To use a schema with **vscode**, begin your config files with:
+
+{{< tabs groupId="config-with-json" >}}
+{{% tab name="toml" %}}
+``````toml
+#:schema {{< absolute "jsonschema/config-2.json" nohtml >}}
+
+version = "2"
+ 
+``````
+{{% /tab %}}
+{{% tab name="yaml" %}}
+``````yaml
+# yaml-language-server: $schema={{< absolute "jsonschema/config.json" nohtml >}}
+
+version: "2"
+ 
+``````
+{{% /tab %}}
+{{% tab name="json" %}}
+``````json
+{
+    "$schema": "{{< absolute "jsonschema/config.json" nohtml >}}",
+    "version": "2"
+}
+``````
+{{% /tab %}}
+{{% /tabs %}}
+
+{{% notice style="hint" %}}
+YAML & TOML validation with JSON schema is not supported out of the box. Additional extensions are required.
+{{% /notice %}}
+
+**Example**
+
+{{< figure src="/recordings/jsonschema-vsc.gif" >}}
+
+**Extension**: `redhat.vscode-yaml`
+
+## Versioned URLs
+
+The following versioned schemas are referenced from `config.json`. Which URL is selected depends 
+on config and restic version. You may use the URLs directly if you need a self-contained schema 
+file or to enforce a certain version of configuration format and/or restic flags
 
 JSON schema URLs for **any** *restic* version:
 
@@ -32,44 +84,3 @@ according to its manual pages.
 As an alternative to URLs, schemas can be generated locally with: 
 `resticprofile generate --json-schema [--version RESTIC_VERSION] [v2|v1]`
 {{% /notice %}}
-
-## Usage (vscode)
-
-To use a schema with **vscode**, begin your config files with: 
-
-{{< tabs groupId="config-with-json" >}}
-{{% tab name="toml" %}}
-``````toml
-#:schema {{< absolute "jsonschema/config-2.json" nohtml >}}
-
-version = "2"
- 
-``````
-{{% /tab %}}
-{{% tab name="yaml" %}}
-``````yaml
-# yaml-language-server: $schema={{< absolute "jsonschema/config-2.json" nohtml >}}
-
-version: "2"
- 
-``````
-{{% /tab %}}
-{{% tab name="json" %}}
-``````json
-{
-    "$schema": "{{< absolute "jsonschema/config-2.json" nohtml >}}",
-    "version": "2"
-}
-``````
-{{% /tab %}}
-{{% /tabs %}}
-
-{{% notice style="hint" %}}
-YAML & TOML validation with JSON schema is not supported out of the box. Additional extensions are required.
-{{% /notice %}}
-
-**Example**
-
-{{< figure src="/recordings/jsonschema-vsc.gif" >}}
-
-**Extension**: `redhat.vscode-yaml`

--- a/main.go
+++ b/main.go
@@ -231,13 +231,19 @@ func main() {
 	}
 
 	// detect restic version
-	if len(global.ResticVersion) == 0 {
-		if global.ResticVersion, err = restic.GetVersion(resticBinary); err != nil {
-			clog.Warningf("assuming restic is at latest known version ; %s", err.Error())
-			global.ResticVersion = restic.AnyVersion
+	{
+		detected := ""
+		if len(global.ResticVersion) == 0 {
+			if global.ResticVersion, err = restic.GetVersion(resticBinary); err == nil {
+				detected = " (detected)"
+			} else {
+				clog.Warningf("assuming restic is at latest known version ; %s", err.Error())
+				global.ResticVersion = restic.AnyVersion
+				detected = "unknown version (any)"
+			}
 		}
+		clog.Debugf("restic %s%s", global.ResticVersion, detected)
 	}
-	clog.Debugf("restic %s", global.ResticVersion)
 
 	if c.HasProfile(flags.name) {
 		// if running as a systemd timer


### PR DESCRIPTION
This PR:
* Generates a JSON schema that redirects to versioned schemas based on `version` and `global.restic-version` properties (see also [SchemaStore](https://github.com/SchemaStore/schemastore/blob/master/CONTRIBUTING.md)). 
* Adds an URL for the schema: https://creativeprojects.github.io/resticprofile/jsonschema/config.json
* Fixes `generate --config-reference filename`
* Simplifies config-1 schema files (schema in `additionalProperties` instead of via regex matching with negative lookbehind)

The is the first step to add the schema to the schemastore catalog (we need a single schema for this) and is also more convenient if the URL doesn't need to be changed 😀