### PR TITLE
Detect if running on battery

### DIFF
--- a/battery_test.go
+++ b/battery_test.go
@@ -1,0 +1,344 @@
+package main
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/distatus/battery"
+	"github.com/stretchr/testify/assert"
+)
+
+var errTest = errors.New("test error")
+
+func TestNotRunningOnBattery(t *testing.T) {
+	battery, charge, err := IsRunningOnBattery()
+	assert.NoError(t, err)
+	assert.False(t, battery)
+	assert.Zero(t, charge)
+}
+
+func TestIsFatalError(t *testing.T) {
+	fixtures := []struct {
+		err      error
+		expected error
+	}{
+		{
+			nil,
+			nil,
+		},
+		{
+			errTest,
+			errTest,
+		},
+		{
+			battery.ErrFatal{},
+			battery.ErrFatal{},
+		},
+		{
+			battery.ErrPartial{
+				State: nil,
+			},
+			nil,
+		},
+		{
+			battery.ErrPartial{
+				State: errTest,
+			},
+			errTest,
+		},
+		{
+			battery.Errors{nil},
+			nil,
+		},
+		{
+			battery.Errors{nil, errTest},
+			errTest,
+		},
+		{
+			battery.Errors{nil, battery.ErrPartial{State: errTest}},
+			errTest,
+		},
+		{
+			battery.Errors{nil, battery.ErrPartial{State: nil}},
+			nil,
+		},
+		{
+			battery.Errors{
+				battery.ErrPartial{State: nil},
+				battery.ErrPartial{State: errTest},
+			},
+			errTest,
+		},
+	}
+
+	for _, fixture := range fixtures {
+		t.Run("", func(t *testing.T) {
+			err := isFatalError(fixture.err)
+			assert.Equal(t, fixture.expected, err)
+		})
+	}
+}
+
+func TestDetectRunningOnBattery(t *testing.T) {
+	fixtures := []struct {
+		batteries        []*battery.Battery
+		runningOnBattery bool
+	}{
+		// one discharging
+		{
+			[]*battery.Battery{
+				{
+					State: battery.State{
+						Raw: battery.Discharging,
+					},
+				},
+			},
+			true,
+		},
+		// one charging
+		{
+			[]*battery.Battery{
+				{
+					State: battery.State{
+						Raw: battery.Charging,
+					},
+				},
+			},
+			false,
+		},
+		// one full
+		{
+			[]*battery.Battery{
+				{
+					State: battery.State{
+						Raw: battery.Full,
+					},
+				},
+			},
+			false,
+		},
+		// one idle (usually at around 80%)
+		{
+			[]*battery.Battery{
+				{
+					State: battery.State{
+						Raw: battery.Idle,
+					},
+				},
+			},
+			false,
+		},
+		// one unknown (we consider this as not running on battery)
+		{
+			[]*battery.Battery{
+				{
+					State: battery.State{
+						Raw: battery.Unknown,
+					},
+				},
+			},
+			false,
+		},
+		// one discharging, one charging
+		{
+			[]*battery.Battery{
+				{
+					State: battery.State{
+						Raw: battery.Discharging,
+					},
+				},
+				{
+					State: battery.State{
+						Raw: battery.Charging,
+					},
+				},
+			},
+			false,
+		},
+		// one discharging, one full
+		{
+			[]*battery.Battery{
+				{
+					State: battery.State{
+						Raw: battery.Discharging,
+					},
+				},
+				{
+					State: battery.State{
+						Raw: battery.Full,
+					},
+				},
+			},
+			false,
+		},
+		// one discharging, one idle (usually at around 80%)
+		{
+			[]*battery.Battery{
+				{
+					State: battery.State{
+						Raw: battery.Discharging,
+					},
+				},
+				{
+					State: battery.State{
+						Raw: battery.Idle,
+					},
+				},
+			},
+			false,
+		},
+		// one discharging, one unknown (we consider this as not running on battery)
+		{
+			[]*battery.Battery{
+				{
+					State: battery.State{
+						Raw: battery.Discharging,
+					},
+				},
+				{
+					State: battery.State{
+						Raw: battery.Unknown,
+					},
+				},
+			},
+			false,
+		},
+		// one charging, one discharging
+		{
+			[]*battery.Battery{
+				{
+					State: battery.State{
+						Raw: battery.Charging,
+					},
+				},
+				{
+					State: battery.State{
+						Raw: battery.Discharging,
+					},
+				},
+			},
+			false,
+		},
+		// one charging, one full
+		{
+			[]*battery.Battery{
+				{
+					State: battery.State{
+						Raw: battery.Charging,
+					},
+				},
+				{
+					State: battery.State{
+						Raw: battery.Full,
+					},
+				},
+			},
+			false,
+		},
+		// one charging, one idle (usually at around 80%)
+		{
+			[]*battery.Battery{
+				{
+					State: battery.State{
+						Raw: battery.Charging,
+					},
+				},
+				{
+					State: battery.State{
+						Raw: battery.Idle,
+					},
+				},
+			},
+			false,
+		},
+		// one charging, one unknown (we consider this as not running on battery)
+		{
+			[]*battery.Battery{
+				{
+					State: battery.State{
+						Raw: battery.Charging,
+					},
+				},
+				{
+					State: battery.State{
+						Raw: battery.Unknown,
+					},
+				},
+			},
+			false,
+		},
+		// one full, one discharging
+		{
+			[]*battery.Battery{
+				{
+					State: battery.State{
+						Raw: battery.Full,
+					},
+				},
+				{
+					State: battery.State{
+						Raw: battery.Discharging,
+					},
+				},
+			},
+			false,
+		},
+	}
+
+	for _, fixture := range fixtures {
+		t.Run("", func(t *testing.T) {
+			bat := detectRunningOnBattery(fixture.batteries)
+			assert.Equal(t, fixture.runningOnBattery, bat)
+		})
+	}
+}
+
+func TestAverageBatteryLevel(t *testing.T) {
+	fixtures := []struct {
+		batteries []*battery.Battery
+		average   float64
+	}{
+		{
+			[]*battery.Battery{},
+			0,
+		},
+		{
+			[]*battery.Battery{
+				{
+					Current: 0,
+					Full:    0,
+				},
+			},
+			0,
+		},
+		{
+			[]*battery.Battery{
+				{
+					Current: 10,
+					Full:    100,
+				},
+			},
+			10,
+		},
+		{
+			[]*battery.Battery{
+				{
+					Current: 10,
+					Full:    100,
+				},
+				{
+					Current: 20,
+					Full:    100,
+				},
+			},
+			15,
+		},
+	}
+
+	for _, fixture := range fixtures {
+		t.Run("", func(t *testing.T) {
+			bat := averageBatteryLevel(fixture.batteries)
+			assert.Equal(t, fixture.average, bat)
+		})
+	}
+}

--- a/complete_test.go
+++ b/complete_test.go
@@ -95,7 +95,7 @@ func TestCompleter(t *testing.T) {
 
 					completions := completer.completeFlagSetValue(flag, "")
 					flagType := flag.Value.Type()
-					if flagType == "bool" || flagType == "duration" {
+					if flagType == "duration" || flag.NoOptDefVal != "" {
 						assert.Empty(t, completions, "Flag --%s", flag.Name)
 					} else {
 						assert.NotEmpty(t, completions, "Flag --%s", flag.Name)

--- a/config/profile.go
+++ b/config/profile.go
@@ -286,13 +286,15 @@ func (s *SectionWithScheduleAndMonitoring) IsEmpty() bool { return s == nil }
 
 // ScheduleBaseSection contains the parameters for scheduling a command (backup, check, forget, etc.)
 type ScheduleBaseSection struct {
-	Schedule           []string      `mapstructure:"schedule" show:"noshow" examples:"hourly;daily;weekly;monthly;10:00,14:00,18:00,22:00;Wed,Fri 17:48;*-*-15 02:45;Mon..Fri 00:30" description:"Set the times at which the scheduled command is run (times are specified in systemd timer format)"`
-	SchedulePermission string        `mapstructure:"schedule-permission" show:"noshow" default:"auto" enum:"auto;system;user;user_logged_on" description:"Specify whether the schedule runs with system or user privileges - see https://creativeprojects.github.io/resticprofile/schedules/configuration/"`
-	ScheduleLog        string        `mapstructure:"schedule-log" show:"noshow" examples:"/resticprofile.log;tcp://localhost:514" description:"Redirect the output into a log file or to syslog when running on schedule"`
-	SchedulePriority   string        `mapstructure:"schedule-priority" show:"noshow" default:"background" enum:"background;standard" description:"Set the priority at which the schedule is run"`
-	ScheduleLockMode   string        `mapstructure:"schedule-lock-mode" show:"noshow" default:"default" enum:"default;fail;ignore" description:"Specify how locks are used when running on schedule - see https://creativeprojects.github.io/resticprofile/schedules/configuration/"`
-	ScheduleLockWait   time.Duration `mapstructure:"schedule-lock-wait" show:"noshow" examples:"150s;15m;30m;45m;1h;2h30m" description:"Set the maximum time to wait for acquiring locks when running on schedule"`
-	ScheduleEnvCapture []string      `mapstructure:"schedule-capture-environment" show:"noshow" default:"RESTIC_*" description:"Set names (or glob expressions) of environment variables to capture during schedule creation. The captured environment is applied prior to \"profile.env\" when running the schedule. Whether capturing is supported depends on the type of scheduler being used (supported in \"systemd\" and \"launchd\")"`
+	Schedule                        []string      `mapstructure:"schedule" show:"noshow" examples:"hourly;daily;weekly;monthly;10:00,14:00,18:00,22:00;Wed,Fri 17:48;*-*-15 02:45;Mon..Fri 00:30" description:"Set the times at which the scheduled command is run (times are specified in systemd timer format)"`
+	SchedulePermission              string        `mapstructure:"schedule-permission" show:"noshow" default:"auto" enum:"auto;system;user;user_logged_on" description:"Specify whether the schedule runs with system or user privileges - see https://creativeprojects.github.io/resticprofile/schedules/configuration/"`
+	ScheduleLog                     string        `mapstructure:"schedule-log" show:"noshow" examples:"/resticprofile.log;tcp://localhost:514" description:"Redirect the output into a log file or to syslog when running on schedule"`
+	SchedulePriority                string        `mapstructure:"schedule-priority" show:"noshow" default:"background" enum:"background;standard" description:"Set the priority at which the schedule is run"`
+	ScheduleLockMode                string        `mapstructure:"schedule-lock-mode" show:"noshow" default:"default" enum:"default;fail;ignore" description:"Specify how locks are used when running on schedule - see https://creativeprojects.github.io/resticprofile/schedules/configuration/"`
+	ScheduleLockWait                time.Duration `mapstructure:"schedule-lock-wait" show:"noshow" examples:"150s;15m;30m;45m;1h;2h30m" description:"Set the maximum time to wait for acquiring locks when running on schedule"`
+	ScheduleEnvCapture              []string      `mapstructure:"schedule-capture-environment" show:"noshow" default:"RESTIC_*" description:"Set names (or glob expressions) of environment variables to capture during schedule creation. The captured environment is applied prior to \"profile.env\" when running the schedule. Whether capturing is supported depends on the type of scheduler being used (supported in \"systemd\" and \"launchd\")"`
+	ScheduleIgnoreOnBattery         bool          `mapstructure:"schedule-ignore-on-battery" default:"false" description:"Don't schedule the start of this profile when running on battery"`
+	ScheduleIgnoreOnBatteryLessThan int           `mapstructure:"schedule-ignore-on-battery-less-than" default:"" description:"Don't schedule the start of this profile when running on battery, and the battery charge left is less than the value"`
 }
 
 func (s *ScheduleBaseSection) setRootPath(_ *Profile, _ string) {
@@ -828,16 +830,18 @@ func (p *Profile) Schedules() []*ScheduleConfig {
 			}
 
 			config := &ScheduleConfig{
-				Title:       p.Name,
-				SubTitle:    name,
-				Schedules:   s.Schedule,
-				Permission:  s.SchedulePermission,
-				Environment: env.Values(),
-				Log:         s.ScheduleLog,
-				LockMode:    s.ScheduleLockMode,
-				LockWait:    s.ScheduleLockWait,
-				Priority:    s.SchedulePriority,
-				ConfigFile:  p.config.configFile,
+				Title:                   p.Name,
+				SubTitle:                name,
+				Schedules:               s.Schedule,
+				Permission:              s.SchedulePermission,
+				Environment:             env.Values(),
+				Log:                     s.ScheduleLog,
+				LockMode:                s.ScheduleLockMode,
+				LockWait:                s.ScheduleLockWait,
+				Priority:                s.SchedulePriority,
+				ConfigFile:              p.config.configFile,
+				IgnoreOnBattery:         s.ScheduleIgnoreOnBattery,
+				IgnoreOnBatteryLessThan: s.ScheduleIgnoreOnBatteryLessThan,
 			}
 
 			if len(config.Log) > 0 {

--- a/config/schedule_config.go
+++ b/config/schedule_config.go
@@ -21,23 +21,25 @@ const (
 
 // ScheduleConfig contains all information to schedule a profile command
 type ScheduleConfig struct {
-	Title            string
-	SubTitle         string
-	Schedules        []string
-	Permission       string
-	WorkingDirectory string
-	Command          string
-	Arguments        []string
-	Environment      []string
-	JobDescription   string
-	TimerDescription string
-	Priority         string
-	Log              string
-	LockMode         string
-	LockWait         time.Duration
-	ConfigFile       string
-	Flags            map[string]string
-	RemoveOnly       bool
+	Title                   string
+	SubTitle                string
+	Schedules               []string
+	Permission              string
+	WorkingDirectory        string
+	Command                 string
+	Arguments               []string
+	Environment             []string
+	JobDescription          string
+	TimerDescription        string
+	Priority                string
+	Log                     string
+	LockMode                string
+	LockWait                time.Duration
+	ConfigFile              string
+	Flags                   map[string]string
+	RemoveOnly              bool
+	IgnoreOnBattery         bool
+	IgnoreOnBatteryLessThan int
 }
 
 // NewRemoveOnlyConfig creates a job config that may be used to call Job.Remove() on a scheduled job

--- a/constants/default.go
+++ b/constants/default.go
@@ -19,4 +19,5 @@ const (
 	DefaultQuietFlag            = false
 	DefaultMinMemory            = 100
 	DefaultSenderTimeout        = 30 * time.Second
+	BatteryFull                 = 100
 )

--- a/docs/content/_index.md
+++ b/docs/content/_index.md
@@ -34,6 +34,7 @@ With resticprofile:
 * **[new for v0.18.0]** Send resticprofile logs to a syslog server
 * **[new for v0.19.0]** Preventing your system from idle sleeping
 * **[new for v0.21.0]** See the help from both restic and resticprofile via the `help` command or `-h` flag
+* **[new for v0.24.0]** Don't schedule a job when the system is running on battery
 
 The configuration file accepts various formats:
 * [TOML](https://github.com/toml-lang/toml) : configuration file with extension _.toml_ and _.conf_ to keep compatibility with versions before 0.6.0

--- a/docs/content/schedules/configuration/index.md
+++ b/docs/content/schedules/configuration/index.md
@@ -173,6 +173,16 @@ Wed..Sat,Tue 12-10-15 1:2:3 → Tue..Sat 2012-10-15 01:02:03
 
 The `schedule` can be a string or an array of string (to allow for multiple schedules)
 
+### schedule-ignore-on-battery
+
+If set to `true` the schedule won't start if the system is running on battery (even if the charge is still at 100%)
+
+### schedule-ignore-on-battery-less-than
+
+If set to a number, the schedule won't start if the system is running on battery and the charge (in %) is less or equal than the number specified.
+
+## Example 
+
 Here's an example of a scheduling configuration:
 
 {{< tabs groupid="config-with-json" >}}

--- a/examples/dev.yaml
+++ b/examples/dev.yaml
@@ -10,6 +10,7 @@ global:
     # restic-binary: ~/fake_restic
     # legacy-arguments: true
     group-continue-on-error: true
+    restic-lock-retry-after: "1m"
 
 groups:
     full-backup:
@@ -24,7 +25,7 @@ default:
     cleanup-cache: true
     password-file: key
     repository: "/Volumes/RAMDisk/{{ .Profile.Name }}"
-    lock: "/Volumes/RAMDisk/resticprofile-{{ .Profile.Name }}.lock"
+    # lock: "/Volumes/RAMDisk/resticprofile-{{ .Profile.Name }}.lock"
     copy:
         initialize: true
         initialize-copy-chunker-params: true
@@ -104,7 +105,7 @@ self:
 
     backup:
         extended-status: false
-        check-before: false
+        check-before: true
         no-error-on-warning: true
         source: "{{ .CurrentDir }}"
         exclude:
@@ -117,10 +118,12 @@ self:
         - "echo restic returned an error, command line = ${ERROR_COMMANDLINE}"
         - "echo restic stderr = ${RESTIC_STDERR}"
     check:
+        read-data: true
         schedule:
             - "*:15"
     retention:
         after-backup: true
+        keep-last: 30
     forget:
         schedule: "weekly"
         schedule-priority: standard

--- a/flags.go
+++ b/flags.go
@@ -13,27 +13,28 @@ import (
 )
 
 type commandLineFlags struct {
-	help        bool
-	quiet       bool
-	verbose     bool
-	veryVerbose bool
-	config      string
-	format      string
-	name        string
-	log         string // file path or log url
-	dryRun      bool
-	noLock      bool
-	lockWait    time.Duration
-	noAnsi      bool
-	theme       string
-	resticArgs  []string
-	selfUpdate  bool
-	wait        bool
-	isChild     bool
-	parentPort  int
-	noPriority  bool
-	run         string
-	usagesHelp  string
+	help            bool
+	quiet           bool
+	verbose         bool
+	veryVerbose     bool
+	config          string
+	format          string
+	name            string
+	log             string // file path or log url
+	dryRun          bool
+	noLock          bool
+	lockWait        time.Duration
+	noAnsi          bool
+	theme           string
+	resticArgs      []string
+	selfUpdate      bool
+	wait            bool
+	isChild         bool
+	parentPort      int
+	noPriority      bool
+	ignoreOnBattery int
+	run             string
+	usagesHelp      string
 }
 
 // loadFlags loads command line flags (before any command)
@@ -59,6 +60,8 @@ func loadFlags(args []string) (*pflag.FlagSet, commandLineFlags, error) {
 	flagset.BoolVar(&flags.noAnsi, "no-ansi", false, "disable ansi control characters (disable console colouring)")
 	flagset.StringVar(&flags.theme, "theme", constants.DefaultTheme, "console colouring theme (dark, light, none)")
 	flagset.BoolVar(&flags.noPriority, "no-prio", false, "don't set any priority on load: used when started from a service that has already set the priority")
+	flagset.IntVar(&flags.ignoreOnBattery, "ignore-on-battery", 0, "don't start the profile when the computer is running on battery. You can specify a value to ignore only when the % charge left is less or equal than the value")
+	flagset.Lookup("ignore-on-battery").NoOptDefVal = "100" // 0 is flag not set, 100 is for a flag with no value (meaning just battery discharge)
 
 	flagset.BoolVarP(&flags.wait, "wait", "w", false, "wait at the end until the user presses the enter key")
 

--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/coreos/go-systemd/v22 v22.5.0
 	github.com/creativeprojects/clog v0.13.0
 	github.com/creativeprojects/go-selfupdate v1.1.1
+	github.com/distatus/battery v0.11.0
 	github.com/fatih/color v1.15.0
 	github.com/mackerelio/go-osstat v0.2.4
 	github.com/mattn/go-colorable v0.1.13

--- a/go.sum
+++ b/go.sum
@@ -68,6 +68,8 @@ github.com/creativeprojects/go-selfupdate v1.1.1/go.mod h1:nm7AWUJfrfYt/SB97NAcM
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/distatus/battery v0.11.0 h1:KJk89gz90Iq/wJtbjjM9yUzBXV+ASV/EG2WOOL7N8lc=
+github.com/distatus/battery v0.11.0/go.mod h1:KmVkE8A8hpIX4T78QRdMktYpEp35QfOL8A8dwZBxq2k=
 github.com/envoyproxy/go-control-plane v0.9.0/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/go-control-plane v0.9.1-0.20191026205805-5f8ba28d4473/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/go-control-plane v0.9.4/go.mod h1:6rpuAdCZL397s3pYoYcLgu1mIlRU8Am5FuJP05cCM98=

--- a/main.go
+++ b/main.go
@@ -131,6 +131,29 @@ func main() {
 		}
 	}
 
+	clog.Infof("ignoreOnBattery: %+v", flags.ignoreOnBattery)
+
+	// check if we're running on battery
+	if flags.ignoreOnBattery > 0 && flags.ignoreOnBattery <= constants.BatteryFull {
+		battery, charge, err := IsRunningOnBattery()
+		if err != nil {
+			clog.Errorf("cannot check if the computer is running on battery: %s", err)
+		}
+		if battery {
+			if flags.ignoreOnBattery == constants.BatteryFull {
+				clog.Warning("running on battery, leaving now")
+				exitCode = 3
+				return
+			}
+			if charge < flags.ignoreOnBattery {
+				clog.Warningf("running on battery (%d%%), leaving now", charge)
+				exitCode = 3
+				return
+			}
+			clog.Info("running on battery with enough charge (%d%%)", charge)
+		}
+	}
+
 	configFile, err := filesearch.FindConfigurationFile(flags.config)
 	if err != nil {
 		clog.Error(err)

--- a/main.go
+++ b/main.go
@@ -131,8 +131,6 @@ func main() {
 		}
 	}
 
-	clog.Infof("ignoreOnBattery: %+v", flags.ignoreOnBattery)
-
 	// check if we're running on battery
 	if flags.ignoreOnBattery > 0 && flags.ignoreOnBattery <= constants.BatteryFull {
 		battery, charge, err := IsRunningOnBattery()

--- a/main.go
+++ b/main.go
@@ -148,7 +148,7 @@ func main() {
 				exitCode = 3
 				return
 			}
-			clog.Info("running on battery with enough charge (%d%%)", charge)
+			clog.Infof("running on battery with enough charge (%d%%)", charge)
 		}
 	}
 

--- a/schedule_jobs.go
+++ b/schedule_jobs.go
@@ -48,11 +48,11 @@ func scheduleJobs(handler schedule.Handler, profileName string, configs []*confi
 		} else if scheduleConfig.GetLockMode() == config.ScheduleLockModeIgnore {
 			args = append(args, "--no-lock")
 		}
-		if scheduleConfig.IgnoreOnBattery {
-			args = append(args, "--ignore-on-battery")
-		}
+
 		if scheduleConfig.IgnoreOnBatteryLessThan > 0 && scheduleConfig.IgnoreOnBatteryLessThan <= 100 {
-			args = append(args, fmt.Sprintf("--ignore-on-battery-less-than=%d", scheduleConfig.IgnoreOnBatteryLessThan))
+			args = append(args, fmt.Sprintf("--ignore-on-battery=%d", scheduleConfig.IgnoreOnBatteryLessThan))
+		} else if scheduleConfig.IgnoreOnBattery {
+			args = append(args, "--ignore-on-battery")
 		}
 
 		args = append(args, getResticCommand(scheduleConfig.SubTitle))

--- a/schedule_jobs.go
+++ b/schedule_jobs.go
@@ -48,6 +48,12 @@ func scheduleJobs(handler schedule.Handler, profileName string, configs []*confi
 		} else if scheduleConfig.GetLockMode() == config.ScheduleLockModeIgnore {
 			args = append(args, "--no-lock")
 		}
+		if scheduleConfig.IgnoreOnBattery {
+			args = append(args, "--ignore-on-battery")
+		}
+		if scheduleConfig.IgnoreOnBatteryLessThan > 0 && scheduleConfig.IgnoreOnBatteryLessThan <= 100 {
+			args = append(args, fmt.Sprintf("--ignore-on-battery-less-than=%d", scheduleConfig.IgnoreOnBatteryLessThan))
+		}
 
 		args = append(args, getResticCommand(scheduleConfig.SubTitle))
 


### PR DESCRIPTION
Add a flag to avoid starting a profile when the system is running on battery.
Works for all supported OS.

Adds 2 new options in the configuration:
* `schedule-ignore-on-battery` boolean (default false)
* `schedule-ignore-on-battery-less-than` int => battery charge left

Adds a new command line flag `--ignore-on-battery`:
* if no parameter, it just stops when the battery is on discharge
* with a parameter, only when the charge is lower or equal than the value (and discharging)
