### PR TITLE
Allow to interrupt the wait for a lock

### DIFF
--- a/command_error.go
+++ b/command_error.go
@@ -24,6 +24,10 @@ func (c *commandError) Error() string {
 	return c.err.Error()
 }
 
+func (c *commandError) Unwrap() error {
+	return c.err
+}
+
 func (c *commandError) Commandline() string {
 	args := ""
 	argsList := c.scd.publicArgs

--- a/constants/default.go
+++ b/constants/default.go
@@ -20,4 +20,5 @@ const (
 	DefaultMinMemory            = 100
 	DefaultSenderTimeout        = 30 * time.Second
 	BatteryFull                 = 100
+	LocalLockRetryDelay         = 5 * time.Second
 )

--- a/lock.go
+++ b/lock.go
@@ -1,0 +1,111 @@
+package main
+
+import (
+	"errors"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/creativeprojects/clog"
+	"github.com/creativeprojects/resticprofile/constants"
+	"github.com/creativeprojects/resticprofile/lock"
+)
+
+// lockRun is making sure the function is only run once by putting a lockfile on the disk
+func lockRun(lockFile string, force bool, lockWait *time.Duration, sigChan <-chan os.Signal, run func(setPID lock.SetPID) error) error {
+	// No lock
+	if lockFile == "" {
+		return run(nil)
+	}
+
+	// Make sure the path to the lock exists
+	if dir := filepath.Dir(lockFile); dir != "" {
+		err := os.MkdirAll(dir, 0755)
+		if err != nil {
+			clog.Warningf("the profile will run without a lockfile: %v", err)
+			return run(nil)
+		}
+	}
+
+	// Acquire lock
+	runLock := lock.NewLock(lockFile)
+	success := runLock.TryAcquire()
+	start := time.Now()
+	locker := ""
+	lockWaitLogged := time.Unix(0, 0)
+
+	for !success {
+		if who, err := runLock.Who(); err == nil {
+			if locker != who {
+				lockWaitLogged = time.Unix(0, 0)
+			}
+			locker = who
+		} else if errors.Is(err, fs.ErrNotExist) {
+			locker = "none"
+		} else {
+			return fmt.Errorf("another process left the lockfile unreadable: %s", err)
+		}
+
+		// should we try to force our way?
+		if force {
+			success = runLock.ForceAcquire()
+
+			if lockWait == nil || success {
+				clog.Warningf("previous run of the profile started by %s hasn't finished properly", locker)
+			}
+		} else {
+			success = runLock.TryAcquire()
+		}
+
+		// Retry or return?
+		if !success {
+			if lockWait == nil {
+				return fmt.Errorf("another process is already running this profile: %s", locker)
+			}
+			if time.Since(start) < *lockWait {
+				lockName := fmt.Sprintf("%s locked by %s", lockFile, locker)
+				lockWaitLogged = logLockWait(lockName, start, lockWaitLogged, 0, *lockWait)
+
+				sleep := constants.LocalLockRetryDelay
+				if sleep > *lockWait {
+					sleep = *lockWait
+				}
+				err := interruptibleSleep(sleep, sigChan)
+				if err != nil {
+					return err
+				}
+			} else {
+				clog.Warningf("previous run of the profile hasn't finished after %s", *lockWait)
+				lockWait = nil
+			}
+		}
+	}
+
+	// Run locked
+	defer runLock.Release()
+	return run(runLock.SetPID)
+}
+
+const logLockWaitEvery = 5 * time.Minute
+
+func logLockWait(lockName string, started, lastLogged time.Time, executed, maxLockWait time.Duration) time.Time {
+	now := time.Now()
+	lastLog := now.Sub(lastLogged)
+	elapsed := now.Sub(started).Truncate(time.Second)
+	waited := (elapsed - executed).Truncate(time.Second)
+	remaining := (maxLockWait - elapsed).Truncate(time.Second)
+
+	if lastLog > logLockWaitEvery {
+		if elapsed > logLockWaitEvery {
+			clog.Infof("lock wait (remaining %s / waited %s / elapsed %s): %s", remaining, waited, elapsed, strings.TrimSpace(lockName))
+		} else {
+			clog.Infof("lock wait (remaining %s): %s", remaining, strings.TrimSpace(lockName))
+		}
+		return now
+	}
+
+	return lastLogged
+}

--- a/lock/lock.go
+++ b/lock/lock.go
@@ -3,7 +3,6 @@ package lock
 import (
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"os/user"
 	"strconv"
@@ -73,7 +72,7 @@ func (l *Lock) Release() {
 
 // Who owns the lock?
 func (l *Lock) Who() (string, error) {
-	buffer, err := ioutil.ReadFile(l.Lockfile)
+	buffer, err := os.ReadFile(l.Lockfile)
 	if err != nil {
 		return "", err
 	}
@@ -99,7 +98,7 @@ func (l *Lock) HasLocked() bool {
 
 // LastPID returns the last PID written into the lock file.
 func (l *Lock) LastPID() (int32, error) {
-	buffer, err := ioutil.ReadFile(l.Lockfile)
+	buffer, err := os.ReadFile(l.Lockfile)
 	if err != nil {
 		return 0, err
 	}

--- a/lock_test.go
+++ b/lock_test.go
@@ -1,0 +1,120 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/creativeprojects/resticprofile/lock"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestLockRunWithNoLockfile(t *testing.T) {
+	called := 0
+	callback := func(setPID lock.SetPID) error {
+		called++
+		return nil
+	}
+	err := lockRun("", false, nil, nil, callback)
+	assert.NoError(t, err)
+	assert.Equal(t, 1, called)
+}
+
+func TestLockRunWithNoLock(t *testing.T) {
+	called := 0
+	callback := func(setPID lock.SetPID) error {
+		called++
+		return nil
+	}
+	lockfile := filepath.Join(t.TempDir(), "lockfile")
+	assert.NoFileExists(t, lockfile)
+
+	err := lockRun(lockfile, false, nil, nil, callback)
+	assert.NoError(t, err)
+	assert.Equal(t, 1, called)
+	assert.NoFileExists(t, lockfile)
+}
+
+func TestLockRunWithLock(t *testing.T) {
+	called := 0
+	callback := func(setPID lock.SetPID) error {
+		called++
+		return nil
+	}
+	lockfile := filepath.Join(t.TempDir(), "lockfile")
+	err := os.WriteFile(lockfile, []byte{}, 0644)
+	assert.NoError(t, err)
+	assert.FileExists(t, lockfile)
+
+	err = lockRun(lockfile, false, nil, nil, callback)
+	assert.Error(t, err)
+	assert.Equal(t, 0, called)
+	assert.FileExists(t, lockfile)
+}
+
+func TestLockRunWithLockAndForce(t *testing.T) {
+	called := 0
+	callback := func(setPID lock.SetPID) error {
+		called++
+		return nil
+	}
+	lockfile := filepath.Join(t.TempDir(), "lockfile")
+	err := os.WriteFile(lockfile, []byte{}, 0644)
+	assert.NoError(t, err)
+	assert.FileExists(t, lockfile)
+
+	err = lockRun(lockfile, true, nil, nil, callback)
+	assert.Error(t, err)
+	assert.Equal(t, 0, called)
+	assert.FileExists(t, lockfile)
+}
+
+func TestLockRunWithLockAndWait(t *testing.T) {
+	called := 0
+	callback := func(setPID lock.SetPID) error {
+		called++
+		return nil
+	}
+	lockfile := filepath.Join(t.TempDir(), "lockfile")
+	err := os.WriteFile(lockfile, []byte{}, 0644)
+	assert.NoError(t, err)
+	assert.FileExists(t, lockfile)
+
+	// remove the lock after half a second
+	timer := time.AfterFunc(500*time.Millisecond, func() {
+		err := os.Remove(lockfile)
+		assert.NoError(t, err)
+	})
+	defer timer.Stop()
+
+	wait := 1 * time.Second
+	err = lockRun(lockfile, false, &wait, nil, callback)
+	assert.NoError(t, err)
+	assert.Equal(t, 1, called)
+}
+
+func TestLockRunWithLockAndCancel(t *testing.T) {
+	called := 0
+	callback := func(setPID lock.SetPID) error {
+		called++
+		return nil
+	}
+	lockfile := filepath.Join(t.TempDir(), "lockfile")
+	err := os.WriteFile(lockfile, []byte{}, 0644)
+	assert.NoError(t, err)
+	assert.FileExists(t, lockfile)
+
+	sigChan := make(chan os.Signal, 1)
+	// cancel the wait after half a second
+	timer := time.AfterFunc(500*time.Millisecond, func() {
+		sigChan <- os.Interrupt
+	})
+	defer timer.Stop()
+
+	wait := 1 * time.Second
+	err = lockRun(lockfile, false, &wait, sigChan, callback)
+	assert.Error(t, err)
+	assert.Equal(t, 0, called)
+	assert.FileExists(t, lockfile)
+}

--- a/platform/darwin.go
+++ b/platform/darwin.go
@@ -2,6 +2,8 @@
 
 package platform
 
+const LineSeparator = "\n"
+
 func IsDarwin() bool {
 	return true
 }

--- a/platform/other.go
+++ b/platform/other.go
@@ -2,6 +2,8 @@
 
 package platform
 
+const LineSeparator = "\n"
+
 func IsDarwin() bool {
 	return false
 }

--- a/platform/windows.go
+++ b/platform/windows.go
@@ -2,6 +2,8 @@
 
 package platform
 
+const LineSeparator = "\r\n"
+
 func IsDarwin() bool {
 	return false
 }

--- a/sleep.go
+++ b/sleep.go
@@ -1,0 +1,21 @@
+package main
+
+import (
+	"errors"
+	"os"
+	"time"
+)
+
+var (
+	errInterrupt = errors.New("interrupted")
+)
+
+// interruptibleSleep returns errInterrupt if interrupted by the channel.
+func interruptibleSleep(delay time.Duration, interrupt <-chan os.Signal) error {
+	select {
+	case <-time.After(delay):
+		return nil
+	case <-interrupt:
+		return errInterrupt
+	}
+}

--- a/sleep_test.go
+++ b/sleep_test.go
@@ -1,0 +1,27 @@
+package main
+
+import (
+	"os"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNonInterruptedSleep(t *testing.T) {
+	err := interruptibleSleep(30*time.Millisecond, make(<-chan os.Signal))
+	assert.NoError(t, err)
+}
+
+func TestInterruptedSleep(t *testing.T) {
+	maxWait := 3 * time.Second
+	sigChan := make(chan os.Signal)
+	go func() {
+		time.Sleep(30 * time.Millisecond)
+		sigChan <- os.Interrupt
+	}()
+	start := time.Now()
+	err := interruptibleSleep(maxWait, sigChan)
+	assert.ErrorIs(t, err, errInterrupt)
+	assert.Less(t, time.Since(start), maxWait)
+}

--- a/wrapper_test.go
+++ b/wrapper_test.go
@@ -655,9 +655,6 @@ func TestBackupWithError(t *testing.T) {
 }
 
 func TestBackupWithResticLockFailureRetried(t *testing.T) {
-	// if testing.Short() {
-	// 	t.Skip("skipping test in short mode.")
-	// }
 	lockWait := constants.MinResticLockRetryDelay + time.Second
 	lockMessage := "unable to create lock in backend: repository is already locked exclusively by PID 60485 on VM by user (UID 503, GID 23)" + platform.LineSeparator +
 		"lock was created at 2023-09-24 15:29:57 (69.406ms ago)" + platform.LineSeparator +
@@ -704,7 +701,7 @@ func TestBackupWithResticLockFailureCancelled(t *testing.T) {
 	wrapper.lockWait = &lockWait
 	wrapper.startTime = time.Now()
 
-	timer := time.AfterFunc(2*time.Second, func() {
+	timer := time.AfterFunc(1*time.Second, func() {
 		sigChan <- os.Interrupt
 	})
 	defer timer.Stop()


### PR DESCRIPTION
In the current implementation it is not possible to interrupt resticprofile when it's waiting for a lock (both kinds of locks).

This small PR returns an `interrupted` error when the wait is cancelled (typically by a `CTRL`-`c`)

- [x] Implementation
- [x] Tests
- [x] Ready for review