### PR TITLE
Fix: Do not add `--tag` for `tag: true`

### DIFF
--- a/config/profile.go
+++ b/config/profile.go
@@ -463,6 +463,8 @@ func (p *Profile) ResolveConfiguration() {
 		// Copy tags from backup if tag is set to boolean true
 		if tags, ok := stringifyValueOf(p.Backup.OtherFlags[constants.ParameterTag]); ok {
 			p.SetTag(tags...)
+		} else {
+			p.SetTag() // resolve tag parameters when no tag is set in backup
 		}
 
 		// Copy parameter path from backup sources if path is set to boolean true
@@ -792,7 +794,11 @@ func replaceTrueValue(source map[string]any, key string, replace ...string) {
 	if genericValue, ok := source[key]; ok {
 		if value, ok := genericValue.(bool); ok {
 			if value {
-				source[key] = replace
+				if len(replace) > 0 {
+					source[key] = replace
+				} else {
+					delete(source, key)
+				}
 			}
 		}
 	}


### PR DESCRIPTION
Fixes a problem, found while testing #220.

`tag` is implicitly true in `retention` from config version 2 and the following config:

```yaml
version: "2"
profiles:
  my-profile:
    inherit: default
    backup:
      source:
        - /path/to/backup
    retention:
      after-backup: true
      keep-last: 3
```

...results in:
```
➜ resticprofile --dry-run my-profile.backup
...
dry-run: /usr/local/bin/restic forget ... --repo="..." --tag
```

But for `tag` (as well as `path` and `host`), `true` means copy from backup, not set an empty flag.

With the pr, no empty `--tag` flags are added for `tag` being boolean `true`.