### PR TITLE
Retention: Align host filter with "backup"

### DIFF
--- a/config/info_customizer.go
+++ b/config/info_customizer.go
@@ -72,18 +72,31 @@ func init() {
 			info.mayBool = true
 			info.examples = []string{"true", "false", fmt.Sprintf(`"%s"`, propertyName)}
 
-			if sectionName == constants.CommandBackup {
-				if propertyName != constants.ParameterHost {
-					info.examples = info.examples[1:] // remove "true" from examples of backup section
-					note = fmt.Sprintf(`Boolean true is unsupported in section "backup".`)
-				}
-			} else {
-				note = fmt.Sprintf(`Boolean true is replaced with the %ss from section "backup".`, propertyName)
-			}
+			suffixDefaultTrueV2 := fmt.Sprintf(` Defaults to true for config version 2 in "%s".`, sectionName)
 
 			if propertyName == constants.ParameterHost {
 				info.format = "hostname"
 				note = `Boolean true is replaced with the hostname of the system.`
+			} else {
+				note = fmt.Sprintf(`Boolean true is replaced with the %ss from section "backup".`, propertyName)
+			}
+
+			if sectionName == constants.CommandBackup {
+				if propertyName != constants.ParameterHost {
+					info.examples = info.examples[1:] // remove "true" from examples of backup section
+					note = fmt.Sprintf(`Boolean true is unsupported in section "backup".`)
+				} else {
+					note += suffixDefaultTrueV2
+				}
+			} else if sectionName == constants.SectionConfigurationRetention {
+				if propertyName == constants.ParameterHost {
+					note = `Boolean true is replaced with the hostname that applies in section "backup".`
+				}
+				if propertyName == constants.ParameterPath {
+					note += ` Defaults to true in "retention".`
+				} else {
+					note += suffixDefaultTrueV2
+				}
 			}
 
 			if note != "" {

--- a/config/info_customizer_test.go
+++ b/config/info_customizer_test.go
@@ -74,6 +74,12 @@ func TestHostTagPathProperty(t *testing.T) {
 	note := `Boolean true is replaced with the {{property}}s from section "backup".`
 	hostNote := `Boolean true is replaced with the hostname of the system.`
 	backupNote := `Boolean true is unsupported in section "backup".`
+	retentionHostNote := `Boolean true is replaced with the hostname that applies in section "backup".`
+	defaultSuffix := ` Defaults to true in "{{section}}".`
+	defaultSuffixV2 := ` Defaults to true for config version 2 in "{{section}}".`
+
+	backup := constants.CommandBackup
+	retention := constants.SectionConfigurationRetention
 
 	tests := []struct {
 		section, property, note, format string
@@ -83,14 +89,20 @@ func TestHostTagPathProperty(t *testing.T) {
 		{section: "any", property: constants.ParameterPath},
 		{section: "any", property: constants.ParameterTag},
 
-		{section: constants.CommandBackup, property: constants.ParameterHost, note: hostNote, format: "hostname"},
-		{section: constants.CommandBackup, property: constants.ParameterPath, note: backupNote, examples: []string{"false", `"{{property}}"`}},
-		{section: constants.CommandBackup, property: constants.ParameterTag, note: backupNote, examples: []string{"false", `"{{property}}"`}},
+		{section: retention, property: constants.ParameterHost, note: retentionHostNote + defaultSuffixV2, format: "hostname"},
+		{section: retention, property: constants.ParameterPath, note: note + defaultSuffix},
+		{section: retention, property: constants.ParameterTag, note: note + defaultSuffixV2},
+
+		{section: backup, property: constants.ParameterHost, note: hostNote + defaultSuffixV2, format: "hostname"},
+		{section: backup, property: constants.ParameterPath, note: backupNote, examples: []string{"false", `"{{property}}"`}},
+		{section: backup, property: constants.ParameterTag, note: backupNote, examples: []string{"false", `"{{property}}"`}},
 	}
 	for i, test := range tests {
 		t.Run(fmt.Sprintf("%d", i), func(t *testing.T) {
 			propertyReplacer := func(s string) string {
-				return strings.ReplaceAll(s, "{{property}}", test.property)
+				s = strings.ReplaceAll(s, "{{property}}", test.property)
+				s = strings.ReplaceAll(s, "{{section}}", test.section)
+				return s
 			}
 			if test.examples == nil {
 				test.examples = examples

--- a/config/profile.go
+++ b/config/profile.go
@@ -532,7 +532,7 @@ func (p *Profile) ResolveConfiguration() {
 	if p.Backup != nil {
 		// Copy tags from backup if tag is set to boolean true
 		if tags, ok := stringifyValueOf(p.Backup.OtherFlags[constants.ParameterTag]); ok {
-			p.SetTag(tags...)
+			p.SetTag(strings.Join(tags, ",")) // must use "tag1,tag2,..." to require all tags
 		} else {
 			p.SetTag() // resolve tag parameters when no tag is set in backup
 		}

--- a/config/profile.go
+++ b/config/profile.go
@@ -206,7 +206,7 @@ type RetentionSection struct {
 	ScheduleBaseSection `mapstructure:",squash" deprecated:"0.11.0"`
 	OtherFlagsSection   `mapstructure:",squash"`
 	BeforeBackup        *bool `mapstructure:"before-backup" description:"Apply retention before starting the backup command"`
-	AfterBackup         *bool `mapstructure:"after-backup" description:"Apply retention after the backup command succeeded"`
+	AfterBackup         *bool `mapstructure:"after-backup" description:"Apply retention after the backup command succeeded. Defaults to true if any \"keep-*\" flag is set and \"before-backup\" is unset"`
 }
 
 func (r *RetentionSection) IsEmpty() bool { return r == nil }
@@ -238,7 +238,7 @@ func (r *RetentionSection) resolve(profile *Profile) {
 		}
 
 		// Copy "tag" from "backup" if it was set and hasn't been redefined here
-		// Allow setting it at profile level when not defined in "backup" or "retention"
+		// Allow setting it at profile level when not defined in "backup" nor "retention"
 		if hasBackup &&
 			!isSet(r, constants.ParameterTag) &&
 			isSet(profile.Backup, constants.ParameterTag) {

--- a/config/profile_test.go
+++ b/config/profile_test.go
@@ -586,6 +586,7 @@ func TestPathAndTagInRetention(t *testing.T) {
 	require.NoError(t, err)
 
 	backupTags := []string{"one", "two"}
+	flatBackupTags := func() []string { return []string{strings.Join(backupTags, ",")} }
 
 	testProfileWithBase := func(t *testing.T, version Version, retention, baseDir string) *Profile {
 		prefix := ""
@@ -693,12 +694,12 @@ func TestPathAndTagInRetention(t *testing.T) {
 
 		t.Run("ImplicitCopyTagInV2", func(t *testing.T) {
 			profile := testProfile(t, Version02, ``)
-			assert.Equal(t, backupTags, tagFlag(t, profile))
+			assert.Equal(t, flatBackupTags(), tagFlag(t, profile))
 		})
 
 		t.Run("CopyTag", func(t *testing.T) {
 			profile := testProfile(t, Version01, `tag = true`)
-			assert.Equal(t, backupTags, tagFlag(t, profile))
+			assert.Equal(t, flatBackupTags(), tagFlag(t, profile))
 		})
 
 		t.Run("ReplaceTag", func(t *testing.T) {

--- a/wrapper.go
+++ b/wrapper.go
@@ -22,6 +22,7 @@ import (
 	"github.com/creativeprojects/resticprofile/restic"
 	"github.com/creativeprojects/resticprofile/shell"
 	"github.com/creativeprojects/resticprofile/term"
+	"github.com/creativeprojects/resticprofile/util/bools"
 	"github.com/creativeprojects/resticprofile/util/collect"
 	"golang.org/x/exp/slices"
 )
@@ -162,7 +163,7 @@ func (r *resticWrapper) getBackupAction() func() error {
 		}
 
 		// Retention before
-		if err == nil && r.profile.Retention != nil && r.profile.Retention.BeforeBackup {
+		if err == nil && r.profile.Retention != nil && bools.IsTrue(r.profile.Retention.BeforeBackup) {
 			err = r.runRetention()
 		}
 
@@ -172,7 +173,7 @@ func (r *resticWrapper) getBackupAction() func() error {
 		}
 
 		// Retention after
-		if err == nil && r.profile.Retention != nil && r.profile.Retention.AfterBackup {
+		if err == nil && r.profile.Retention != nil && bools.IsTrue(r.profile.Retention.AfterBackup) {
 			err = r.runRetention()
 		}
 


### PR DESCRIPTION
Aligns the `--host` filter of "retention" (forget) with "backup" in restic (if host is not set, it defaults to [`os.Hostname()`](https://github.com/restic/restic/blob/237f32c651d4924242783a02c9a52b09ccc2dc4f/cmd/restic/cmd_backup.go#L48) in restic, but forget has no default matching all hosts if unset)

After this change, when using `retention` in version 2 configs, all 3 filters `path`, `tags` and `host` are aligned with the `backup` section if not redefined.

Other changes:
* Auto enables `after-backup: true` if nothing was specified explicitly but `keep-*` is set
  (to avoid case like #226).
* Fixes a problem with the `tag` copy from `backup`. Tags must be copied as single flag (`"tag1,tag2,tag3,..."`) instead of multiple flags to match correctly
  (mentioned in #225)

@creativeprojects : before I create tests, what do you think on this?