### PR TITLE
Templates: Add `map`/`splitR`/`contains`/`matches`

### DIFF
--- a/docs/content/configuration/templates/index.md
+++ b/docs/content/configuration/templates/index.md
@@ -579,9 +579,12 @@ Please note there are some functions only made available by hugo though, resticp
 ## Template functions
 
 resticprofile supports the following set of own functions in all templates:
-
+* `{{ "some string" | contains "some" }}` => `true`
+* `{{ "some string" | matches "^.+str.+$" }}` => `true`
 * `{{ "some old string" | replace "old" "new" }}` => `"some new string"`
+* `{{ "some old string" | replaceR "(old)" "$1 and new" }}` => `"some old and new string"`
 * `{{ "some old string" | regex "(old)" "$1 and new" }}` => `"some old and new string"`
+  (`regex` is an alias to `replaceR`) 
 * `{{ "ABC" | lower }}` => `"abc"`
 * `{{ "abc" | upper }}` => `"ABC"`
 * `{{ "  A " | trim }}` => `"A"`
@@ -589,10 +592,14 @@ resticprofile supports the following set of own functions in all templates:
 * `{{ "--A-" | trimSuffix "-" }}` => `"--A"`
 * `{{ "A,B,C" | split "," }}` => `["A", "B", "C"]`
 * `{{ "A,B,C" | split "," | join ";" }}` => `"A;B;C"`
+* `{{ "A, B, C" | splitR "\\s*,\\s*" | join ";" }}` => `"A;B;C"`
 * `{{ range $v := list "A" "B" "C" }} ({{ $v }}) {{ end }}` => ` (A)  (B)  (C) `
+* `{{ with $v := map "k1" "v1" "k2" "v2" }} {{ .k1 }}-{{ .k2 }} {{ end }}` => ` v1-v2 `
+* `{{ with $v := list "A" "B" "C" "D" | map }} {{ ._0 }}-{{ ._1 }}-{{ ._3 }} {{ end }}` => ` A-B-D `
+* `{{ with $v := list "A" "B" "C" "D" | map "key" }} {{ .key | join "-" }} {{ end }}` => ` A-B-C-D `
 * `{{ tempDir }}` => `"/tmp/resticprofile.../t"` - unique OS specific existing temporary directory
 * `{{ tempFile "filename" }}` => `"/tmp/resticprofile.../t/filename"` - unique OS specific existing temporary file
 
-The temporary directory and files returned by the `{{ temp* }}` functions are guaranteed to exist, accessible and removed when resticprofile ends.
+The temporary directory and files returned by the `{{ temp* }}` functions are guaranteed to exist, be accessible and are removed when resticprofile ends.
 
 Please refer to the official documentation for the set of additional default functions provided in go templates. 

--- a/util/templates/functions.go
+++ b/util/templates/functions.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"path"
 	"path/filepath"
+	"reflect"
 	"regexp"
 	"strings"
 	"sync"
@@ -18,8 +19,11 @@ import (
 // TemplateFuncs declares a few standard functions to simplify working with templates
 //
 // Available functions:
+//   - {{ "some string" | contains "some" }} => true
+//   - {{ "some string" | matches "^.+str.+$" }} => true
 //   - {{ "some old string" | replace "old" "new" }} => "some new string"
-//   - {{ "some old string" | regex "(old)" "$1 and new" }} => "some old and new string"
+//   - {{ "some old string" | replaceR "(old)" "$1 and new" }} => "some old and new string"
+//   - {{ "some old string" | regex "(old)" "$1 and new" }} => "some old and new string" (alias to "replaceR")
 //   - {{ "ABC" | lower }} => "abc"
 //   - {{ "abc" | upper }} => "ABC"
 //   - {{ "  A " | trim }} => "A"
@@ -27,36 +31,44 @@ import (
 //   - {{ "--A-" | trimSuffix " " }} => "--A"
 //   - {{ "A,B,C" | split "," }} => ["A", "B", "C"]
 //   - {{ "A,B,C" | split "," | join ";" }} => "A;B;C"
+//   - {{ "A ,B, C" | splitR "\\s*,\\s*" | join ";" }} => "A;B;C"
 //   - {{ list "A" "B" "C" }} => ["A", "B", "C"]
+//   - {{ with $v := map "k1" "v1" "k2" "v2" }} {{ .k1 }}-{{ .k2 }} {{ end }}  => " v1-v2 "
+//   - {{ with $v := list "A" "B" "C" "D" | map }} {{ ._0 }}-{{ ._1 }}-{{ ._3 }} {{ end }}  => " A-B-D "
+//   - {{ with $v := list "A" "B" "C" "D" | map "key" }} {{ .key | join "-" }} {{ end }}  => " A-B-C-D "
 //   - {{ tempDir }} => "/path/to/unique-tempdir"
 //   - {{ tempFile "filename" }} => "/path/to/unique-tempdir/filename"
 func TemplateFuncs(funcs ...map[string]any) (templateFuncs map[string]any) {
-	toString := func(arg any) string { return fmt.Sprint(arg) }
-	toAny := func(arg string) any { return arg }
-
-	compiledRegex := sync.Map{}
-	mustCompileRegex := func(pattern string) *regexp.Regexp {
-		value, ok := compiledRegex.Load(pattern)
+	compiled := sync.Map{}
+	mustCompile := func(pattern string) *regexp.Regexp {
+		value, ok := compiled.Load(pattern)
 		if !ok {
-			value, _ = compiledRegex.LoadOrStore(pattern, regexp.MustCompile(pattern))
+			value, _ = compiled.LoadOrStore(pattern, regexp.MustCompile(pattern))
 		}
 		return value.(*regexp.Regexp)
 	}
 
 	templateFuncs = map[string]any{
+		"contains":   func(search any, src any) bool { return strings.Contains(toString(src), toString(search)) },
+		"matches":    func(ptn string, src any) bool { return mustCompile(ptn).MatchString(toString(src)) },
 		"replace":    func(old, new, src string) string { return strings.ReplaceAll(src, old, new) },
-		"regex":      func(ptn, repl, src string) string { return mustCompileRegex(ptn).ReplaceAllString(src, repl) },
+		"replaceR":   func(ptn, repl, src string) string { return mustCompile(ptn).ReplaceAllString(src, repl) },
 		"lower":      strings.ToLower,
 		"upper":      strings.ToUpper,
 		"trim":       strings.TrimSpace,
 		"trimPrefix": func(prefix, src string) string { return strings.TrimPrefix(src, prefix) },
 		"trimSuffix": func(suffix, src string) string { return strings.TrimSuffix(src, suffix) },
-		"split":      func(sep, src string) []any { return collect.From(strings.Split(src, sep), toAny) },
+		"split":      func(sep, src string) []any { return collect.From(strings.Split(src, sep), toAny[string]) },
+		"splitR":     func(ptn, src string) []any { return collect.From(mustCompile(ptn).Split(src, -1), toAny[string]) },
 		"join":       func(sep string, src []any) string { return strings.Join(collect.From(src, toString), sep) },
 		"list":       func(args ...any) []any { return args },
+		"map":        toMap,
 		"tempDir":    TempDir,
 		"tempFile":   TempFile,
 	}
+
+	// aliases
+	templateFuncs["regex"] = templateFuncs["replaceR"]
 
 	for _, funcsMap := range funcs {
 		maps.Copy(templateFuncs, funcsMap)
@@ -97,6 +109,49 @@ func TempFile(name string) (filename string) {
 		_ = file.Close()
 	} else if !os.IsExist(err) {
 		panic(err)
+	}
+	return
+}
+
+func toAny[T any](arg T) any { return arg }
+
+func toString(arg any) string {
+	switch t := arg.(type) {
+	case string:
+		return t
+	case []any:
+		return "[" + strings.Join(collect.From(t, toString), ",") + "]"
+	default:
+		return fmt.Sprint(arg)
+	}
+}
+
+func toMap(args ...any) (m map[string]any) {
+	m = make(map[string]any)
+	var key *string
+	for _, arg := range args {
+		switch v := arg.(type) {
+		case string:
+			if key == nil {
+				key = &v
+			} else {
+				m[*key] = v
+				key = nil
+			}
+		default:
+			if key != nil {
+				m[*key] = v
+			} else if v != nil && reflect.TypeOf(v).Kind() == reflect.Slice {
+				rv := reflect.ValueOf(v)
+				for i, length := 0, rv.Len(); i < length; i++ {
+					if value := rv.Index(i); value.CanInterface() {
+						k := fmt.Sprintf("_%d", i)
+						m[k] = value.Interface()
+					}
+				}
+			}
+			key = nil
+		}
 	}
 	return
 }

--- a/util/templates/functions_test.go
+++ b/util/templates/functions_test.go
@@ -18,7 +18,15 @@ func TestTemplateFuncs(t *testing.T) {
 	tests := []struct {
 		template, expected string
 	}{
+		{template: `{{ "some string" | contains "some" }}`, expected: `true`},
+		{template: `{{ "some string" | contains "else" }}`, expected: `false`},
+		{template: `{{ "1 2 3 5" | split " " | contains "3" }}`, expected: `true`},
+		{template: `{{ "1 2 3 5" | split " " | contains 03.0 }}`, expected: `true`},
+		{template: `{{ "1 2 3 5" | split " " | contains "23" }}`, expected: `false`},
+		{template: `{{ "some string" | matches "^.+str.+$" }}`, expected: `true`},
+		{template: `{{ "some string" | matches "^.+else.+$" }}`, expected: `false`},
 		{template: `{{ "some old string" | replace "old" "new" }}`, expected: `some new string`},
+		{template: `{{ "some old string" | replaceR "(old)" "$1 and new" }}`, expected: `some old and new string`},
 		{template: `{{ "some old string" | regex "(old)" "$1 and new" }}`, expected: `some old and new string`},
 		{template: `{{ "ABC" | lower }}`, expected: `abc`},
 		{template: `{{ "abc" | upper }}`, expected: `ABC`},
@@ -26,9 +34,15 @@ func TestTemplateFuncs(t *testing.T) {
 		{template: `{{ "--A-" | trimPrefix "--" }}`, expected: `A-`},
 		{template: `{{ "--A-" | trimSuffix "-" }}`, expected: `--A`},
 		{template: `{{ "A,B,C" | split "," | join ";" }}`, expected: `A;B;C`},
+		{template: `{{ "A , B,C" | splitR "\\s*,\\s*" | join ";" }}`, expected: `A;B;C`},
 		{template: `{{ list "A" "B" "C" | join ";" }}`, expected: `A;B;C`},
+		{template: `{{ "1 2 3 5" | split " " | list | join "-" }}`, expected: `[1,2,3,5]`},
 		{template: `{{ range $v := "A,B,C" | split "," }} {{ $v }} {{ end }}`, expected: ` A  B  C `},
 		{template: `{{ range $v := list "A" "B" "C" }} {{ $v }} {{ end }}`, expected: ` A  B  C `},
+		{template: `{{ with $v := map "k1" "v1" "k2" "v2" }} {{ .k1 }}-{{ .k2 }} {{ end }}`, expected: ` v1-v2 `},
+		{template: `{{ with $v := map "k1" nil nil "v2" }} {{ .k1 }}-{{ .k2 }} {{ end }}`, expected: ` <no value>-<no value> `},
+		{template: `{{ with $v := list "A" "B" nil "D" | map }} {{ ._0 }}-{{ ._1 }}-{{ ._2 }}-{{ ._3 }} {{ end }}`, expected: ` A-B-<no value>-D `},
+		{template: `{{ with $v := list "A" "B" nil "D" | map "key" }} {{ .key | join "-" }} {{ end }}`, expected: ` A-B-<nil>-D `},
 		{template: `{{ tempDir }}`, expected: dir},
 		{template: `{{ tempDir }}`, expected: dir}, // constant results when repeated
 		{template: `{{ tempFile "test.txt" }}`, expected: file},


### PR DESCRIPTION
Adds a few more template functions:

* `{{ if "some string" | contains "some" }} some is there {{ end }}`
* `{{ if "some string" | matches "some|thing" }} some or thing is there {{ end }}`
* `{{ $token := range ( "x ; y , z" | splitR "\\s*[,;]\\s*" ) }} {{ $token }} {{ end }}`

Mapping variant 1: 

````
{{ define "tpl" }}
Hello {{ .whom }}
{{ end }}
{{ template "tpl" ("whom" "World" | map) }}
````

Mapping variant 2:

````
{{ define "tpl" }}
Hello {{ ._0 }}
{{ end }}
{{ template "tpl" (list "World" | map) }}.
````
