### PR TITLE
Logging: allow to setup default log output in global

### DIFF
--- a/commands_display.go
+++ b/commands_display.go
@@ -158,15 +158,6 @@ func displayResticHelp(output io.Writer, configuration *config.Config, flags com
 	out, closer := displayWriter(output, flags)
 	defer closer()
 
-	// try to load the config
-	if configuration == nil {
-		if file, err := filesearch.FindConfigurationFile(flags.config); err == nil {
-			if configuration, err = config.LoadFile(file, flags.format); err != nil {
-				configuration = nil
-			}
-		}
-	}
-
 	resticBinary := ""
 	if configuration != nil {
 		if section, err := configuration.GetGlobalSection(); err == nil {

--- a/config/global.go
+++ b/config/global.go
@@ -23,6 +23,7 @@ type Global struct {
 	ShellBinary          []string      `mapstructure:"shell" default:"auto" examples:"sh;bash;pwsh;powershell;cmd" description:"The shell that is used to run commands (default is OS specific)"`
 	MinMemory            uint64        `mapstructure:"min-memory" default:"100" description:"Minimum available memory (in MB) required to run any commands - see https://creativeprojects.github.io/resticprofile/usage/memory/"`
 	Scheduler            string        `mapstructure:"scheduler" description:"Leave blank for the default scheduler or use \"crond\" to select cron on supported operating systems"`
+	Log                  string        `mapstructure:"log" default:"" description:"Sets the default log destination to be used if not specified in '--log' or 'schedule-log' - see https://creativeprojects.github.io/resticprofile/configuration/logs/"`
 	LegacyArguments      bool          `mapstructure:"legacy-arguments" default:"false" deprecated:"0.20.0" description:"Legacy, broken arguments mode of resticprofile before version 0.15"`
 	SystemdUnitTemplate  string        `mapstructure:"systemd-unit-template" default:"" description:"File containing the go template to generate a systemd unit - see https://creativeprojects.github.io/resticprofile/schedules/systemd/"`
 	SystemdTimerTemplate string        `mapstructure:"systemd-timer-template" default:"" description:"File containing the go template to generate a systemd timer - see https://creativeprojects.github.io/resticprofile/schedules/systemd/"`

--- a/docs/content/configuration/logs/_index.md
+++ b/docs/content/configuration/logs/_index.md
@@ -11,6 +11,7 @@ You can redirect the logs to a local file, a temporary file or a syslog server.
 ## Destination
 
 The log destination syntax is a such:
+* `-` {{% icon icon="arrow-right" %}} redirects all the logs to the console / stdout (is the default log destination)
 * `filename` {{% icon icon="arrow-right" %}} redirects all the logs to the local file called **filename**
 * `temp:filename` {{% icon icon="arrow-right" %}} redirects all the logs to a temporary file available during the whole session, and deleted afterwards.
 * `tcp://syslog_server:514` or `udp://syslog_server:514` {{% icon icon="arrow-right" %}} redirects all the logs to the **syslog** server.
@@ -18,6 +19,54 @@ The log destination syntax is a such:
 {{% notice tip %}}
 If the location cannot be opened, **resticprofile** will default to send the logs to the console.
 {{% /notice %}}
+
+## Default
+
+You can adjust the default log destination in the `global` section:
+
+{{< tabs groupid="config-with-json" >}}
+{{% tab title="toml" %}}
+
+```toml
+version = "1"
+
+[global]
+log = "resticprofile.log"
+```
+
+{{% /tab %}}
+{{% tab title="yaml" %}}
+
+```yaml
+version: "1"
+
+global:
+  log: "resticprofile.log"
+```
+
+{{% /tab %}}
+{{% tab title="hcl" %}}
+
+```hcl
+"global" {
+  "log" = "resticprofile.log"
+}
+```
+
+{{% /tab %}}
+{{% tab title="json" %}}
+
+```json
+{
+  "version": "1",
+  "global": {
+    "log": "resticprofile.log"
+  }
+}
+```
+
+{{% /tab %}}
+{{< /tabs >}}
 
 ## Command line
 


### PR DESCRIPTION
Fixes #261

Adds a new option to define the default log output in global:

```yaml
global:
  log: 'some-destination'
```

Adds a new destination syntax `-` for the case that:
* global redirects to a file
* you want to redirect to console or stdout instead (`-` means "console or stdout")
