### PR TITLE
Templates: {{ "data" | base64 }} & {{ "data" | hex }}

### DIFF
--- a/docs/content/configuration/templates/index.md
+++ b/docs/content/configuration/templates/index.md
@@ -579,27 +579,43 @@ Please note there are some functions only made available by hugo though, resticp
 ## Template functions
 
 resticprofile supports the following set of own functions in all templates:
+
 * `{{ "some string" | contains "some" }}` => `true`
 * `{{ "some string" | matches "^.+str.+$" }}` => `true`
-* `{{ "some old string" | replace "old" "new" }}` => `"some new string"`
-* `{{ "some old string" | replaceR "(old)" "$1 and new" }}` => `"some old and new string"`
-* `{{ "some old string" | regex "(old)" "$1 and new" }}` => `"some old and new string"`
+* `{{ "some old string" | replace "old" "new" }}` => `some new string`
+* `{{ "some old string" | replaceR "(old)" "$1 and new" }}` => `some old and new string`
+* `{{ "some old string" | regex "(old)" "$1 and new" }}` => `some old and new string`
   (`regex` is an alias to `replaceR`) 
-* `{{ "ABC" | lower }}` => `"abc"`
-* `{{ "abc" | upper }}` => `"ABC"`
-* `{{ "  A " | trim }}` => `"A"`
-* `{{ "--A-" | trimPrefix "--" }}` => `"A-"`
-* `{{ "--A-" | trimSuffix "-" }}` => `"--A"`
-* `{{ "A,B,C" | split "," }}` => `["A", "B", "C"]`
-* `{{ "A,B,C" | split "," | join ";" }}` => `"A;B;C"`
-* `{{ "A, B, C" | splitR "\\s*,\\s*" | join ";" }}` => `"A;B;C"`
+* `{{ "ABC" | lower }}` => `abc`
+* `{{ "abc" | upper }}` => `ABC`
+* `{{ "  A " | trim }}` => `A`
+* `{{ "--A-" | trimPrefix "--" }}` => `A-`
+* `{{ "--A-" | trimSuffix "-" }}` => `--A`
+* `{{ range $v := "A,B,C" | split "," }} ({{ $v }}) {{ end }}` => ` (A)  (B)  (C) `
+* `{{ "A,B,C" | split "," | join ";" }}` => `A;B;C`
+* `{{ "A, B, C" | splitR "\\s*,\\s*" | join ";" }}` => `A;B;C`
 * `{{ range $v := list "A" "B" "C" }} ({{ $v }}) {{ end }}` => ` (A)  (B)  (C) `
-* `{{ with $v := map "k1" "v1" "k2" "v2" }} {{ .k1 }}-{{ .k2 }} {{ end }}` => ` v1-v2 `
-* `{{ with $v := list "A" "B" "C" "D" | map }} {{ ._0 }}-{{ ._1 }}-{{ ._3 }} {{ end }}` => ` A-B-D `
-* `{{ with $v := list "A" "B" "C" "D" | map "key" }} {{ .key | join "-" }} {{ end }}` => ` A-B-C-D `
-* `{{ tempDir }}` => `"/tmp/resticprofile.../t"` - unique OS specific existing temporary directory
-* `{{ tempFile "filename" }}` => `"/tmp/resticprofile.../t/filename"` - unique OS specific existing temporary file
+* `{{ with map "k1" "v1" "k2" "v2" }} {{ .k1 }}-{{ .k2 }} {{ end }}` => ` v1-v2 `
+* `{{ with list "A" "B" "C" "D" | map }} {{ ._0 }}-{{ ._1 }}-{{ ._3 }} {{ end }}` => ` A-B-D `
+* `{{ with list "A" "B" "C" "D" | map "key" }} {{ .key | join "-" }} {{ end }}` => ` A-B-C-D `
+* `{{ tempDir }}` => `/tmp/resticprofile.../t` - unique OS specific existing temporary directory
+* `{{ tempFile "filename" }}` => `/tmp/resticprofile.../t/filename` - unique OS specific existing temporary file
 
-The temporary directory and files returned by the `{{ temp* }}` functions are guaranteed to exist, be accessible and are removed when resticprofile ends.
+All `{{ temp* }}` functions guarantee that returned temporary directories and files are existing & writable. 
+When resticprofile ends, temporary directories and files are removed.
 
-Please refer to the official documentation for the set of additional default functions provided in go templates. 
+The following functions can be used to encode data (e.g. when dealing with arbitrary input):
+
+* `{{ "a & b\n" | js }}` => `a \u0026 b\u000A` - JSON string equivalent of the input (*builtin*)
+* `{{ "a & b\n" | html }}` => `a &amp; b\n` - HTML text escaped input (*builtin*)
+* `{{ "a & b\n" | urlquery }}` => `a+%26+b%0A` - URL query escaped input (*builtin*)
+* `{{ "plain" | base64 }}` => `cGxhaW4=` - Base64 encoded input
+* `{{ "plain" | hex }}` => `706c61696e` - Hexadecimal encoded input
+
+{{% notice hint %}}
+Encode with `js` when creating **strings** in *YAML*, *TOML* or *JSON* configuration files, e.g.: `"{{ .Env.MyVar | js }}"`. 
+This ensures the markup remains correct and can be parsed regardless of the input data.
+{{% /notice %}}
+
+
+Please refer to the [official documentation](https://golang.org/pkg/text/template/) for the general syntax and set of default functions provided in go text templates. 

--- a/util/templates/functions.go
+++ b/util/templates/functions.go
@@ -1,6 +1,8 @@
 package templates
 
 import (
+	"encoding/base64"
+	"encoding/hex"
 	"fmt"
 	"os"
 	"path"
@@ -36,6 +38,8 @@ import (
 //   - {{ with $v := map "k1" "v1" "k2" "v2" }} {{ .k1 }}-{{ .k2 }} {{ end }}  => " v1-v2 "
 //   - {{ with $v := list "A" "B" "C" "D" | map }} {{ ._0 }}-{{ ._1 }}-{{ ._3 }} {{ end }}  => " A-B-D "
 //   - {{ with $v := list "A" "B" "C" "D" | map "key" }} {{ .key | join "-" }} {{ end }}  => " A-B-C-D "
+//   - {{ "plain" | hex }} => "706c61696e"
+//   - {{ "plain" | base64 }} => "cGxhaW4="
 //   - {{ tempDir }} => "/path/to/unique-tempdir"
 //   - {{ tempFile "filename" }} => "/path/to/unique-tempdir/filename"
 func TemplateFuncs(funcs ...map[string]any) (templateFuncs map[string]any) {
@@ -63,6 +67,8 @@ func TemplateFuncs(funcs ...map[string]any) (templateFuncs map[string]any) {
 		"join":       func(sep string, src []any) string { return strings.Join(collect.From(src, toString), sep) },
 		"list":       func(args ...any) []any { return args },
 		"map":        toMap,
+		"base64":     func(src any) string { return base64.StdEncoding.EncodeToString([]byte(toString(src))) },
+		"hex":        func(src any) string { return hex.EncodeToString([]byte(toString(src))) },
 		"tempDir":    TempDir,
 		"tempFile":   TempFile,
 	}
@@ -119,6 +125,8 @@ func toString(arg any) string {
 	switch t := arg.(type) {
 	case string:
 		return t
+	case []byte:
+		return string(t)
 	case []any:
 		return "[" + strings.Join(collect.From(t, toString), ",") + "]"
 	default:

--- a/util/templates/functions_test.go
+++ b/util/templates/functions_test.go
@@ -39,14 +39,19 @@ func TestTemplateFuncs(t *testing.T) {
 		{template: `{{ "1 2 3 5" | split " " | list | join "-" }}`, expected: `[1,2,3,5]`},
 		{template: `{{ range $v := "A,B,C" | split "," }} {{ $v }} {{ end }}`, expected: ` A  B  C `},
 		{template: `{{ range $v := list "A" "B" "C" }} {{ $v }} {{ end }}`, expected: ` A  B  C `},
-		{template: `{{ with $v := map "k1" "v1" "k2" "v2" }} {{ .k1 }}-{{ .k2 }} {{ end }}`, expected: ` v1-v2 `},
-		{template: `{{ with $v := map "k1" nil nil "v2" }} {{ .k1 }}-{{ .k2 }} {{ end }}`, expected: ` <no value>-<no value> `},
-		{template: `{{ with $v := list "A" "B" nil "D" | map }} {{ ._0 }}-{{ ._1 }}-{{ ._2 }}-{{ ._3 }} {{ end }}`, expected: ` A-B-<no value>-D `},
-		{template: `{{ with $v := list "A" "B" nil "D" | map "key" }} {{ .key | join "-" }} {{ end }}`, expected: ` A-B-<nil>-D `},
+		{template: `{{ with map "k1" "v1" "k2" "v2" }} {{ .k1 }}-{{ .k2 }} {{ end }}`, expected: ` v1-v2 `},
+		{template: `{{ with map "k1" nil nil "v2" }} {{ .k1 }}-{{ .k2 }} {{ end }}`, expected: ` <no value>-<no value> `},
+		{template: `{{ with list "A" "B" nil "D" | map }} {{ ._0 }}-{{ ._1 }}-{{ ._2 }}-{{ ._3 }} {{ end }}`, expected: ` A-B-<no value>-D `},
+		{template: `{{ with list "A" "B" nil "D" | map "key" }} {{ .key | join "-" }} {{ end }}`, expected: ` A-B-<nil>-D `},
 		{template: `{{ tempDir }}`, expected: dir},
 		{template: `{{ tempDir }}`, expected: dir}, // constant results when repeated
 		{template: `{{ tempFile "test.txt" }}`, expected: file},
 		{template: `{{ tempFile "test.txt" }}`, expected: file}, // constant results when repeated
+		{template: `{{ "a & b\n" | html }}`, expected: "a &amp; b\n"},
+		{template: `{{ "a & b\n" | urlquery }}`, expected: "a+%26+b%0A"},
+		{template: `{{ "a & b\n" | js }}`, expected: "a \\u0026 b\\u000A"},
+		{template: `{{ "plain" | hex }}`, expected: "706c61696e"},
+		{template: `{{ "plain" | base64 }}`, expected: "cGxhaW4="},
 		{template: `{{ hello }}`, expected: `Hello World`},
 	}
 


### PR DESCRIPTION
Inspired by #210 

Adds 2 more standard encoding options (`base64` / `hex`) and improves documentation on encoding functions in templates