### PR TITLE
Support `lock-wait` with `--lock-retry` in restic 0.16

### DIFF
--- a/.mockery.yaml
+++ b/.mockery.yaml
@@ -17,3 +17,7 @@ packages:
   github.com/creativeprojects/resticprofile/schedule:
     interfaces:
       Handler:
+
+  github.com/creativeprojects/resticprofile/monitor:
+    interfaces:
+      OutputAnalysis:

--- a/config/global.go
+++ b/config/global.go
@@ -19,7 +19,7 @@ type Global struct {
 	ResticVersion        string        // not configurable at the moment. To be set after ResticBinary is known.
 	FilterResticFlags    bool          `mapstructure:"restic-arguments-filter" default:"true" description:"Remove unknown flags instead of passing all configured flags to restic"`
 	ResticLockRetryAfter time.Duration `mapstructure:"restic-lock-retry-after" default:"1m" description:"Time to wait before trying to get a lock on a restic repositoey - see https://creativeprojects.github.io/resticprofile/usage/locks/"`
-	ResticStaleLockAge   time.Duration `mapstructure:"restic-stale-lock-age" default:"2h" description:"The age an unused lock on a restic repository must have at least before resiticprofile attempts to unlock - see https://creativeprojects.github.io/resticprofile/usage/locks/"`
+	ResticStaleLockAge   time.Duration `mapstructure:"restic-stale-lock-age" default:"1h" description:"The age an unused lock on a restic repository must have at least before resiticprofile attempts to unlock - see https://creativeprojects.github.io/resticprofile/usage/locks/"`
 	ShellBinary          []string      `mapstructure:"shell" default:"auto" examples:"sh;bash;pwsh;powershell;cmd" description:"The shell that is used to run commands (default is OS specific)"`
 	MinMemory            uint64        `mapstructure:"min-memory" default:"100" description:"Minimum available memory (in MB) required to run any commands - see https://creativeprojects.github.io/resticprofile/usage/memory/"`
 	Scheduler            string        `mapstructure:"scheduler" description:"Leave blank for the default scheduler or use \"crond\" to select cron on supported operating systems"`

--- a/constants/default.go
+++ b/constants/default.go
@@ -9,7 +9,7 @@ const (
 	DefaultCommand              = "snapshots"
 	DefaultFilterResticFlags    = true
 	DefaultResticLockRetryAfter = 60 * time.Second
-	DefaultResticStaleLockAge   = 2 * time.Hour
+	DefaultResticStaleLockAge   = 1 * time.Hour
 	DefaultTheme                = "light"
 	DefaultIONiceFlag           = false
 	DefaultIONiceClass          = 2

--- a/constants/global.go
+++ b/constants/global.go
@@ -28,9 +28,10 @@ var (
 
 // Limits for restic lock handling (stale locks and retry on lock failure)
 const (
-	MinResticLockRetryTime = 15 * time.Second
-	MaxResticLockRetryTime = 30 * time.Minute
-	MinResticStaleLockAge  = 1 * time.Hour
+	MinResticLockRetryDelay        = 15 * time.Second
+	MaxResticLockRetryDelay        = 30 * time.Minute
+	MaxResticLockRetryTimeArgument = 10 * time.Minute
+	MinResticStaleLockAge          = 1 * time.Hour
 )
 
 // Schedule lock mode config options

--- a/constants/global.go
+++ b/constants/global.go
@@ -31,7 +31,7 @@ const (
 	MinResticLockRetryDelay        = 15 * time.Second
 	MaxResticLockRetryDelay        = 30 * time.Minute
 	MaxResticLockRetryTimeArgument = 10 * time.Minute
-	MinResticStaleLockAge          = 30 * time.Minute
+	MinResticStaleLockAge          = 15 * time.Minute
 )
 
 // Schedule lock mode config options

--- a/constants/global.go
+++ b/constants/global.go
@@ -31,7 +31,7 @@ const (
 	MinResticLockRetryDelay        = 15 * time.Second
 	MaxResticLockRetryDelay        = 30 * time.Minute
 	MaxResticLockRetryTimeArgument = 10 * time.Minute
-	MinResticStaleLockAge          = 1 * time.Hour
+	MinResticStaleLockAge          = 30 * time.Minute
 )
 
 // Schedule lock mode config options

--- a/constants/parameter.go
+++ b/constants/parameter.go
@@ -19,6 +19,7 @@ const (
 	ParameterVerbose         = "verbose"
 	ParameterDescription     = "description"
 	ParameterVersion         = "version"
+	ParameterRetryLock       = "retry-lock"
 	ParameterRepository      = "repo"
 	ParameterRepositoryFile  = "repository-file"
 	ParameterPasswordFile    = "password-file"

--- a/docs/content/usage/locks/index.md
+++ b/docs/content/usage/locks/index.md
@@ -121,7 +121,7 @@ In some cases, resticprofile as well as restic may leave a lock behind if the pr
 
 For that matter, if you add the flag `force-inactive-lock` to your profile, resticprofile will detect and remove stale locks: 
 * **resticprofile locks**: Check for the presence of a process with the PID indicated in the lockfile. If it can't find any, it will try to delete the lock and continue the operation (locking again, running profile and so on...)
-* **restic locks**: Evaluate if a restic command failed on acquiring a lock. If the lock is older than `restic-stale-lock-age`, invoke `restic unlock` and retry the command that failed (can be disabled by setting `restic-stale-lock-age` to 0, default is 2h).
+* **restic locks**: Evaluate if a restic command failed on acquiring a lock. If the lock is older than `restic-stale-lock-age`, invoke `restic unlock` and retry the command that failed (can be disabled by setting `restic-stale-lock-age` to 0, default is 1h).
 
 {{< tabs groupId="config-with-json" >}}
 {{% tab name="toml" %}}

--- a/monitor/summary.go
+++ b/monitor/summary.go
@@ -26,6 +26,10 @@ type OutputAnalysis interface {
 	// If no remote lock is held or the time cannot be determined, the second parameter is false.
 	GetRemoteLockedSince() (time.Duration, bool)
 
+	// GetRemoteLockedMaxWait returns the max time duration that restic waited for the lock to acquire.
+	// If no remote lock is held or the time cannot be determined, the second parameter is false.
+	GetRemoteLockedMaxWait() (time.Duration, bool)
+
 	// GetRemoteLockedBy returns who locked the remote lock, if available.
 	GetRemoteLockedBy() (string, bool)
 }

--- a/shell/analyser_test.go
+++ b/shell/analyser_test.go
@@ -10,6 +10,7 @@ import (
 )
 
 const ResticLockFailureOutput = `
+repo already locked, waiting up to 2m1s115.3ms for the lock
 unable to create lock in backend: repository is already locked by PID 27153 on app-server-01 by root (UID 0, GID 0)
 lock was created at 2021-04-17 19:00:16 (1s727.5ms ago)
 storage ID 870530a4
@@ -32,6 +33,12 @@ func TestRemoteLockFailure(t *testing.T) {
 		name, ok := analysis.GetRemoteLockedBy()
 		assert.Equal(t, true, ok)
 		assert.Equal(t, "PID 27153 on app-server-01 by root (UID 0, GID 0)", name)
+	})
+
+	t.Run("GetRemoteLockedMaxWait", func(t *testing.T) {
+		wait, ok := analysis.GetRemoteLockedMaxWait()
+		assert.Equal(t, true, ok)
+		assert.Equal(t, 2*time.Minute+time.Second+(115*time.Millisecond), wait)
 	})
 }
 

--- a/wrapper.go
+++ b/wrapper.go
@@ -373,7 +373,7 @@ func (r *resticWrapper) prepareCommand(command string, args *shell.Args, allowEx
 	lockRetryFlag := fmt.Sprintf("--%s", constants.ParameterRetryLock)
 	if enabled, lockRetryTime := r.remainingLockRetryTime(); enabled && filter != nil {
 		// limiting the retry handling in restic, we need to make sure we can retry internally so that unlock is called.
-		lockRetryTime -= 2 * r.global.ResticLockRetryAfter
+		lockRetryTime = lockRetryTime - r.global.ResticLockRetryAfter - constants.MinResticLockRetryDelay
 		if lockRetryTime > constants.MaxResticLockRetryTimeArgument {
 			lockRetryTime = constants.MaxResticLockRetryTimeArgument
 		}

--- a/wrapper.go
+++ b/wrapper.go
@@ -346,7 +346,9 @@ func (r *resticWrapper) getCommandArgumentsFilter(command string) argumentsFilte
 }
 
 func (r *resticWrapper) containsArguments(arguments []string, subset ...string) (found bool) {
-	found = len(r.validArgumentsFilter(subset)(arguments, true)) > 0
+	filter := r.validArgumentsFilter(subset)
+	argMatcher := func(arg string) bool { return strings.HasPrefix(arg, "-") }
+	found = slices.ContainsFunc(filter(arguments, true), argMatcher)
 	return
 }
 

--- a/wrapper_test.go
+++ b/wrapper_test.go
@@ -884,18 +884,18 @@ func TestCanUseResticLockRetry(t *testing.T) {
 
 	t.Run("SubtractsResticLockRetryAfter", func(t *testing.T) {
 		wrapper := getWrapper()
-		wrapper.maxWaitOnLock(10*time.Minute + 10*time.Second)
+		wrapper.maxWaitOnLock(10*time.Minute + 30*time.Second)
 		command := wrapper.prepareCommand(constants.CommandBackup, emptyArgs, true)
-		assert.Contains(t, command.args, "--retry-lock=8m")
+		assert.Contains(t, command.args, "--retry-lock=9m")
 	})
 
 	t.Run("SubtractsRemainingTime", func(t *testing.T) {
 		wrapper := getWrapper()
-		wrapper.maxWaitOnLock(10*time.Minute + 10*time.Second)
+		wrapper.maxWaitOnLock(10*time.Minute + 30*time.Second)
 		wrapper.executionTime = 3 * time.Minute
 		wrapper.startTime = wrapper.startTime.Add(-5 * time.Minute) // 2 minutes for locks, 3 minutes for execution
 		command := wrapper.prepareCommand(constants.CommandBackup, emptyArgs, true)
-		assert.Contains(t, command.args, "--retry-lock=6m")
+		assert.Contains(t, command.args, "--retry-lock=7m")
 	})
 
 	t.Run("10MinutesIsMax", func(t *testing.T) {
@@ -907,12 +907,12 @@ func TestCanUseResticLockRetry(t *testing.T) {
 
 	t.Run("1MinuteIsMin", func(t *testing.T) {
 		wrapper := getWrapper()
-		wrapper.maxWaitOnLock(3*time.Minute + 10*time.Second)
+		wrapper.maxWaitOnLock(2*time.Minute + 30*time.Second)
 		command := wrapper.prepareCommand(constants.CommandBackup, emptyArgs, true)
 		assert.Contains(t, command.args, "--retry-lock=1m")
 		assert.True(t, slices.ContainsFunc(command.args, argMatcher))
 
-		wrapper.maxWaitOnLock(3 * time.Minute)
+		wrapper.maxWaitOnLock(2 * time.Minute)
 		command = wrapper.prepareCommand(constants.CommandBackup, emptyArgs, true)
 		assert.False(t, slices.ContainsFunc(command.args, argMatcher))
 	})

--- a/wrapper_test.go
+++ b/wrapper_test.go
@@ -932,6 +932,24 @@ func TestCanUseResticLockRetry(t *testing.T) {
 		command := wrapper.prepareCommand(constants.CommandBackup, emptyArgs, true)
 		assert.False(t, slices.ContainsFunc(command.args, argMatcher))
 	})
+
+	t.Run("NotOverwritingAlreadyProvided", func(t *testing.T) {
+		wrapper := getWrapper()
+		wrapper.moreArgs = []string{"--retry-lock", "25m"}
+		wrapper.maxWaitOnLock(30 * time.Minute)
+		command := wrapper.prepareCommand(constants.CommandBackup, emptyArgs, true)
+		assert.Subset(t, command.args, wrapper.moreArgs)
+		assert.NotContains(t, command.args, "--retry-lock=10m")
+	})
+
+	t.Run("Regression-WorksWithExtraValues", func(t *testing.T) {
+		wrapper := getWrapper()
+		wrapper.moreArgs = []string{"/some/path", "some-other-option"}
+		wrapper.maxWaitOnLock(30 * time.Minute)
+		command := wrapper.prepareCommand(constants.CommandBackup, emptyArgs, true)
+		assert.Subset(t, command.args, wrapper.moreArgs)
+		assert.Contains(t, command.args, "--retry-lock=10m")
+	})
 }
 
 func TestLocksAndLockWait(t *testing.T) {


### PR DESCRIPTION
This PR leverages the newly added restic 0.16 flag `--lock-retry` to offload some of the remote lock retry logic to restic (sequences of up to 10 minutes). 

This should lower resource usage (no startup overhead) and allow faster retry cycles (managed by restic itself).

Had also relaxed the stale lock age (the time that a remote lock must not have been refreshed before resticprofile attempts to unlock). Restic allows ~10 minutes and maybe less if host is the same, resticprofile's new min is 15m and default 1h for automatic `unlock`.

Example: 

```shell
➜ resticprofile --lock-wait=10m test-backup.check --read-data
2023/08/06 17:32:38 using configuration file: profiles.yaml
2023/08/06 17:32:38 profile 'test-backup': initializing repository (if not existing)
2023/08/06 17:32:39 profile 'test-backup': starting 'check'
using temporary cache in /tmp/restic-check-cache-1566484652
repository bb429813 opened (version 2, compression level auto)
created new cache in /tmp/restic-check-cache-1566484652
create exclusive lock for repository
repo already locked, waiting up to 8m0s for the lock
unable to create lock in backend: repository is already locked exclusively by PID 46959 on MYHOST by MYUSER (UID 502, GID 20)
lock was created at 2023-08-06 16:14:23 (1h26m16.339556s ago)
storage ID aeccdab0
the `unlock` command can be used to remove stale locks
2023/08/06 17:40:40 lock wait (remaining 1m59s / waited 8m1s / elapsed 8m1s): /resticprofile/test-repo locked by PID 46959 on MYHOST by MYUSER (UID 502, GID 20)
using temporary cache in /tmp/restic-check-cache-428519430
repository bb429813 opened (version 2, compression level auto)
created new cache in /tmp/restic-check-cache-428519430
create exclusive lock for repository
repo already locked, waiting up to 0s for the lock
unable to create lock in backend: repository is already locked exclusively by PID 46959 on MYHOST by MYUSER (UID 502, GID 20)
lock was created at 2023-08-06 16:14:23 (1h27m17.241516s ago)
storage ID aeccdab0
the `unlock` command can be used to remove stale locks
2023/08/06 17:41:41 restic: possible stale lock detected (lock age 1h27m17.242s >= 1h27m0s). Trying to unlock.
2023/08/06 17:41:41 profile 'test-backup': unlock stale locks
repository bb429813 opened (version 2, compression level auto)
successfully removed 1 locks
using temporary cache in /tmp/restic-check-cache-113952085
repository bb429813 opened (version 2, compression level auto)
created new cache in /tmp/restic-check-cache-113952085
create exclusive lock for repository
load indexes
...
```