### PR TITLE
Support build when GOPATH is unset / fix mockery build warning

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,10 +15,7 @@
 /dist
 
 # binary
-/resticprofile
-/resticprofile_darwin
-/resticprofile_linux
-/resticprofile_pi
+/resticprofile*
 *.exe
 
 # test output

--- a/.mockery.yaml
+++ b/.mockery.yaml
@@ -1,1 +1,19 @@
+# Mockery config >= v2.31.0
 with-expecter: true
+
+dir: "{{.InterfaceDir}}/mocks"
+outpkg: "mocks"
+filename: "{{.InterfaceName}}.go"
+mockname: "{{.InterfaceName}}"
+
+packages:
+  github.com/creativeprojects/resticprofile/config:
+    interfaces:
+      ProfileInfo:
+      PropertyInfo:
+      SectionInfo:
+      NamedPropertySet:
+
+  github.com/creativeprojects/resticprofile/schedule:
+    interfaces:
+      Handler:

--- a/config/info.go
+++ b/config/info.go
@@ -16,8 +16,6 @@ import (
 )
 
 // ProfileInfo provides structural information on profiles and can be used for specification and validation
-//
-//go:generate mockery --name=ProfileInfo
 type ProfileInfo interface {
 	// PropertySet contains properties shared across sections
 	PropertySet
@@ -28,8 +26,6 @@ type ProfileInfo interface {
 }
 
 // SectionInfo provides structural information on a particular profile section
-//
-//go:generate mockery --name=SectionInfo
 type SectionInfo interface {
 	// Named provides Name and Description of the section
 	Named
@@ -66,16 +62,12 @@ type PropertySet interface {
 }
 
 // NamedPropertySet is Named and PropertySet
-//
-//go:generate mockery --name=NamedPropertySet
 type NamedPropertySet interface {
 	Named
 	PropertySet
 }
 
 // PropertyInfo provides details on an individual property
-//
-//go:generate mockery --name=PropertyInfo
 type PropertyInfo interface {
 	// Named provides Name and Description of the property
 	Named

--- a/docs/content/installation/source/_index.md
+++ b/docs/content/installation/source/_index.md
@@ -25,3 +25,28 @@ To install the binary in your user path:
 ```shell
 $ make install
 ```
+
+To build all common platforms (`build-mac`, `build-linux`, `build-pi` & `build-windows`):
+
+```shell
+$ make build-all
+```
+
+Alternatively, a **go-only** build (without `GNU Make`) is accomplished with:
+
+```shell
+$ git clone https://github.com/creativeprojects/resticprofile.git
+$ cd resticprofile
+$ go mod download
+$ go generate ./... 
+$ go build -o resticprofile .
+```
+
+
+{{% notice style="note" %}}
+
+The build step `go generate ./...` installs additional binaries `github.com/zyedidia/eget` and `github.com/vektra/mockery` into `$GOPATH/bin`.
+See `generate.go`, `Makefile` and `go.mod` for details on additional dependencies.
+
+{{% /notice %}}
+

--- a/generate.go
+++ b/generate.go
@@ -2,3 +2,4 @@ package main
 
 //go:generate go install -v github.com/zyedidia/eget@latest
 //go:generate eget vektra/mockery --upgrade-only --to "${GOPATH}/bin"
+//go:generate mockery --config .mockery.yaml

--- a/generate.go
+++ b/generate.go
@@ -1,5 +1,5 @@
 package main
 
 //go:generate go install -v github.com/zyedidia/eget@latest
-//go:generate eget vektra/mockery --upgrade-only --to "${GOPATH}/bin"
-//go:generate mockery --config .mockery.yaml
+//go:generate "${GOPATH}/bin/eget" vektra/mockery --upgrade-only --to "${GOPATH}/bin"
+//go:generate "${GOPATH}/bin/mockery" --config .mockery.yaml

--- a/schedule/handler.go
+++ b/schedule/handler.go
@@ -9,8 +9,6 @@ import (
 )
 
 // Handler interface for the scheduling software available on the system
-//
-//go:generate mockery --name=Handler
 type Handler interface {
 	Init() error
 	Close()


### PR DESCRIPTION
Changes

* Extends the documentation on how to build (includes info that `eget` and `mockery` are installed)
* Use more absolute paths (do not depend on GOBIN being in PATH)
* Apply suggested mockery config to silence deprecation warning
* Add ARM64 for all 3 OS (for builds with `make`, goreleaser already had it)
* Might also fix: #233