### PR TITLE
Fix 242: iexclude-file not converted to abs path

### DIFF
--- a/config/profile.go
+++ b/config/profile.go
@@ -172,7 +172,10 @@ type BackupSection struct {
 	Exclude                          []string `mapstructure:"exclude" argument:"exclude" argument-type:"no-glob"`
 	Iexclude                         []string `mapstructure:"iexclude" argument:"iexclude" argument-type:"no-glob"`
 	ExcludeFile                      []string `mapstructure:"exclude-file" argument:"exclude-file"`
+	IexcludeFile                     []string `mapstructure:"iexclude-file" argument:"iexclude-file"`
 	FilesFrom                        []string `mapstructure:"files-from" argument:"files-from"`
+	FilesFromRaw                     []string `mapstructure:"files-from-raw" argument:"files-from-raw"`
+	FilesFromVerbatim                []string `mapstructure:"files-from-verbatim" argument:"files-from-verbatim"`
 	ExtendedStatus                   bool     `mapstructure:"extended-status" argument:"json"`
 	NoErrorOnWarning                 bool     `mapstructure:"no-error-on-warning" description:"Do not fail the backup when some files could not be read"`
 }
@@ -203,7 +206,10 @@ func (s *BackupSection) setRootPath(p *Profile, rootPath string) {
 	s.SectionWithScheduleAndMonitoring.setRootPath(p, rootPath)
 
 	s.ExcludeFile = fixPaths(s.ExcludeFile, expandEnv, expandUserHome, absolutePrefix(rootPath))
+	s.IexcludeFile = fixPaths(s.IexcludeFile, expandEnv, expandUserHome, absolutePrefix(rootPath))
 	s.FilesFrom = fixPaths(s.FilesFrom, expandEnv, expandUserHome, absolutePrefix(rootPath))
+	s.FilesFromRaw = fixPaths(s.FilesFromRaw, expandEnv, expandUserHome, absolutePrefix(rootPath))
+	s.FilesFromVerbatim = fixPaths(s.FilesFromVerbatim, expandEnv, expandUserHome, absolutePrefix(rootPath))
 	s.Exclude = fixPaths(s.Exclude, expandEnv, expandUserHome)
 	s.Iexclude = fixPaths(s.Iexclude, expandEnv, expandUserHome)
 }

--- a/config/profile_test.go
+++ b/config/profile_test.go
@@ -322,7 +322,10 @@ lock = "lock"
 [` + prefix + `profile.backup]
 source = ["backup", "root"]
 exclude-file = "exclude"
+iexclude-file = "iexclude"
 files-from = "include"
+files-from-raw = "include-raw"
+files-from-verbatim = "include-verbatim"
 exclude = "exclude"
 iexclude = "iexclude"
 [` + prefix + `profile.copy]
@@ -355,7 +358,10 @@ from-password-file = "key"
 			filepath.Join(homeDir, "root"),
 		}, profile.GetBackupSource())
 		assert.ElementsMatch(t, []string{"/wd/exclude"}, profile.Backup.ExcludeFile)
+		assert.ElementsMatch(t, []string{"/wd/iexclude"}, profile.Backup.IexcludeFile)
 		assert.ElementsMatch(t, []string{"/wd/include"}, profile.Backup.FilesFrom)
+		assert.ElementsMatch(t, []string{"/wd/include-raw"}, profile.Backup.FilesFromRaw)
+		assert.ElementsMatch(t, []string{"/wd/include-verbatim"}, profile.Backup.FilesFromVerbatim)
 		assert.ElementsMatch(t, []string{"exclude"}, profile.Backup.Exclude)
 		assert.ElementsMatch(t, []string{"iexclude"}, profile.Backup.Iexclude)
 		assert.Equal(t, "/wd/key", profile.Copy.PasswordFile)


### PR DESCRIPTION
fix for #242 , also fixes `files-from-raw` & `files-from-verbatim`