### PR TITLE
Docs for installation from scoop

### DIFF
--- a/docs/content/installation/windows/_index.md
+++ b/docs/content/installation/windows/_index.md
@@ -16,6 +16,14 @@ curl -LO https://raw.githubusercontent.com/creativeprojects/resticprofile/master
 ```
 It will create a `bin` directory under your current directory and place `resticprofile.exe` in it.
 
+## Installation using scoop
+
+Resticprofile can be installed from [scoop](https://scoop.sh) main bucket:
+
+```powershell
+scoop install resticprofile
+```
+
 ## Manual installation (Windows)
 
 - Download the package corresponding to your system and CPU from the [release page](https://github.com/creativeprojects/resticprofile/releases)


### PR DESCRIPTION
resticprofile is available for installation from the [scoop](https://scoop.sh) main bucket. Automatic update for new versions is supported as long as download and hash paths do not change except for the version number.