### PR TITLE
Pass context to own commands and profile runner

### DIFF
--- a/commands.go
+++ b/commands.go
@@ -151,8 +151,8 @@ func panicCommand(_ io.Writer, _ commandContext) error {
 	panic("you asked for it")
 }
 
-func completeCommand(output io.Writer, request commandContext) error {
-	args := request.context.arguments
+func completeCommand(output io.Writer, ctx commandContext) error {
+	args := ctx.request.arguments
 	requester := "unknown"
 	requesterVersion := 0
 
@@ -178,7 +178,7 @@ func completeCommand(output io.Writer, request commandContext) error {
 		return nil
 	}
 
-	completions := NewCompleter(request.ownCommands.All(), DefaultFlagsLoader).Complete(args)
+	completions := NewCompleter(ctx.ownCommands.All(), DefaultFlagsLoader).Complete(args)
 	if len(completions) > 0 {
 		for _, completion := range completions {
 			fmt.Fprintln(output, completion)
@@ -193,8 +193,8 @@ var bashCompletionScript string
 //go:embed contrib/completion/zsh-completion.sh
 var zshCompletionScript string
 
-func generateCommand(output io.Writer, request commandContext) (err error) {
-	args := request.context.arguments
+func generateCommand(output io.Writer, ctx commandContext) (err error) {
+	args := ctx.request.arguments
 	// enforce no-log
 	logger := clog.GetDefaultLogger()
 	handler := logger.GetHandler()
@@ -207,8 +207,8 @@ func generateCommand(output io.Writer, request commandContext) (err error) {
 	} else if slices.Contains(args, "--json-schema") {
 		err = generateJsonSchema(output, args[slices.Index(args, "--json-schema")+1:])
 	} else if slices.Contains(args, "--random-key") {
-		request.context.flags.resticArgs = args[slices.Index(args, "--random-key"):]
-		err = randomKey(output, request)
+		ctx.flags.resticArgs = args[slices.Index(args, "--random-key"):]
+		err = randomKey(output, ctx)
 	} else if slices.Contains(args, "--zsh-completion") {
 		_, err = fmt.Fprintln(output, zshCompletionScript)
 	} else {
@@ -278,9 +278,9 @@ func sortedProfileKeys(data map[string]*config.Profile) []string {
 	return keys
 }
 
-func showProfile(output io.Writer, request commandContext) error {
-	c := request.context.config
-	flags := request.context.flags
+func showProfile(output io.Writer, ctx commandContext) error {
+	c := ctx.config
+	flags := ctx.flags
 
 	// Load global section
 	global, err := c.GetGlobalSection()
@@ -340,9 +340,9 @@ func showSchedules(output io.Writer, schedulesConfig []*config.ScheduleConfig) {
 }
 
 // randomKey simply display a base64'd random key to the console
-func randomKey(output io.Writer, request commandContext) error {
+func randomKey(output io.Writer, ctx commandContext) error {
 	var err error
-	flags := request.context.flags
+	flags := ctx.flags
 	size := uint64(1024)
 	// flags.resticArgs contain the command and the rest of the command line
 	if len(flags.resticArgs) > 1 {
@@ -398,10 +398,10 @@ func flagsForProfile(flags commandLineFlags, profileName string) commandLineFlag
 }
 
 // createSchedule accepts one argument from the commandline: --no-start
-func createSchedule(_ io.Writer, request commandContext) error {
-	c := request.context.config
-	flags := request.context.flags
-	args := request.context.arguments
+func createSchedule(_ io.Writer, ctx commandContext) error {
+	c := ctx.config
+	flags := ctx.flags
+	args := ctx.request.arguments
 
 	defer c.DisplayConfigurationIssues()
 
@@ -453,10 +453,10 @@ func createSchedule(_ io.Writer, request commandContext) error {
 	return nil
 }
 
-func removeSchedule(_ io.Writer, request commandContext) error {
-	c := request.context.config
-	flags := request.context.flags
-	args := request.context.arguments
+func removeSchedule(_ io.Writer, ctx commandContext) error {
+	c := ctx.config
+	flags := ctx.flags
+	args := ctx.request.arguments
 
 	// Unschedule all jobs of all selected profiles
 	for _, profileName := range selectProfiles(c, flags, args) {
@@ -476,10 +476,10 @@ func removeSchedule(_ io.Writer, request commandContext) error {
 	return nil
 }
 
-func statusSchedule(w io.Writer, request commandContext) error {
-	c := request.context.config
-	flags := request.context.flags
-	args := request.context.arguments
+func statusSchedule(w io.Writer, ctx commandContext) error {
+	c := ctx.config
+	flags := ctx.flags
+	args := ctx.request.arguments
 
 	defer c.DisplayConfigurationIssues()
 
@@ -572,9 +572,9 @@ func getRemovableScheduleJobs(c *config.Config, flags commandLineFlags) (schedul
 	return scheduler, profile, schedules, nil
 }
 
-func testElevationCommand(_ io.Writer, request commandContext) error {
-	if request.context.flags.isChild {
-		client := remote.NewClient(request.context.flags.parentPort)
+func testElevationCommand(_ io.Writer, ctx commandContext) error {
+	if ctx.flags.isChild {
+		client := remote.NewClient(ctx.flags.parentPort)
 		term.Print("first line", "\n")
 		term.Println("second", "one")
 		term.Printf("value = %d\n", 11)
@@ -585,7 +585,7 @@ func testElevationCommand(_ io.Writer, request commandContext) error {
 		return nil
 	}
 
-	return elevated(request.context.flags)
+	return elevated(ctx.flags)
 }
 
 func retryElevated(err error, flags commandLineFlags) error {

--- a/commands_display.go
+++ b/commands_display.go
@@ -73,11 +73,11 @@ func getCommonUsageHelpLine(commandName string, withProfile bool) string {
 	)
 }
 
-func displayOwnCommands(output io.Writer, request commandContext) {
-	out, closer := displayWriter(output, request.context.flags)
+func displayOwnCommands(output io.Writer, ctx commandContext) {
+	out, closer := displayWriter(output, ctx.flags)
 	defer closer()
 
-	for _, command := range request.ownCommands.commands {
+	for _, command := range ctx.ownCommands.commands {
 		if command.hide {
 			continue
 		}
@@ -86,12 +86,12 @@ func displayOwnCommands(output io.Writer, request commandContext) {
 	}
 }
 
-func displayOwnCommandHelp(output io.Writer, commandName string, request commandContext) {
-	out, closer := displayWriter(output, request.context.flags)
+func displayOwnCommandHelp(output io.Writer, commandName string, ctx commandContext) {
+	out, closer := displayWriter(output, ctx.flags)
 	defer closer()
 
 	var command *ownCommand
-	for _, c := range request.ownCommands.commands {
+	for _, c := range ctx.ownCommands.commands {
 		if c.name == commandName {
 			command = &c
 			break
@@ -130,8 +130,8 @@ func displayOwnCommandHelp(output io.Writer, commandName string, request command
 	}
 }
 
-func displayCommonUsageHelp(output io.Writer, request commandContext) {
-	out, closer := displayWriter(output, request.context.flags)
+func displayCommonUsageHelp(output io.Writer, ctx commandContext) {
+	out, closer := displayWriter(output, ctx.flags)
 	defer closer()
 
 	out("resticprofile is a configuration profiles manager for backup profiles and ")
@@ -142,10 +142,10 @@ func displayCommonUsageHelp(output io.Writer, request commandContext) {
 	out("\t%s [command specific flags]\n", getCommonUsageHelpLine("resticprofile-command", true))
 	out("\n")
 	out(ansiBold("resticprofile flags:\n"))
-	out(request.context.flags.usagesHelp)
+	out(ctx.flags.usagesHelp)
 	out("\n\n")
 	out(ansiBold("resticprofile own commands:\n"))
-	displayOwnCommands(out(), request)
+	displayOwnCommands(out(), ctx)
 	out("\n")
 
 	out("%s at %s\n",
@@ -218,10 +218,10 @@ func displayResticHelp(output io.Writer, configuration *config.Config, flags com
 	}
 }
 
-func displayHelpCommand(output io.Writer, request commandContext) error {
-	flags := request.context.flags
+func displayHelpCommand(output io.Writer, ctx commandContext) error {
+	flags := ctx.flags
 
-	out, closer := displayWriter(output, request.context.flags)
+	out, closer := displayWriter(output, ctx.flags)
 	defer closer()
 
 	if flags.log == "" {
@@ -237,26 +237,27 @@ func displayHelpCommand(output io.Writer, request commandContext) error {
 	}
 
 	if helpForCommand == nil {
-		displayCommonUsageHelp(out("\n"), request)
+		displayCommonUsageHelp(out("\n"), ctx)
 
-	} else if request.ownCommands.Exists(*helpForCommand, true) || request.ownCommands.Exists(*helpForCommand, false) {
-		displayOwnCommandHelp(out("\n"), *helpForCommand, request)
+	} else if ctx.ownCommands.Exists(*helpForCommand, true) || ctx.ownCommands.Exists(*helpForCommand, false) {
+		displayOwnCommandHelp(out("\n"), *helpForCommand, ctx)
 
 	} else {
-		displayResticHelp(out(), request.context.config, flags, *helpForCommand)
+		displayResticHelp(out(), ctx.config, flags, *helpForCommand)
 	}
 
 	return nil
 }
 
-func displayVersion(output io.Writer, request commandContext) error {
-	out, closer := displayWriter(output, request.context.flags)
+func displayVersion(output io.Writer, ctx commandContext) error {
+	out, closer := displayWriter(output, ctx.flags)
 	defer closer()
 
 	out("resticprofile version %s commit %s\n", ansiBold(version), ansiYellow(commit))
 
 	// allow for the general verbose flag, or specified after the command
-	if request.context.flags.verbose || (len(request.context.arguments) > 0 && (request.context.arguments[0] == "-v" || request.context.arguments[0] == "--verbose")) {
+	arguments := ctx.request.arguments
+	if ctx.flags.verbose || (len(arguments) > 0 && (arguments[0] == "-v" || arguments[0] == "--verbose")) {
 		out("\n")
 		out("\t%s:\t%s\n", "home", "https://github.com/creativeprojects/resticprofile")
 		out("\t%s:\t%s\n", "os", runtime.GOOS)
@@ -280,9 +281,9 @@ func displayVersion(output io.Writer, request commandContext) error {
 	return nil
 }
 
-func displayProfilesCommand(output io.Writer, request commandContext) error {
-	displayProfiles(output, request.context.config, request.context.flags)
-	displayGroups(output, request.context.config, request.context.flags)
+func displayProfilesCommand(output io.Writer, ctx commandContext) error {
+	displayProfiles(output, ctx.config, ctx.flags)
+	displayGroups(output, ctx.config, ctx.flags)
 	return nil
 }
 

--- a/commands_display.go
+++ b/commands_display.go
@@ -73,8 +73,8 @@ func getCommonUsageHelpLine(commandName string, withProfile bool) string {
 	)
 }
 
-func displayOwnCommands(output io.Writer, request commandRequest) {
-	out, closer := displayWriter(output, request.flags)
+func displayOwnCommands(output io.Writer, request commandContext) {
+	out, closer := displayWriter(output, request.context.flags)
 	defer closer()
 
 	for _, command := range request.ownCommands.commands {
@@ -86,8 +86,8 @@ func displayOwnCommands(output io.Writer, request commandRequest) {
 	}
 }
 
-func displayOwnCommandHelp(output io.Writer, commandName string, request commandRequest) {
-	out, closer := displayWriter(output, request.flags)
+func displayOwnCommandHelp(output io.Writer, commandName string, request commandContext) {
+	out, closer := displayWriter(output, request.context.flags)
 	defer closer()
 
 	var command *ownCommand
@@ -130,8 +130,8 @@ func displayOwnCommandHelp(output io.Writer, commandName string, request command
 	}
 }
 
-func displayCommonUsageHelp(output io.Writer, request commandRequest) {
-	out, closer := displayWriter(output, request.flags)
+func displayCommonUsageHelp(output io.Writer, request commandContext) {
+	out, closer := displayWriter(output, request.context.flags)
 	defer closer()
 
 	out("resticprofile is a configuration profiles manager for backup profiles and ")
@@ -142,7 +142,7 @@ func displayCommonUsageHelp(output io.Writer, request commandRequest) {
 	out("\t%s [command specific flags]\n", getCommonUsageHelpLine("resticprofile-command", true))
 	out("\n")
 	out(ansiBold("resticprofile flags:\n"))
-	out(request.flags.usagesHelp)
+	out(request.context.flags.usagesHelp)
 	out("\n\n")
 	out(ansiBold("resticprofile own commands:\n"))
 	displayOwnCommands(out(), request)
@@ -218,10 +218,10 @@ func displayResticHelp(output io.Writer, configuration *config.Config, flags com
 	}
 }
 
-func displayHelpCommand(output io.Writer, request commandRequest) error {
-	flags := request.flags
+func displayHelpCommand(output io.Writer, request commandContext) error {
+	flags := request.context.flags
 
-	out, closer := displayWriter(output, request.flags)
+	out, closer := displayWriter(output, request.context.flags)
 	defer closer()
 
 	if flags.log == "" {
@@ -243,20 +243,20 @@ func displayHelpCommand(output io.Writer, request commandRequest) error {
 		displayOwnCommandHelp(out("\n"), *helpForCommand, request)
 
 	} else {
-		displayResticHelp(out(), request.config, flags, *helpForCommand)
+		displayResticHelp(out(), request.context.config, flags, *helpForCommand)
 	}
 
 	return nil
 }
 
-func displayVersion(output io.Writer, request commandRequest) error {
-	out, closer := displayWriter(output, request.flags)
+func displayVersion(output io.Writer, request commandContext) error {
+	out, closer := displayWriter(output, request.context.flags)
 	defer closer()
 
 	out("resticprofile version %s commit %s\n", ansiBold(version), ansiYellow(commit))
 
 	// allow for the general verbose flag, or specified after the command
-	if request.flags.verbose || (len(request.args) > 0 && (request.args[0] == "-v" || request.args[0] == "--verbose")) {
+	if request.context.flags.verbose || (len(request.context.arguments) > 0 && (request.context.arguments[0] == "-v" || request.context.arguments[0] == "--verbose")) {
 		out("\n")
 		out("\t%s:\t%s\n", "home", "https://github.com/creativeprojects/resticprofile")
 		out("\t%s:\t%s\n", "os", runtime.GOOS)
@@ -280,9 +280,9 @@ func displayVersion(output io.Writer, request commandRequest) error {
 	return nil
 }
 
-func displayProfilesCommand(output io.Writer, request commandRequest) error {
-	displayProfiles(output, request.config, request.flags)
-	displayGroups(output, request.config, request.flags)
+func displayProfilesCommand(output io.Writer, request commandContext) error {
+	displayProfiles(output, request.context.config, request.context.flags)
+	displayGroups(output, request.context.config, request.context.flags)
 	return nil
 }
 

--- a/commands_display_test.go
+++ b/commands_display_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"bytes"
 	"fmt"
+	"runtime"
 	"strings"
 	"testing"
 
@@ -294,4 +295,16 @@ https://creativeprojects.github.io/resticprofile/
 			})
 		}
 	}
+}
+
+func TestDisplayVersionVerbose1(t *testing.T) {
+	buffer := &bytes.Buffer{}
+	displayVersion(buffer, commandContext{Context: Context{flags: commandLineFlags{verbose: true}}})
+	assert.True(t, strings.Contains(buffer.String(), runtime.GOOS))
+}
+
+func TestDisplayVersionVerbose2(t *testing.T) {
+	buffer := &bytes.Buffer{}
+	displayVersion(buffer, commandContext{Context: Context{request: Request{arguments: []string{"-v"}}}})
+	assert.True(t, strings.Contains(buffer.String(), runtime.GOOS))
 }

--- a/commands_test.go
+++ b/commands_test.go
@@ -46,27 +46,27 @@ func fakeCommands() *OwnCommands {
 	return ownCommands
 }
 
-func firstCommand(_ io.Writer, _ commandRequest) error {
+func firstCommand(_ io.Writer, _ commandContext) error {
 	return errors.New("first")
 }
 
-func secondCommand(_ io.Writer, _ commandRequest) error {
+func secondCommand(_ io.Writer, _ commandContext) error {
 	return errors.New("second")
 }
 
-func thirdCommand(_ io.Writer, _ commandRequest) error {
+func thirdCommand(_ io.Writer, _ commandContext) error {
 	return errors.New("third")
 }
 
 func TestDisplayOwnCommands(t *testing.T) {
 	buffer := &strings.Builder{}
-	displayOwnCommands(buffer, commandRequest{ownCommands: fakeCommands()})
+	displayOwnCommands(buffer, commandContext{ownCommands: fakeCommands(), context: &Context{}})
 	assert.Equal(t, "  first   first first\n  second  second second\n", buffer.String())
 }
 
 func TestDisplayOwnCommand(t *testing.T) {
 	buffer := &strings.Builder{}
-	displayOwnCommandHelp(buffer, "second", commandRequest{ownCommands: fakeCommands()})
+	displayOwnCommandHelp(buffer, "second", commandContext{ownCommands: fakeCommands(), context: &Context{}})
 	assert.Equal(t, `Purpose: second second
 
 Usage:
@@ -87,29 +87,37 @@ func TestIsOwnCommand(t *testing.T) {
 }
 
 func TestRunOwnCommand(t *testing.T) {
-	assert.EqualError(t, fakeCommands().Run(nil, "first", commandLineFlags{}, nil), "first")
-	assert.EqualError(t, fakeCommands().Run(nil, "second", commandLineFlags{}, nil), "second")
-	assert.EqualError(t, fakeCommands().Run(nil, "third", commandLineFlags{}, nil), "third")
-	assert.EqualError(t, fakeCommands().Run(nil, "another one", commandLineFlags{}, nil), "command not found: another one")
+	assert.EqualError(t, fakeCommands().Run(&Context{resticCommand: "first"}), "first")
+	assert.EqualError(t, fakeCommands().Run(&Context{resticCommand: "second"}), "second")
+	assert.EqualError(t, fakeCommands().Run(&Context{resticCommand: "third"}), "third")
+	assert.EqualError(t, fakeCommands().Run(&Context{resticCommand: "another one"}), "command not found: another one")
 }
 
 func TestPanicCommand(t *testing.T) {
 	assert.Panics(t, func() {
-		_ = panicCommand(nil, commandRequest{})
+		_ = panicCommand(nil, commandContext{})
 	})
 }
 
 func TestRandomKeyOfInvalidSize(t *testing.T) {
-	assert.Error(t, randomKey(os.Stdout, commandRequest{flags: commandLineFlags{resticArgs: []string{"restic", "size"}}}))
+	assert.Error(t, randomKey(os.Stdout, commandContext{
+		context: &Context{
+			flags: commandLineFlags{resticArgs: []string{"restic", "size"}},
+		},
+	}))
 }
 
 func TestRandomKeyOfZeroSize(t *testing.T) {
-	assert.Error(t, randomKey(os.Stdout, commandRequest{flags: commandLineFlags{resticArgs: []string{"restic", "0"}}}))
+	assert.Error(t, randomKey(os.Stdout, commandContext{
+		context: &Context{
+			flags: commandLineFlags{resticArgs: []string{"restic", "0"}},
+		},
+	}))
 }
 
 func TestRandomKey(t *testing.T) {
 	// doesn't look like much, but it's testing the random generator is not throwing an error
-	assert.NoError(t, randomKey(os.Stdout, commandRequest{}))
+	assert.NoError(t, randomKey(os.Stdout, commandContext{context: &Context{}}))
 }
 
 func TestRemovableSchedules(t *testing.T) {
@@ -263,7 +271,7 @@ func TestCompleteCall(t *testing.T) {
 	for _, test := range testTable {
 		t.Run(strings.Join(test.args, " "), func(t *testing.T) {
 			buffer := &strings.Builder{}
-			assert.Nil(t, completeCommand(buffer, commandRequest{ownCommands: ownCommands, args: test.args}))
+			assert.Nil(t, completeCommand(buffer, commandContext{ownCommands: ownCommands, context: &Context{arguments: test.args}}))
 			assert.Equal(t, test.expected, buffer.String())
 		})
 	}
@@ -274,21 +282,21 @@ func TestGenerateCommand(t *testing.T) {
 
 	t.Run("--bash-completion", func(t *testing.T) {
 		buffer.Reset()
-		assert.Nil(t, generateCommand(buffer, commandRequest{args: []string{"--bash-completion"}}))
+		assert.Nil(t, generateCommand(buffer, commandContext{context: &Context{arguments: []string{"--bash-completion"}}}))
 		assert.Equal(t, strings.TrimSpace(bashCompletionScript), strings.TrimSpace(buffer.String()))
 		assert.Contains(t, bashCompletionScript, "#!/usr/bin/env bash")
 	})
 
 	t.Run("--zsh-completion", func(t *testing.T) {
 		buffer.Reset()
-		assert.Nil(t, generateCommand(buffer, commandRequest{args: []string{"--zsh-completion"}}))
+		assert.Nil(t, generateCommand(buffer, commandContext{context: &Context{arguments: []string{"--zsh-completion"}}}))
 		assert.Equal(t, strings.TrimSpace(zshCompletionScript), strings.TrimSpace(buffer.String()))
 		assert.Contains(t, zshCompletionScript, "#!/usr/bin/env zsh")
 	})
 
 	t.Run("--config-reference", func(t *testing.T) {
 		buffer.Reset()
-		assert.NoError(t, generateCommand(buffer, commandRequest{args: []string{"--config-reference"}}))
+		assert.NoError(t, generateCommand(buffer, commandContext{context: &Context{arguments: []string{"--config-reference"}}}))
 		ref := buffer.String()
 		assert.Contains(t, ref, "| **ionice-class** |")
 		assert.Contains(t, ref, "| **check-after** |")
@@ -297,7 +305,7 @@ func TestGenerateCommand(t *testing.T) {
 
 	t.Run("--json-schema", func(t *testing.T) {
 		buffer.Reset()
-		assert.NoError(t, generateCommand(buffer, commandRequest{args: []string{"--json-schema"}}))
+		assert.NoError(t, generateCommand(buffer, commandContext{context: &Context{arguments: []string{"--json-schema"}}}))
 		ref := buffer.String()
 		assert.Contains(t, ref, "\"profiles\":")
 		assert.Contains(t, ref, "/jsonschema/config-2.json")
@@ -305,21 +313,21 @@ func TestGenerateCommand(t *testing.T) {
 
 	t.Run("--json-schema v1", func(t *testing.T) {
 		buffer.Reset()
-		assert.NoError(t, generateCommand(buffer, commandRequest{args: []string{"--json-schema", "v1"}}))
+		assert.NoError(t, generateCommand(buffer, commandContext{context: &Context{arguments: []string{"--json-schema", "v1"}}}))
 		ref := buffer.String()
 		assert.Contains(t, ref, "/jsonschema/config-1.json")
 	})
 
 	t.Run("--json-schema --version 0.13 v1", func(t *testing.T) {
 		buffer.Reset()
-		assert.NoError(t, generateCommand(buffer, commandRequest{args: []string{"--json-schema", "--version", "0.13", "v1"}}))
+		assert.NoError(t, generateCommand(buffer, commandContext{context: &Context{arguments: []string{"--json-schema", "--version", "0.13", "v1"}}}))
 		ref := buffer.String()
 		assert.Contains(t, ref, "/jsonschema/config-1-restic-0-13.json")
 	})
 
 	t.Run("--random-key", func(t *testing.T) {
 		buffer.Reset()
-		assert.Nil(t, generateCommand(buffer, commandRequest{args: []string{"--random-key", "512"}}))
+		assert.Nil(t, generateCommand(buffer, commandContext{context: &Context{arguments: []string{"--random-key", "512"}}}))
 		assert.Equal(t, 684, len(strings.TrimSpace(buffer.String())))
 	})
 
@@ -328,7 +336,7 @@ func TestGenerateCommand(t *testing.T) {
 		opts := []string{"", "invalid", "--unknown"}
 		for _, option := range opts {
 			buffer.Reset()
-			err := generateCommand(buffer, commandRequest{args: []string{option}})
+			err := generateCommand(buffer, commandContext{context: &Context{arguments: []string{option}}})
 			assert.EqualError(t, err, fmt.Sprintf("nothing to generate for: %s", option))
 			assert.Equal(t, 0, buffer.Len())
 		}

--- a/commands_test.go
+++ b/commands_test.go
@@ -2,9 +2,7 @@ package main
 
 import (
 	"bytes"
-	"errors"
 	"fmt"
-	"io"
 	"os"
 	"sort"
 	"strings"
@@ -15,83 +13,6 @@ import (
 	"github.com/creativeprojects/resticprofile/util/collect"
 	"github.com/stretchr/testify/assert"
 )
-
-func fakeCommands() *OwnCommands {
-	ownCommands := NewOwnCommands()
-	ownCommands.Register([]ownCommand{
-		{
-			name:              "first",
-			description:       "first first",
-			action:            firstCommand,
-			needConfiguration: false,
-		},
-		{
-			name:              "second",
-			description:       "second second",
-			action:            secondCommand,
-			needConfiguration: true,
-			flags: map[string]string{
-				"-f, --first":   "first flag",
-				"-s, --seccond": "second flag",
-			},
-		},
-		{
-			name:              "third",
-			description:       "third third",
-			action:            thirdCommand,
-			needConfiguration: false,
-			hide:              true,
-		},
-	})
-	return ownCommands
-}
-
-func firstCommand(_ io.Writer, _ commandContext) error {
-	return errors.New("first")
-}
-
-func secondCommand(_ io.Writer, _ commandContext) error {
-	return errors.New("second")
-}
-
-func thirdCommand(_ io.Writer, _ commandContext) error {
-	return errors.New("third")
-}
-
-func TestDisplayOwnCommands(t *testing.T) {
-	buffer := &strings.Builder{}
-	displayOwnCommands(buffer, commandContext{ownCommands: fakeCommands()})
-	assert.Equal(t, "  first   first first\n  second  second second\n", buffer.String())
-}
-
-func TestDisplayOwnCommand(t *testing.T) {
-	buffer := &strings.Builder{}
-	displayOwnCommandHelp(buffer, "second", commandContext{ownCommands: fakeCommands()})
-	assert.Equal(t, `Purpose: second second
-
-Usage:
-  resticprofile [resticprofile flags] [profile name.]second [command specific flags]
-
-Flags:
-  -f, --first    first flag
-  -s, --seccond  second flag
-
-`, buffer.String())
-}
-
-func TestIsOwnCommand(t *testing.T) {
-	assert.True(t, fakeCommands().Exists("first", false))
-	assert.True(t, fakeCommands().Exists("second", true))
-	assert.True(t, fakeCommands().Exists("third", false))
-	assert.False(t, fakeCommands().Exists("another one", true))
-}
-
-func TestRunOwnCommand(t *testing.T) {
-	assert.EqualError(t, fakeCommands().Run(&Context{request: Request{command: "first"}}), "first")
-	assert.EqualError(t, fakeCommands().Run(&Context{request: Request{command: "second"}}), "second")
-	assert.EqualError(t, fakeCommands().Run(&Context{request: Request{command: "third"}}), "third")
-	assert.EqualError(t, fakeCommands().Run(&Context{request: Request{command: "another one"}}), "command not found: another one")
-}
 
 func TestPanicCommand(t *testing.T) {
 	assert.Panics(t, func() {

--- a/context.go
+++ b/context.go
@@ -6,39 +6,67 @@ import (
 	"github.com/creativeprojects/resticprofile/config"
 )
 
+type Request struct {
+	command   string   // from the command line
+	arguments []string // added arguments after the restic command; all arguments for own commands
+	profile   string   // profile name (if any)
+	group     string   // when running as part of a group of profiles
+	schedule  string   // when started with command: run-schedule <schedule-name>
+}
+
 // Context for running a profile command.
 // Not everything is always available,
 // but any information should be added to the context as soon as known.
 type Context struct {
-	flags         commandLineFlags
-	global        *config.Global
-	config        *config.Config
-	resticBinary  string
-	resticCommand string
-	arguments     []string // arguments added after the restic command || all arguments for own commands
-	profileName   string
-	group         string // when running as part of a group of profiles
-	scheduleName  string // when started with command: run-schedule <schedule-name>
-	profile       *config.Profile
-	schedule      *config.Schedule // when profile is running with run-schedule command
-	sigChan       chan os.Signal
+	request   Request
+	flags     commandLineFlags
+	global    *config.Global
+	config    *config.Config
+	binary    string // where to find the restic binary
+	command   string // which restic command to use
+	profile   *config.Profile
+	schedule  *config.Schedule // when profile is running with run-schedule command
+	sigChan   chan os.Signal   // termination request
+	logTarget string           // where to send the log output
 }
 
-// NewProfileContext creates a new context from the current one.
-// It does NOT copy the profile and schedule.
-func (c *Context) NewProfileContext() *Context {
+// WithBinary sets the restic binary to use. It doesn't create a new context.
+func (c *Context) WithBinary(resticBinary string) *Context {
+	c.binary = resticBinary
+	return c
+}
+
+// WithCommand sets the restic command. It doesn't create a new context.
+func (c *Context) WithCommand(resticCommand string) *Context {
+	c.command = resticCommand
+	return c
+}
+
+// WithGroup sets the configuration group. It doesn't create a new context.
+func (c *Context) WithGroup(group string) *Context {
+	c.request.group = group
+	return c
+}
+
+// WithProfile sets the profile name. A new copy of the context is created.
+// Profile and schedule information are not copied over.
+func (c *Context) WithProfile(profileName string) *Context {
 	return &Context{
-		flags:         c.flags,
-		global:        c.global,
-		config:        c.config,
-		resticBinary:  c.resticBinary,
-		resticCommand: c.resticCommand,
-		arguments:     c.arguments,
-		profileName:   c.profileName,
-		group:         c.group,
-		scheduleName:  c.scheduleName,
-		profile:       nil,
-		schedule:      nil,
-		sigChan:       c.sigChan,
+		request: Request{
+			command:   c.request.command,
+			arguments: c.request.arguments,
+			profile:   profileName,
+			group:     "",
+			schedule:  "",
+		},
+		flags:     c.flags,
+		global:    c.global,
+		config:    c.config,
+		binary:    c.binary,
+		command:   c.command,
+		profile:   nil,
+		schedule:  nil,
+		sigChan:   c.sigChan,
+		logTarget: c.logTarget, // the logTarget might change in case of a scheduled context :-/
 	}
 }

--- a/context.go
+++ b/context.go
@@ -30,50 +30,48 @@ type Context struct {
 	logTarget string           // where to send the log output
 }
 
-// WithConfig sets the configuration and global values. It doesn't create a new context.
+// WithConfig sets the configuration and global values. A new copy of the context is returned.
 func (c *Context) WithConfig(cfg *config.Config, global *config.Global) *Context {
-	c.config = cfg
-	c.global = global
-	return c
+	newContext := c.clone()
+	newContext.config = cfg
+	newContext.global = global
+	return newContext
 }
 
-// WithBinary sets the restic binary to use. It doesn't create a new context.
+// WithBinary sets the restic binary to use. A new copy of the context is returned.
 func (c *Context) WithBinary(resticBinary string) *Context {
-	c.binary = resticBinary
-	return c
+	newContext := c.clone()
+	newContext.binary = resticBinary
+	return newContext
 }
 
-// WithCommand sets the restic command. It doesn't create a new context.
+// WithCommand sets the restic command. A new copy of the context is returned.
 func (c *Context) WithCommand(resticCommand string) *Context {
-	c.command = resticCommand
-	return c
+	newContext := c.clone()
+	newContext.command = resticCommand
+	return newContext
 }
 
-// WithGroup sets the configuration group. It doesn't create a new context.
+// WithGroup sets the configuration group. A new copy of the context is returned.
 func (c *Context) WithGroup(group string) *Context {
-	c.request.group = group
-	return c
+	newContext := c.clone()
+	newContext.request.group = group
+	return newContext
 }
 
-// WithProfile sets the profile name. A new copy of the context is created.
+// WithProfile sets the profile name. A new copy of the context is returned.
 // Profile and schedule information are not copied over.
 func (c *Context) WithProfile(profileName string) *Context {
-	return &Context{
-		request: Request{
-			command:   c.request.command,
-			arguments: c.request.arguments,
-			profile:   profileName,
-			group:     "",
-			schedule:  "",
-		},
-		flags:     c.flags,
-		global:    c.global,
-		config:    c.config,
-		binary:    c.binary,
-		command:   c.command,
-		profile:   nil,
-		schedule:  nil,
-		sigChan:   c.sigChan,
-		logTarget: c.logTarget, // the logTarget might change in case of a scheduled context :-/
-	}
+	newContext := c.clone()
+	newContext.request.profile = profileName
+	newContext.request.group = ""
+	newContext.request.schedule = ""
+	newContext.profile = nil
+	newContext.schedule = nil
+	return newContext
+}
+
+func (c *Context) clone() *Context {
+	clone := *c
+	return &clone
 }

--- a/context.go
+++ b/context.go
@@ -1,0 +1,44 @@
+package main
+
+import (
+	"os"
+
+	"github.com/creativeprojects/resticprofile/config"
+)
+
+// Context for running a profile command.
+// Not everything is always available,
+// but any information should be added to the context as soon as known.
+type Context struct {
+	flags         commandLineFlags
+	global        *config.Global
+	config        *config.Config
+	resticBinary  string
+	resticCommand string
+	arguments     []string // arguments added after the restic command || all arguments for own commands
+	profileName   string
+	group         string // when running as part of a group of profiles
+	scheduleName  string // when started with command: run-schedule <schedule-name>
+	profile       *config.Profile
+	schedule      *config.Schedule // when profile is running with run-schedule command
+	sigChan       chan os.Signal
+}
+
+// NewProfileContext creates a new context from the current one.
+// It does NOT copy the profile and schedule.
+func (c *Context) NewProfileContext() *Context {
+	return &Context{
+		flags:         c.flags,
+		global:        c.global,
+		config:        c.config,
+		resticBinary:  c.resticBinary,
+		resticCommand: c.resticCommand,
+		arguments:     c.arguments,
+		profileName:   c.profileName,
+		group:         c.group,
+		scheduleName:  c.scheduleName,
+		profile:       nil,
+		schedule:      nil,
+		sigChan:       c.sigChan,
+	}
+}

--- a/context.go
+++ b/context.go
@@ -30,6 +30,13 @@ type Context struct {
 	logTarget string           // where to send the log output
 }
 
+// WithConfig sets the configuration and global values. It doesn't create a new context.
+func (c *Context) WithConfig(cfg *config.Config, global *config.Global) *Context {
+	c.config = cfg
+	c.global = global
+	return c
+}
+
 // WithBinary sets the restic binary to use. It doesn't create a new context.
 func (c *Context) WithBinary(resticBinary string) *Context {
 	c.binary = resticBinary

--- a/context_test.go
+++ b/context_test.go
@@ -7,6 +7,17 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+func TestContextClone(t *testing.T) {
+	ctx := &Context{
+		config: &config.Config{},
+		global: &config.Global{},
+		binary: "test",
+	}
+	clone := ctx.clone()
+	assert.False(t, ctx == clone) // different pointers
+	assert.Equal(t, ctx, clone)   // same values
+}
+
 func TestContextWithConfig(t *testing.T) {
 	ctx := &Context{
 		config: nil,

--- a/context_test.go
+++ b/context_test.go
@@ -7,6 +7,16 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+func TestContextWithConfig(t *testing.T) {
+	ctx := &Context{
+		config: nil,
+		global: nil,
+	}
+	ctx = ctx.WithConfig(&config.Config{}, &config.Global{})
+	assert.NotNil(t, ctx.config)
+	assert.NotNil(t, ctx.global)
+}
+
 func TestContextWithBinary(t *testing.T) {
 	ctx := &Context{
 		binary: "test",

--- a/context_test.go
+++ b/context_test.go
@@ -1,0 +1,18 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/creativeprojects/resticprofile/config"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCloningContextLeavesProfileAndScheduleBehind(t *testing.T) {
+	ctx := Context{
+		profile:  &config.Profile{},
+		schedule: &config.Schedule{},
+	}
+	newCtx := ctx.NewProfileContext()
+	assert.Nil(t, newCtx.profile)
+	assert.Nil(t, newCtx.schedule)
+}

--- a/context_test.go
+++ b/context_test.go
@@ -7,6 +7,34 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+func TestContextWithBinary(t *testing.T) {
+	ctx := &Context{
+		binary: "test",
+	}
+	ctx = ctx.WithBinary("test2")
+	assert.Equal(t, "test2", ctx.binary)
+}
+
+func TestContextWithCommand(t *testing.T) {
+	ctx := &Context{
+		command: "test",
+	}
+	ctx = ctx.WithCommand("test2")
+	assert.Equal(t, "test2", ctx.command)
+}
+
+func TestContextWithGroup(t *testing.T) {
+	ctx := &Context{
+		request: Request{
+			command: "test",
+			group:   "test",
+		},
+	}
+	ctx = ctx.WithGroup("test2")
+	assert.Equal(t, "test2", ctx.request.group)
+	assert.NotEmpty(t, ctx.request.command)
+}
+
 func TestContextWithProfile(t *testing.T) {
 	ctx := &Context{
 		request: Request{

--- a/context_test.go
+++ b/context_test.go
@@ -7,12 +7,24 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestCloningContextLeavesProfileAndScheduleBehind(t *testing.T) {
-	ctx := Context{
+func TestContextWithProfile(t *testing.T) {
+	ctx := &Context{
+		request: Request{
+			command:  "test",
+			profile:  "test",
+			group:    "test",
+			schedule: "test",
+		},
 		profile:  &config.Profile{},
 		schedule: &config.Schedule{},
 	}
-	newCtx := ctx.NewProfileContext()
-	assert.Nil(t, newCtx.profile)
-	assert.Nil(t, newCtx.schedule)
+	ctx = ctx.WithProfile("test2")
+	assert.Equal(t, "test2", ctx.request.profile)
+	assert.NotEmpty(t, ctx.request.command)
+
+	assert.Empty(t, ctx.request.group)
+	assert.Empty(t, ctx.request.schedule)
+
+	assert.Nil(t, ctx.profile)
+	assert.Nil(t, ctx.schedule)
 }

--- a/errors.go
+++ b/errors.go
@@ -1,0 +1,7 @@
+package main
+
+import "errors"
+
+var (
+	ErrProfileNotFound = errors.New("profile or group not found")
+)

--- a/integration_test.go
+++ b/integration_test.go
@@ -138,11 +138,13 @@ func TestFromConfigFileToCommandLine(t *testing.T) {
 					require.NotNil(t, profile)
 
 					ctx := &Context{
-						resticBinary:  echoBinary,
-						profileName:   fixture.profileName,
-						profile:       profile,
-						resticCommand: fixture.commandName,
-						arguments:     fixture.cmdlineArgs,
+						request: Request{
+							profile:   fixture.profileName,
+							arguments: fixture.cmdlineArgs,
+						},
+						binary:  echoBinary,
+						profile: profile,
+						command: fixture.commandName,
 					}
 					wrapper := newResticWrapper(ctx)
 					buffer := &bytes.Buffer{}
@@ -178,11 +180,13 @@ func TestFromConfigFileToCommandLine(t *testing.T) {
 					profile.SetLegacyArg(true)
 
 					ctx := &Context{
-						resticBinary:  echoBinary,
-						profileName:   fixture.profileName,
-						profile:       profile,
-						resticCommand: fixture.commandName,
-						arguments:     fixture.cmdlineArgs,
+						request: Request{
+							profile:   fixture.profileName,
+							arguments: fixture.cmdlineArgs,
+						},
+						binary:  echoBinary,
+						profile: profile,
+						command: fixture.commandName,
 					}
 					wrapper := newResticWrapper(ctx)
 					buffer := &bytes.Buffer{}

--- a/integration_test.go
+++ b/integration_test.go
@@ -137,15 +137,14 @@ func TestFromConfigFileToCommandLine(t *testing.T) {
 					require.NoError(t, err)
 					require.NotNil(t, profile)
 
-					wrapper := newResticWrapper(
-						nil,
-						echoBinary,
-						false,
-						profile,
-						fixture.commandName,
-						fixture.cmdlineArgs,
-						nil,
-					)
+					ctx := &Context{
+						resticBinary:  echoBinary,
+						profileName:   fixture.profileName,
+						profile:       profile,
+						resticCommand: fixture.commandName,
+						arguments:     fixture.cmdlineArgs,
+					}
+					wrapper := newResticWrapper(ctx)
 					buffer := &bytes.Buffer{}
 					// setting the output via the package global setter could lead to some issues
 					// when some tests are running in parallel. I should fix that at some point :-/
@@ -178,15 +177,14 @@ func TestFromConfigFileToCommandLine(t *testing.T) {
 
 					profile.SetLegacyArg(true)
 
-					wrapper := newResticWrapper(
-						nil,
-						echoBinary,
-						false,
-						profile,
-						fixture.commandName,
-						fixture.cmdlineArgs,
-						nil,
-					)
+					ctx := &Context{
+						resticBinary:  echoBinary,
+						profileName:   fixture.profileName,
+						profile:       profile,
+						resticCommand: fixture.commandName,
+						arguments:     fixture.cmdlineArgs,
+					}
+					wrapper := newResticWrapper(ctx)
 					buffer := &bytes.Buffer{}
 					// setting the output via the package global setter could lead to some issues
 					// when some tests are running in parallel. I should fix that at some point :-/

--- a/logger_test.go
+++ b/logger_test.go
@@ -36,9 +36,7 @@ func TestFileHandlerWithTemporaryDirMarker(t *testing.T) {
 	logFile := filepath.Join(util.MustGetTempDir(), "sub", "file.log")
 	assert.NoFileExists(t, logFile)
 
-	handler, _, err := getFileHandler(commandLineFlags{
-		log: filepath.Join(constants.TemporaryDirMarker, "sub", "file.log"),
-	})
+	handler, _, err := getFileHandler(filepath.Join(constants.TemporaryDirMarker, "sub", "file.log"))
 	require.NoError(t, err)
 	assert.FileExists(t, logFile)
 
@@ -49,7 +47,7 @@ func TestFileHandlerWithTemporaryDirMarker(t *testing.T) {
 
 func TestFileHandler(t *testing.T) {
 	logFile := filepath.Join(t.TempDir(), "file.log")
-	handler, writer, err := getFileHandler(commandLineFlags{log: logFile})
+	handler, writer, err := getFileHandler(logFile)
 	require.NoError(t, err)
 	defer handler.Close()
 
@@ -97,3 +95,22 @@ func TestFileHandler(t *testing.T) {
 		}
 	}
 }
+
+// FIXME: writing into a closed handler shouldn't panic
+//
+// func TestCloseFileHandler(t *testing.T) {
+// 	logFile := filepath.Join(t.TempDir(), "file.log")
+// 	handler, writer, err := getFileHandler(logFile)
+// 	require.NoError(t, err)
+// 	assert.NotNil(t, handler)
+// 	assert.NotNil(t, writer)
+// 	defer handler.Close()
+
+// 	log := func(line string) {
+// 		assert.NoError(t, handler.LogEntry(clog.LogEntry{Level: clog.LevelInfo, Format: line}))
+// 	}
+
+// 	log("log-line-1")
+// 	handler.Close()
+// 	log("log-line-2")
+// }

--- a/main.go
+++ b/main.go
@@ -146,10 +146,9 @@ func main() {
 				},
 			}
 			// try to load the config and setup logging for own command
-			configuration, global, err := loadConfig(flags, true)
+			cfg, global, err := loadConfig(flags, true)
 			if err == nil {
-				ctx.config = configuration
-				ctx.global = global
+				ctx = ctx.WithConfig(cfg, global)
 			}
 			closeLogger := setupLogging(ctx)
 			defer closeLogger()
@@ -167,7 +166,7 @@ func main() {
 		}
 	}
 
-	// Load the mandatory configuration and setup logging (before returning on error)
+	// Load the now mandatory configuration and setup logging (before returning an error)
 	ctx, err := loadContext(flags, false)
 	closeLogger := setupLogging(ctx)
 	defer closeLogger()

--- a/main.go
+++ b/main.go
@@ -54,7 +54,13 @@ func main() {
 	_, flags, flagErr := loadFlags(args)
 	if flagErr != nil && flagErr != pflag.ErrHelp {
 		fmt.Println(flagErr)
-		_ = displayHelpCommand(os.Stdout, commandRequest{ownCommands: ownCommands, flags: flags, args: args})
+		_ = displayHelpCommand(os.Stdout, commandContext{
+			ownCommands: ownCommands,
+			context: &Context{
+				flags:     flags,
+				arguments: args,
+			},
+		})
 		exitCode = 2
 		return
 	}
@@ -77,7 +83,13 @@ func main() {
 
 	// help
 	if flags.help || errors.Is(flagErr, pflag.ErrHelp) {
-		_ = displayHelpCommand(os.Stdout, commandRequest{ownCommands: ownCommands, flags: flags, args: args})
+		_ = displayHelpCommand(os.Stdout, commandContext{
+			ownCommands: ownCommands,
+			context: &Context{
+				flags:     flags,
+				arguments: args,
+			},
+		})
 		return
 	}
 
@@ -94,11 +106,13 @@ func main() {
 			// also redirect the terminal through the client
 			term.SetAllOutput(term.NewRemoteTerm(client))
 		} else {
-			if flags.log == "" && global != nil {
-				flags.log = global.Log
+			// command line flag supersedes global configuration
+			logTarget := flags.log
+			if logTarget == "" && global != nil {
+				logTarget = global.Log
 			}
-			if flags.log != "" && flags.log != "-" {
-				if closer, err := setupTargetLogger(flags); err == nil {
+			if logTarget != "" && logTarget != "-" {
+				if closer, err := setupTargetLogger(flags, logTarget); err == nil {
 					logCloser = func() { _ = closer.Close() }
 				} else {
 					// fallback to a console logger
@@ -118,16 +132,29 @@ func main() {
 
 	banner()
 
-	// resticprofile own commands (configuration file may NOT be loaded)
+	// resticprofile own commands (configuration file may not be loaded)
 	if len(flags.resticArgs) > 0 {
 		if ownCommands.Exists(flags.resticArgs[0], false) {
+			ctx := &Context{
+				flags:         flags,
+				resticCommand: flags.resticArgs[0],
+				arguments:     flags.resticArgs[1:],
+			}
 			// try to load the config and setup logging for own command
-			configuration, global, _ := loadConfig(flags, true)
+			configuration, global, err := loadConfig(flags, true)
+			if err == nil {
+				ctx.config = configuration
+				ctx.global = global
+			}
 			defer setupLogging(global)()
-			err = ownCommands.Run(configuration, flags.resticArgs[0], flags, flags.resticArgs[1:])
+			err = ownCommands.Run(ctx)
 			if err != nil {
 				clog.Error(err)
 				exitCode = 1
+				var ownCommandError *ownCommandError
+				if errors.As(err, &ownCommandError) {
+					exitCode = ownCommandError.ExitCode()
+				}
 				return
 			}
 			return
@@ -144,24 +171,9 @@ func main() {
 	}
 
 	// check if we're running on battery
-	if flags.ignoreOnBattery > 0 && flags.ignoreOnBattery <= constants.BatteryFull {
-		battery, charge, err := IsRunningOnBattery()
-		if err != nil {
-			clog.Errorf("cannot check if the computer is running on battery: %s", err)
-		}
-		if battery {
-			if flags.ignoreOnBattery == constants.BatteryFull {
-				clog.Warning("running on battery, leaving now")
-				exitCode = 3
-				return
-			}
-			if charge < flags.ignoreOnBattery {
-				clog.Warningf("running on battery (%d%%), leaving now", charge)
-				exitCode = 3
-				return
-			}
-			clog.Infof("running on battery with enough charge (%d%%)", charge)
-		}
+	if shouldStopOnBattery(flags.ignoreOnBattery) {
+		exitCode = 3
+		return
 	}
 
 	// prevent computer from sleeping
@@ -208,9 +220,9 @@ func main() {
 		}
 	}
 
-	resticBinary, err := filesearch.FindResticBinary(global.ResticBinary)
+	resticBinary, err := detectResticBinary(global)
 	if err != nil {
-		clog.Error("cannot find restic: ", err)
+		clog.Error(err)
 		clog.Warning("you can specify the path of the restic binary in the global section of the configuration file (restic-binary)")
 		exitCode = 1
 		return
@@ -226,68 +238,49 @@ func main() {
 
 	// resticprofile own commands (with configuration file)
 	if ownCommands.Exists(resticCommand, true) {
-		err = ownCommands.Run(c, resticCommand, flags, resticArguments)
+		ctx := &Context{
+			flags:         flags,
+			global:        global,
+			config:        c,
+			resticBinary:  resticBinary,
+			resticCommand: resticCommand,
+			arguments:     resticArguments,
+		}
+		err = ownCommands.Run(ctx)
 		if err != nil {
 			clog.Error(err)
 			exitCode = 1
+			var ownCommandError *ownCommandError
+			if errors.As(err, &ownCommandError) {
+				exitCode = ownCommandError.ExitCode()
+			}
 			return
 		}
 		return
 	}
 
-	// detect restic version
-	if len(global.ResticVersion) == 0 {
-		if global.ResticVersion, err = restic.GetVersion(resticBinary); err != nil {
-			clog.Warningf("assuming restic is at latest known version ; %s", err.Error())
-			global.ResticVersion = restic.AnyVersion
-		}
+	// it wasn't an internal command so we run a profile
+	ctx := &Context{
+		flags:         flags,
+		global:        global,
+		config:        c,
+		resticBinary:  resticBinary,
+		resticCommand: resticCommand,
+		arguments:     resticArguments,
+		profileName:   flags.name,
+		group:         "",
+		scheduleName:  "",
+		profile:       nil,
+		schedule:      nil,
+		sigChan:       nil,
 	}
-	clog.Debugf("restic %s", global.ResticVersion)
-
-	if c.HasProfile(flags.name) {
-		// if running as a systemd timer
-		notifyStart()
-		defer notifyStop()
-
-		// Single profile run
-		err = runProfile(c, global, flags, flags.name, resticBinary, resticArguments, resticCommand, "")
-		if err != nil {
-			clog.Error(err)
-			exitCode = 1
-			return
+	err = startProfileOrGroup(ctx)
+	if err != nil {
+		clog.Error(err)
+		if errors.Is(err, ErrProfileNotFound) {
+			displayProfiles(os.Stdout, c, flags)
+			displayGroups(os.Stdout, c, flags)
 		}
-
-	} else if c.HasProfileGroup(flags.name) {
-		// Group run
-		group, err := c.GetProfileGroup(flags.name)
-		if err != nil {
-			clog.Errorf("cannot load group '%s': %v", flags.name, err)
-		}
-		if group != nil && len(group.Profiles) > 0 {
-			// if running as a systemd timer
-			notifyStart()
-			defer notifyStop()
-
-			for i, profileName := range group.Profiles {
-				clog.Debugf("[%d/%d] starting profile '%s' from group '%s'", i+1, len(group.Profiles), profileName, flags.name)
-				err = runProfile(c, global, flags, profileName, resticBinary, resticArguments, resticCommand, flags.name)
-				if err != nil {
-					clog.Error(err)
-					if global.GroupContinueOnError && bools.IsTrueOrUndefined(group.ContinueOnError) ||
-						bools.IsTrue(group.ContinueOnError) {
-						// keep going to the next profile
-						continue
-					}
-					exitCode = 1
-					return
-				}
-			}
-		}
-
-	} else {
-		clog.Errorf("profile or group not found '%s'", flags.name)
-		displayProfiles(os.Stdout, c, flags)
-		displayGroups(os.Stdout, c, flags)
 		exitCode = 1
 		return
 	}
@@ -335,6 +328,95 @@ func setPriority(nice int, class string) error {
 		if err != nil {
 			return err
 		}
+	}
+	return nil
+}
+
+func shouldStopOnBattery(batteryLimit int) bool {
+	if batteryLimit > 0 && batteryLimit <= constants.BatteryFull {
+		battery, charge, err := IsRunningOnBattery()
+		if err != nil {
+			clog.Errorf("cannot check if the computer is running on battery: %s", err)
+		}
+		if battery {
+			if batteryLimit == constants.BatteryFull {
+				clog.Warning("running on battery, leaving now")
+				return true
+			}
+			if charge < batteryLimit {
+				clog.Warningf("running on battery (%d%%), leaving now", charge)
+				return true
+			}
+			clog.Infof("running on battery with enough charge (%d%%)", charge)
+		}
+	}
+	return false
+}
+
+func detectResticBinary(global *config.Global) (string, error) {
+	resticBinary, err := filesearch.FindResticBinary(global.ResticBinary)
+	if err != nil {
+		return "", fmt.Errorf("cannot find restic: %w", err)
+	}
+	// detect restic version
+	if len(global.ResticVersion) == 0 {
+		if global.ResticVersion, err = restic.GetVersion(resticBinary); err != nil {
+			clog.Warningf("assuming restic is at latest known version ; %s", err.Error())
+			global.ResticVersion = restic.AnyVersion
+		}
+	}
+	if len(global.ResticVersion) > 0 {
+		clog.Debugf("using restic %s", global.ResticVersion)
+	}
+	return resticBinary, nil
+}
+
+func startProfileOrGroup(ctx *Context) error {
+	if ctx.config.HasProfile(ctx.profileName) {
+		// if running as a systemd timer
+		notifyStart()
+		defer notifyStop()
+
+		// Single profile run
+		err := runProfile(ctx)
+		if err != nil {
+			return err
+		}
+
+	} else if ctx.config.HasProfileGroup(ctx.profileName) {
+		// Group run
+		group, err := ctx.config.GetProfileGroup(ctx.profileName)
+		if err != nil {
+			clog.Errorf("cannot load group '%s': %v", ctx.profileName, err)
+		}
+		if group != nil && len(group.Profiles) > 0 {
+			// if running as a systemd timer
+			notifyStart()
+			defer notifyStop()
+
+			groupName := ctx.profileName
+
+			for i, profileName := range group.Profiles {
+				clog.Debugf("[%d/%d] starting profile '%s' from group '%s'", i+1, len(group.Profiles), profileName, groupName)
+				singleProfileCtx := ctx.NewProfileContext()
+				singleProfileCtx.profileName = profileName
+				singleProfileCtx.group = groupName
+				err = runProfile(ctx)
+				if err != nil {
+					if ctx.global.GroupContinueOnError && bools.IsTrueOrUndefined(group.ContinueOnError) ||
+						bools.IsTrue(group.ContinueOnError) {
+						// keep going to the next profile
+						clog.Error(err)
+						continue
+					}
+					// fail otherwise
+					return err
+				}
+			}
+		}
+
+	} else {
+		return fmt.Errorf("%w: %q", ErrProfileNotFound, ctx.profileName)
 	}
 	return nil
 }
@@ -387,35 +469,27 @@ func openProfile(c *config.Config, profileName string) (profile *config.Profile,
 	return
 }
 
-func runProfile(
-	c *config.Config,
-	global *config.Global,
-	flags commandLineFlags,
-	profileName string,
-	resticBinary string,
-	resticArguments []string,
-	resticCommand string,
-	group string,
-) error {
-	profile, cleanup, err := openProfile(c, profileName)
+func runProfile(ctx *Context) error {
+	profile, cleanup, err := openProfile(ctx.config, ctx.profileName)
 	defer cleanup()
 	if err != nil {
 		return err
 	}
+	ctx.profile = profile
 
 	displayProfileDeprecationNotices(profile)
-	c.DisplayConfigurationIssues()
+	ctx.config.DisplayConfigurationIssues()
 
 	// Send the quiet/verbose down to restic as well (override profile configuration)
-	if flags.quiet {
+	if ctx.flags.quiet {
 		profile.Quiet = true
 		profile.Verbose = constants.VerbosityNone
 	}
-	if flags.verbose {
+	if ctx.flags.verbose {
 		profile.Verbose = constants.VerbosityLevel1
 		profile.Quiet = false
 	}
-	if flags.veryVerbose {
+	if ctx.flags.veryVerbose {
 		profile.Verbose = constants.VerbosityLevel3
 		profile.Quiet = false
 	}
@@ -423,18 +497,18 @@ func runProfile(
 	// change log filter according to profile settings
 	if profile.Quiet {
 		changeLevelFilter(clog.LevelWarning)
-	} else if profile.Verbose > constants.VerbosityNone && !flags.veryVerbose {
+	} else if profile.Verbose > constants.VerbosityNone && !ctx.flags.veryVerbose {
 		changeLevelFilter(clog.LevelDebug)
 	}
 
 	// use the broken arguments escaping (before v0.15.0)
-	if global.LegacyArguments {
+	if ctx.global.LegacyArguments {
 		profile.SetLegacyArg(true)
 	}
 
 	// tell the profile what version of restic is in use
-	if e := profile.SetResticVersion(global.ResticVersion); e != nil {
-		clog.Warningf("restic version %q is no valid semver: %s", global.ResticVersion, e.Error())
+	if e := profile.SetResticVersion(ctx.global.ResticVersion); e != nil {
+		clog.Warningf("restic version %q is no valid semver: %s", ctx.global.ResticVersion, e.Error())
 	}
 
 	// Specific case for the "host" flag where an empty value should be replaced by the hostname
@@ -451,20 +525,13 @@ func runProfile(
 	// remove signal catch before leaving
 	defer signal.Stop(sigChan)
 
-	wrapper := newResticWrapper(
-		global,
-		resticBinary,
-		flags.dryRun,
-		profile,
-		resticCommand,
-		resticArguments,
-		sigChan,
-	)
+	ctx.sigChan = sigChan
+	wrapper := newResticWrapper(ctx)
 
-	if flags.noLock {
+	if ctx.flags.noLock {
 		wrapper.ignoreLock()
-	} else if flags.lockWait > 0 {
-		wrapper.maxWaitOnLock(flags.lockWait)
+	} else if ctx.flags.lockWait > 0 {
+		wrapper.maxWaitOnLock(ctx.flags.lockWait)
 	}
 
 	// add progress receivers if necessary
@@ -472,7 +539,7 @@ func runProfile(
 		wrapper.addProgress(status.NewProgress(profile, status.NewStatus(profile.StatusFile)))
 	}
 	if profile.PrometheusPush != "" || profile.PrometheusSaveToFile != "" {
-		wrapper.addProgress(prom.NewProgress(profile, prom.NewMetrics(group, version, profile.PrometheusLabels)))
+		wrapper.addProgress(prom.NewProgress(profile, prom.NewMetrics(ctx.group, version, profile.PrometheusLabels)))
 	}
 
 	err = wrapper.runProfile()
@@ -488,12 +555,13 @@ func randomBool() bool {
 }
 
 func free() uint64 {
+	const oneMB = 1048576
 	mem, err := memory.Get()
 	if err != nil {
 		clog.Info("OS memory information not available")
 		return 0
 	}
-	avail := (mem.Total - mem.Used) / 1048576
+	avail := (mem.Total - mem.Used) / oneMB
 	clog.Debugf("memory available: %vMB", avail)
 	return avail
 }

--- a/own_command_error.go
+++ b/own_command_error.go
@@ -1,0 +1,28 @@
+package main
+
+// ownCommandError is an error that can be returned by an own command.
+// It contains an exit code that should be used to exit the program.
+// There's no need to return this error if the exit code is 1.
+type ownCommandError struct {
+	err      error
+	exitCode int
+}
+
+func (e *ownCommandError) Error() string {
+	return e.err.Error()
+}
+
+func (e *ownCommandError) Unwrap() error {
+	return e.err
+}
+
+func (e *ownCommandError) ExitCode() int {
+	return e.exitCode
+}
+
+func newOwnCommandError(err error, exitCode int) *ownCommandError {
+	return &ownCommandError{
+		err:      err,
+		exitCode: exitCode,
+	}
+}

--- a/own_command_error_test.go
+++ b/own_command_error_test.go
@@ -1,0 +1,20 @@
+package main
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestOwnCommandError(t *testing.T) {
+	var wrap error = errors.New("wrap")
+	var err error = newOwnCommandError(wrap, 10)
+
+	assert.Equal(t, "wrap", err.Error())
+	assert.ErrorIs(t, err, wrap)
+
+	var unwrap *ownCommandError
+	assert.True(t, errors.As(err, &unwrap))
+	assert.Equal(t, 10, unwrap.ExitCode())
+}

--- a/own_commands.go
+++ b/own_commands.go
@@ -9,20 +9,21 @@ import (
 
 // commandContext is the context for running a command.
 type commandContext struct {
+	Context
 	ownCommands *OwnCommands
-	context     *Context
 }
 
 type ownCommand struct {
 	name              string
 	description       string
 	longDescription   string
-	action            func(io.Writer, commandContext) error
-	needConfiguration bool              // true if the action needs a configuration file loaded
-	hide              bool              // don't display the command in help and completion
-	hideInCompletion  bool              // don't display the command in completion
-	noProfile         bool              // true if the command doesn't need a profile name
-	flags             map[string]string // own command flags should be simple enough to be handled manually for now
+	pre               func(*Context) error                  // pre-command action (for checking the context)
+	action            func(io.Writer, commandContext) error // run command action
+	needConfiguration bool                                  // true if the action needs a configuration file loaded
+	hide              bool                                  // don't display the command in help and completion
+	hideInCompletion  bool                                  // don't display the command in completion
+	noProfile         bool                                  // true if the command doesn't need a profile name
+	flags             map[string]string                     // own command flags should be simple enough to be handled manually for now
 }
 
 // OwnCommands is a list of resticprofile commands
@@ -56,14 +57,33 @@ func (o *OwnCommands) All() []ownCommand {
 }
 
 func (o *OwnCommands) Run(ctx *Context) error {
-	commandName := strings.ToLower(ctx.resticCommand)
-	for _, command := range o.commands {
-		if command.name == commandName {
-			return command.action(os.Stdout, commandContext{
-				ownCommands: o,
-				context:     ctx,
-			})
+	command := o.find(ctx.request.command)
+	if command == nil {
+		return fmt.Errorf("command not found: %v", ctx.request.command)
+	}
+	return command.action(os.Stdout, commandContext{
+		ownCommands: o,
+		Context:     *ctx,
+	})
+}
+
+func (o *OwnCommands) Pre(ctx *Context) error {
+	command := o.find(ctx.request.command)
+	if command == nil {
+		return fmt.Errorf("command not found: %v", ctx.request.command)
+	}
+	if command.pre == nil {
+		return nil
+	}
+	return command.pre(ctx)
+}
+
+func (o *OwnCommands) find(commandName string) *ownCommand {
+	commandName = strings.ToLower(commandName)
+	for _, commandDef := range o.commands {
+		if commandDef.name == commandName {
+			return &commandDef
 		}
 	}
-	return fmt.Errorf("command not found: %v", commandName)
+	return nil
 }

--- a/own_commands_test.go
+++ b/own_commands_test.go
@@ -1,0 +1,99 @@
+package main
+
+import (
+	"errors"
+	"io"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func fakeCommands() *OwnCommands {
+	ownCommands := NewOwnCommands()
+	ownCommands.Register([]ownCommand{
+		{
+			name:              "first",
+			description:       "first first",
+			pre:               pre,
+			action:            firstCommand,
+			needConfiguration: false,
+		},
+		{
+			name:              "second",
+			description:       "second second",
+			action:            secondCommand,
+			needConfiguration: true,
+			flags: map[string]string{
+				"-f, --first":   "first flag",
+				"-s, --seccond": "second flag",
+			},
+		},
+		{
+			name:              "third",
+			description:       "third third",
+			action:            thirdCommand,
+			needConfiguration: false,
+			hide:              true,
+		},
+	})
+	return ownCommands
+}
+
+func firstCommand(_ io.Writer, _ commandContext) error {
+	return errors.New("first")
+}
+
+func secondCommand(_ io.Writer, _ commandContext) error {
+	return errors.New("second")
+}
+
+func thirdCommand(_ io.Writer, _ commandContext) error {
+	return errors.New("third")
+}
+
+func pre(_ *Context) error {
+	return errors.New("pre")
+}
+
+func TestDisplayOwnCommands(t *testing.T) {
+	buffer := &strings.Builder{}
+	displayOwnCommands(buffer, commandContext{ownCommands: fakeCommands()})
+	assert.Equal(t, "  first   first first\n  second  second second\n", buffer.String())
+}
+
+func TestDisplayOwnCommand(t *testing.T) {
+	buffer := &strings.Builder{}
+	displayOwnCommandHelp(buffer, "second", commandContext{ownCommands: fakeCommands()})
+	assert.Equal(t, `Purpose: second second
+
+Usage:
+  resticprofile [resticprofile flags] [profile name.]second [command specific flags]
+
+Flags:
+  -f, --first    first flag
+  -s, --seccond  second flag
+
+`, buffer.String())
+}
+
+func TestIsOwnCommand(t *testing.T) {
+	assert.True(t, fakeCommands().Exists("first", false))
+	assert.True(t, fakeCommands().Exists("second", true))
+	assert.True(t, fakeCommands().Exists("third", false))
+	assert.False(t, fakeCommands().Exists("another one", true))
+}
+
+func TestRunOwnCommand(t *testing.T) {
+	assert.EqualError(t, fakeCommands().Run(&Context{request: Request{command: "first"}}), "first")
+	assert.EqualError(t, fakeCommands().Run(&Context{request: Request{command: "second"}}), "second")
+	assert.EqualError(t, fakeCommands().Run(&Context{request: Request{command: "third"}}), "third")
+	assert.EqualError(t, fakeCommands().Run(&Context{request: Request{command: "another one"}}), "command not found: another one")
+}
+
+func TestPreOwnCommand(t *testing.T) {
+	assert.EqualError(t, fakeCommands().Pre(&Context{request: Request{command: "first"}}), "pre")
+	assert.NoError(t, fakeCommands().Pre(&Context{request: Request{command: "second"}}))
+	assert.NoError(t, fakeCommands().Pre(&Context{request: Request{command: "third"}}))
+	assert.EqualError(t, fakeCommands().Pre(&Context{request: Request{command: "another one"}}), "command not found: another one")
+}

--- a/syslog.go
+++ b/syslog.go
@@ -48,7 +48,7 @@ func (l *Syslog) Close() error {
 
 var _ LogCloser = &Syslog{}
 
-func getSyslogHandler(flags commandLineFlags, scheme, hostPort string) (*Syslog, error) {
+func getSyslogHandler(scheme, hostPort string) (*Syslog, error) {
 	writer, err := syslog.Dial(scheme, hostPort, syslog.LOG_USER|syslog.LOG_NOTICE, constants.ApplicationName)
 	if err != nil {
 		return nil, fmt.Errorf("cannot open syslog logger: %w", err)

--- a/syslog_windows.go
+++ b/syslog_windows.go
@@ -6,6 +6,6 @@ import (
 	"errors"
 )
 
-func getSyslogHandler(flags commandLineFlags, scheme, hostPort string) (LogCloser, error) {
+func getSyslogHandler(scheme, hostPort string) (LogCloser, error) {
 	return nil, errors.New("syslog is not supported on Windows")
 }

--- a/update.go
+++ b/update.go
@@ -32,12 +32,12 @@ func init() {
 	config.ExcludeProfileSection(def.name)
 }
 
-func selfUpdate(_ io.Writer, request commandContext) error {
-	quiet := request.context.flags.quiet
-	if !quiet && len(request.context.arguments) > 0 && (request.context.arguments[0] == "-q" || request.context.arguments[0] == "--quiet") {
+func selfUpdate(_ io.Writer, ctx commandContext) error {
+	quiet := ctx.flags.quiet
+	if !quiet && len(ctx.request.arguments) > 0 && (ctx.request.arguments[0] == "-q" || ctx.request.arguments[0] == "--quiet") {
 		quiet = true
 	}
-	err := confirmAndSelfUpdate(quiet, request.context.flags.verbose, version, true)
+	err := confirmAndSelfUpdate(quiet, ctx.flags.verbose, version, true)
 	if err != nil {
 		return err
 	}

--- a/update.go
+++ b/update.go
@@ -32,12 +32,12 @@ func init() {
 	config.ExcludeProfileSection(def.name)
 }
 
-func selfUpdate(_ io.Writer, request commandRequest) error {
-	quiet := request.flags.quiet
-	if !quiet && len(request.args) > 0 && (request.args[0] == "-q" || request.args[0] == "--quiet") {
+func selfUpdate(_ io.Writer, request commandContext) error {
+	quiet := request.context.flags.quiet
+	if !quiet && len(request.context.arguments) > 0 && (request.context.arguments[0] == "-q" || request.context.arguments[0] == "--quiet") {
 		quiet = true
 	}
-	err := confirmAndSelfUpdate(quiet, request.flags.verbose, version, true)
+	err := confirmAndSelfUpdate(quiet, request.context.flags.verbose, version, true)
 	if err != nil {
 		return err
 	}

--- a/wrapper.go
+++ b/wrapper.go
@@ -52,7 +52,7 @@ func newResticWrapper(ctx *Context) *resticWrapper {
 		ctx.global = config.NewGlobal()
 	}
 
-	resticDryRun := slices.ContainsFunc(ctx.arguments, collect.In("--dry-run", "-n"))
+	resticDryRun := slices.ContainsFunc(ctx.request.arguments, collect.In("--dry-run", "-n"))
 
 	return &resticWrapper{
 		ctx:      ctx,
@@ -61,8 +61,8 @@ func newResticWrapper(ctx *Context) *resticWrapper {
 		lockWait: nil,
 		profile:  ctx.profile,
 		global:   ctx.global,
-		command:  ctx.resticCommand,
-		moreArgs: ctx.arguments,
+		command:  ctx.command,
+		moreArgs: ctx.request.arguments,
 		sigChan:  ctx.sigChan,
 		stdin:    os.Stdin,
 		progress: make([]monitor.Receiver, 0),
@@ -330,7 +330,7 @@ func (r *resticWrapper) getShell() (shell []string) {
 func (r *resticWrapper) getCommandArgumentsFilter(command string) argumentsFilter {
 	binaryIsRestic := strings.EqualFold(
 		"restic",
-		strings.TrimSuffix(filepath.Base(r.ctx.resticBinary), filepath.Ext(r.ctx.resticBinary)),
+		strings.TrimSuffix(filepath.Base(r.ctx.binary), filepath.Ext(r.ctx.binary)),
 	)
 	if binaryIsRestic && (r.global == nil || r.global.FilterResticFlags) {
 		if validArgs := r.validResticArgumentsList(command); len(validArgs) > 0 {
@@ -396,8 +396,8 @@ func (r *resticWrapper) prepareCommand(command string, args *shell.Args, allowEx
 	env := append(os.Environ(), r.getEnvironment()...)
 	env = append(env, r.getProfileEnvironment()...)
 
-	clog.Debugf("starting command: %s %s", r.ctx.resticBinary, strings.Join(publicArguments, " "))
-	rCommand := newShellCommand(r.ctx.resticBinary, arguments, env, r.getShell(), r.dryRun, r.sigChan, r.setPID)
+	clog.Debugf("starting command: %s %s", r.ctx.binary, strings.Join(publicArguments, " "))
+	rCommand := newShellCommand(r.ctx.binary, arguments, env, r.getShell(), r.dryRun, r.sigChan, r.setPID)
 	rCommand.publicArgs = publicArguments
 	// stdout are stderr are coming from the default terminal (in case they're redirected)
 	rCommand.stdout = term.GetOutput()

--- a/wrapper.go
+++ b/wrapper.go
@@ -27,19 +27,19 @@ import (
 )
 
 type resticWrapper struct {
-	resticBinary string
-	dryRun       bool
-	noLock       bool
-	lockWait     *time.Duration
-	profile      *config.Profile
-	global       *config.Global
-	command      string
-	moreArgs     []string
-	sigChan      chan os.Signal
-	setPID       func(pid int)
-	stdin        io.ReadCloser
-	progress     []monitor.Receiver
-	sender       *hook.Sender
+	ctx      *Context
+	dryRun   bool // resticprofile dry-run (not restic dry-run via flags added on the command line)
+	noLock   bool
+	lockWait *time.Duration
+	profile  *config.Profile
+	global   *config.Global
+	command  string
+	moreArgs []string
+	sigChan  chan os.Signal
+	setPID   func(pid int)
+	stdin    io.ReadCloser
+	progress []monitor.Receiver
+	sender   *hook.Sender
 
 	// States
 	startTime     time.Time
@@ -47,34 +47,31 @@ type resticWrapper struct {
 	doneTryUnlock bool
 }
 
-func newResticWrapper(
-	global *config.Global,
-	resticBinary string,
-	dryRun bool,
-	profile *config.Profile,
-	command string,
-	moreArgs []string,
-	c chan os.Signal,
-) *resticWrapper {
-	if global == nil {
-		global = config.NewGlobal()
+func newResticWrapper(ctx *Context) *resticWrapper {
+	if ctx.global == nil {
+		ctx.global = config.NewGlobal()
 	}
 
-	senderDryRun := dryRun || slices.ContainsFunc(moreArgs, collect.In("--dry-run", "-n"))
+	resticDryRun := slices.ContainsFunc(ctx.arguments, collect.In("--dry-run", "-n"))
 
 	return &resticWrapper{
-		resticBinary:  resticBinary,
-		dryRun:        dryRun,
-		noLock:        false,
-		lockWait:      nil,
-		profile:       profile,
-		global:        global,
-		command:       command,
-		moreArgs:      moreArgs,
-		sigChan:       c,
-		stdin:         os.Stdin,
-		progress:      make([]monitor.Receiver, 0),
-		sender:        hook.NewSender(global.CACertificates, "resticprofile/"+version, global.SenderTimeout, senderDryRun),
+		ctx:      ctx,
+		dryRun:   ctx.flags.dryRun,
+		noLock:   false,
+		lockWait: nil,
+		profile:  ctx.profile,
+		global:   ctx.global,
+		command:  ctx.resticCommand,
+		moreArgs: ctx.arguments,
+		sigChan:  ctx.sigChan,
+		stdin:    os.Stdin,
+		progress: make([]monitor.Receiver, 0),
+		sender: hook.NewSender(
+			ctx.global.CACertificates,
+			"resticprofile/"+version,
+			ctx.global.SenderTimeout,
+			ctx.flags.dryRun || resticDryRun,
+		),
 		startTime:     time.Unix(0, 0),
 		executionTime: 0,
 		doneTryUnlock: false,
@@ -333,7 +330,7 @@ func (r *resticWrapper) getShell() (shell []string) {
 func (r *resticWrapper) getCommandArgumentsFilter(command string) argumentsFilter {
 	binaryIsRestic := strings.EqualFold(
 		"restic",
-		strings.TrimSuffix(filepath.Base(r.resticBinary), filepath.Ext(r.resticBinary)),
+		strings.TrimSuffix(filepath.Base(r.ctx.resticBinary), filepath.Ext(r.ctx.resticBinary)),
 	)
 	if binaryIsRestic && (r.global == nil || r.global.FilterResticFlags) {
 		if validArgs := r.validResticArgumentsList(command); len(validArgs) > 0 {
@@ -399,8 +396,8 @@ func (r *resticWrapper) prepareCommand(command string, args *shell.Args, allowEx
 	env := append(os.Environ(), r.getEnvironment()...)
 	env = append(env, r.getProfileEnvironment()...)
 
-	clog.Debugf("starting command: %s %s", r.resticBinary, strings.Join(publicArguments, " "))
-	rCommand := newShellCommand(r.resticBinary, arguments, env, r.getShell(), r.dryRun, r.sigChan, r.setPID)
+	clog.Debugf("starting command: %s %s", r.ctx.resticBinary, strings.Join(publicArguments, " "))
+	rCommand := newShellCommand(r.ctx.resticBinary, arguments, env, r.getShell(), r.dryRun, r.sigChan, r.setPID)
 	rCommand.publicArgs = publicArguments
 	// stdout are stderr are coming from the default terminal (in case they're redirected)
 	rCommand.stdout = term.GetOutput()

--- a/wrapper_test.go
+++ b/wrapper_test.go
@@ -190,10 +190,10 @@ func TestFilteredArgumentsRegression(t *testing.T) {
 			profile, err := cfg.GetProfile("default")
 			require.NoError(t, err)
 			wrapper := newResticWrapper(&Context{
-				flags:         commandLineFlags{dryRun: true},
-				resticBinary:  "restic",
-				profile:       profile,
-				resticCommand: "test",
+				flags:   commandLineFlags{dryRun: true},
+				binary:  "restic",
+				profile: profile,
+				command: "test",
 			})
 
 			for command, commandline := range test.expected {
@@ -209,9 +209,9 @@ func TestFilteredArgumentsRegression(t *testing.T) {
 func TestGetEmptyEnvironment(t *testing.T) {
 	profile := config.NewProfile(nil, "name")
 	ctx := &Context{
-		resticBinary:  "restic",
-		profile:       profile,
-		resticCommand: "test",
+		binary:  "restic",
+		profile: profile,
+		command: "test",
 	}
 	wrapper := newResticWrapper(ctx)
 	env := wrapper.getEnvironment()
@@ -225,9 +225,9 @@ func TestGetSingleEnvironment(t *testing.T) {
 	}
 	profile.ResolveConfiguration()
 	ctx := &Context{
-		resticBinary:  "restic",
-		profile:       profile,
-		resticCommand: "test",
+		binary:  "restic",
+		profile: profile,
+		command: "test",
 	}
 	wrapper := newResticWrapper(ctx)
 	env := wrapper.getEnvironment()
@@ -242,9 +242,9 @@ func TestGetMultipleEnvironment(t *testing.T) {
 	}
 	profile.ResolveConfiguration()
 	ctx := &Context{
-		resticBinary:  "restic",
-		profile:       profile,
-		resticCommand: "test",
+		binary:  "restic",
+		profile: profile,
+		command: "test",
 	}
 	wrapper := newResticWrapper(ctx)
 	env := wrapper.getEnvironment()
@@ -257,9 +257,9 @@ func TestPreProfileScriptFail(t *testing.T) {
 	profile := config.NewProfile(nil, "name")
 	profile.RunBefore = []string{"exit 1"} // this should both work on unix shell and windows batch
 	ctx := &Context{
-		resticBinary:  "echo",
-		profile:       profile,
-		resticCommand: "test",
+		binary:  "echo",
+		profile: profile,
+		command: "test",
 	}
 	wrapper := newResticWrapper(ctx)
 	err := wrapper.runProfile()
@@ -270,9 +270,9 @@ func TestPostProfileScriptFail(t *testing.T) {
 	profile := config.NewProfile(nil, "name")
 	profile.RunAfter = []string{"exit 1"} // this should both work on unix shell and windows batch
 	ctx := &Context{
-		resticBinary:  "echo",
-		profile:       profile,
-		resticCommand: "test",
+		binary:  "echo",
+		profile: profile,
+		command: "test",
 	}
 	wrapper := newResticWrapper(ctx)
 	err := wrapper.runProfile()
@@ -282,9 +282,9 @@ func TestPostProfileScriptFail(t *testing.T) {
 func TestRunEchoProfile(t *testing.T) {
 	profile := config.NewProfile(nil, "name")
 	ctx := &Context{
-		resticBinary:  "echo",
-		profile:       profile,
-		resticCommand: "test",
+		binary:  "echo",
+		profile: profile,
+		command: "test",
 	}
 	wrapper := newResticWrapper(ctx)
 	err := wrapper.runProfile()
@@ -297,9 +297,9 @@ func TestPostProfileAfterFail(t *testing.T) {
 	profile := config.NewProfile(nil, "name")
 	profile.RunAfter = []string{"echo failed > " + testFile}
 	ctx := &Context{
-		resticBinary:  "exit",
-		profile:       profile,
-		resticCommand: "1",
+		binary:  "exit",
+		profile: profile,
+		command: "1",
 	}
 	wrapper := newResticWrapper(ctx)
 	err := wrapper.runProfile()
@@ -314,9 +314,9 @@ func TestPostFailProfile(t *testing.T) {
 	profile := config.NewProfile(nil, "name")
 	profile.RunAfterFail = []string{"echo failed > " + testFile}
 	ctx := &Context{
-		resticBinary:  "exit",
-		profile:       profile,
-		resticCommand: "1",
+		binary:  "exit",
+		profile: profile,
+		command: "1",
 	}
 	wrapper := newResticWrapper(ctx)
 	err := wrapper.runProfile()
@@ -347,9 +347,9 @@ func TestFinallyProfile(t *testing.T) {
 	t.Run("backup-before-profile", func(t *testing.T) {
 		newProfile()
 		ctx := &Context{
-			resticBinary:  "echo",
-			profile:       profile,
-			resticCommand: "backup",
+			binary:  "echo",
+			profile: profile,
+			command: "backup",
 		}
 		wrapper := newResticWrapper(ctx)
 		err := wrapper.runProfile()
@@ -361,9 +361,9 @@ func TestFinallyProfile(t *testing.T) {
 		newProfile()
 		profile.RunFinally = nil
 		ctx := &Context{
-			resticBinary:  "echo",
-			profile:       profile,
-			resticCommand: "backup",
+			binary:  "echo",
+			profile: profile,
+			command: "backup",
 		}
 		wrapper := newResticWrapper(ctx)
 		err := wrapper.runProfile()
@@ -374,9 +374,9 @@ func TestFinallyProfile(t *testing.T) {
 	t.Run("on-error", func(t *testing.T) {
 		newProfile()
 		ctx := &Context{
-			resticBinary:  "exit",
-			profile:       profile,
-			resticCommand: "1",
+			binary:  "exit",
+			profile: profile,
+			command: "1",
 		}
 		wrapper := newResticWrapper(ctx)
 		err := wrapper.runProfile()
@@ -389,9 +389,9 @@ func Example_runProfile() {
 	term.SetOutput(os.Stdout)
 	profile := config.NewProfile(nil, "name")
 	ctx := &Context{
-		resticBinary:  "echo",
-		profile:       profile,
-		resticCommand: "test",
+		binary:  "echo",
+		profile: profile,
+		command: "test",
 	}
 	wrapper := newResticWrapper(ctx)
 	wrapper.runProfile()
@@ -403,9 +403,9 @@ func TestRunRedirectOutputOfEchoProfile(t *testing.T) {
 	term.SetOutput(buffer)
 	profile := config.NewProfile(nil, "name")
 	ctx := &Context{
-		resticBinary:  "echo",
-		profile:       profile,
-		resticCommand: "test",
+		binary:  "echo",
+		profile: profile,
+		command: "test",
 	}
 	wrapper := newResticWrapper(ctx)
 	err := wrapper.runProfile()
@@ -418,10 +418,10 @@ func TestDryRun(t *testing.T) {
 	term.SetOutput(buffer)
 	profile := config.NewProfile(nil, "name")
 	wrapper := newResticWrapper(&Context{
-		flags:         commandLineFlags{dryRun: true},
-		resticBinary:  "echo",
-		profile:       profile,
-		resticCommand: "test",
+		flags:   commandLineFlags{dryRun: true},
+		binary:  "echo",
+		profile: profile,
+		command: "test",
 	})
 	err := wrapper.runProfile()
 	assert.NoError(t, err)
@@ -435,9 +435,9 @@ func TestEnvProfileName(t *testing.T) {
 	profile.RunBefore = []string{"echo profile name = $PROFILE_NAME"}
 
 	ctx := &Context{
-		resticBinary:  "echo",
-		profile:       profile,
-		resticCommand: "test",
+		binary:  "echo",
+		profile: profile,
+		command: "test",
 	}
 	wrapper := newResticWrapper(ctx)
 	err := wrapper.runProfile()
@@ -452,9 +452,9 @@ func TestEnvProfileCommand(t *testing.T) {
 	profile.RunBefore = []string{"echo profile command = $PROFILE_COMMAND"}
 
 	ctx := &Context{
-		resticBinary:  "echo",
-		profile:       profile,
-		resticCommand: "test-command",
+		binary:  "echo",
+		profile: profile,
+		command: "test-command",
 	}
 	wrapper := newResticWrapper(ctx)
 	err := wrapper.runProfile()
@@ -469,9 +469,9 @@ func TestEnvError(t *testing.T) {
 	profile.RunAfterFail = []string{"echo error: $ERROR_MESSAGE"}
 
 	ctx := &Context{
-		resticBinary:  "exit",
-		profile:       profile,
-		resticCommand: "1",
+		binary:  "exit",
+		profile: profile,
+		command: "1",
 	}
 	wrapper := newResticWrapper(ctx)
 	err := wrapper.runProfile()
@@ -486,9 +486,9 @@ func TestEnvErrorCommandLine(t *testing.T) {
 	profile.RunAfterFail = []string{"echo cmd: $ERROR_COMMANDLINE"}
 
 	ctx := &Context{
-		resticBinary:  "exit",
-		profile:       profile,
-		resticCommand: "1",
+		binary:  "exit",
+		profile: profile,
+		command: "1",
 	}
 	wrapper := newResticWrapper(ctx)
 	err := wrapper.runProfile()
@@ -503,9 +503,9 @@ func TestEnvErrorExitCode(t *testing.T) {
 	profile.RunAfterFail = []string{"echo exit-code: $ERROR_EXIT_CODE"}
 
 	ctx := &Context{
-		resticBinary:  "exit",
-		profile:       profile,
-		resticCommand: "5",
+		binary:  "exit",
+		profile: profile,
+		command: "5",
 	}
 	wrapper := newResticWrapper(ctx)
 	err := wrapper.runProfile()
@@ -520,10 +520,10 @@ func TestEnvStderr(t *testing.T) {
 	profile.RunAfterFail = []string{"echo stderr: $ERROR_STDERR"}
 
 	ctx := &Context{
-		resticBinary:  mockBinary,
-		profile:       profile,
-		resticCommand: "command",
-		arguments:     []string{"--stderr", "error_message", "--exit", "1"},
+		binary:  mockBinary,
+		profile: profile,
+		command: "command",
+		request: Request{arguments: []string{"--stderr", "error_message", "--exit", "1"}},
 	}
 	wrapper := newResticWrapper(ctx)
 	err := wrapper.runProfile()
@@ -536,9 +536,9 @@ func TestRunProfileWithSetPIDCallback(t *testing.T) {
 	profile.Lock = filepath.Join(os.TempDir(), fmt.Sprintf("%s%d%d.tmp", "TestRunProfileWithSetPIDCallback", time.Now().UnixNano(), os.Getpid()))
 	t.Logf("lockfile = %s", profile.Lock)
 	ctx := &Context{
-		resticBinary:  "echo",
-		profile:       profile,
-		resticCommand: "test",
+		binary:  "echo",
+		profile: profile,
+		command: "test",
 	}
 	wrapper := newResticWrapper(ctx)
 	err := wrapper.runProfile()
@@ -548,9 +548,9 @@ func TestRunProfileWithSetPIDCallback(t *testing.T) {
 func TestInitializeNoError(t *testing.T) {
 	profile := config.NewProfile(nil, "name")
 	ctx := &Context{
-		resticBinary:  mockBinary,
-		profile:       profile,
-		resticCommand: "",
+		binary:  mockBinary,
+		profile: profile,
+		command: "",
 	}
 	wrapper := newResticWrapper(ctx)
 	err := wrapper.runInitialize()
@@ -560,10 +560,10 @@ func TestInitializeNoError(t *testing.T) {
 func TestInitializeWithError(t *testing.T) {
 	profile := config.NewProfile(nil, "name")
 	ctx := &Context{
-		resticBinary:  mockBinary,
-		profile:       profile,
-		resticCommand: "",
-		arguments:     []string{"--exit", "10"},
+		binary:  mockBinary,
+		profile: profile,
+		command: "",
+		request: Request{arguments: []string{"--exit", "10"}},
 	}
 	wrapper := newResticWrapper(ctx)
 	err := wrapper.runInitialize()
@@ -574,9 +574,9 @@ func TestInitializeCopyNoError(t *testing.T) {
 	profile := config.NewProfile(nil, "name")
 	profile.Copy = &config.CopySection{InitializeCopyChunkerParams: bools.False()}
 	ctx := &Context{
-		resticBinary:  mockBinary,
-		profile:       profile,
-		resticCommand: "",
+		binary:  mockBinary,
+		profile: profile,
+		command: "",
 	}
 	wrapper := newResticWrapper(ctx)
 	err := wrapper.runInitializeCopy()
@@ -587,10 +587,10 @@ func TestInitializeCopyWithError(t *testing.T) {
 	profile := config.NewProfile(nil, "name")
 	profile.Copy = &config.CopySection{InitializeCopyChunkerParams: bools.False()}
 	ctx := &Context{
-		resticBinary:  mockBinary,
-		profile:       profile,
-		resticCommand: "",
-		arguments:     []string{"--exit", "10"},
+		binary:  mockBinary,
+		profile: profile,
+		command: "",
+		request: Request{arguments: []string{"--exit", "10"}},
 	}
 	wrapper := newResticWrapper(ctx)
 	err := wrapper.runInitializeCopy()
@@ -600,9 +600,9 @@ func TestInitializeCopyWithError(t *testing.T) {
 func TestCheckNoError(t *testing.T) {
 	profile := config.NewProfile(nil, "name")
 	ctx := &Context{
-		resticBinary:  mockBinary,
-		profile:       profile,
-		resticCommand: "",
+		binary:  mockBinary,
+		profile: profile,
+		command: "",
 	}
 	wrapper := newResticWrapper(ctx)
 	err := wrapper.runCheck()
@@ -612,10 +612,10 @@ func TestCheckNoError(t *testing.T) {
 func TestCheckWithError(t *testing.T) {
 	profile := config.NewProfile(nil, "name")
 	ctx := &Context{
-		resticBinary:  mockBinary,
-		profile:       profile,
-		resticCommand: "",
-		arguments:     []string{"--exit", "10"},
+		binary:  mockBinary,
+		profile: profile,
+		command: "",
+		request: Request{arguments: []string{"--exit", "10"}},
 	}
 	wrapper := newResticWrapper(ctx)
 	err := wrapper.runCheck()
@@ -625,9 +625,9 @@ func TestCheckWithError(t *testing.T) {
 func TestRetentionNoError(t *testing.T) {
 	profile := config.NewProfile(nil, "name")
 	ctx := &Context{
-		resticBinary:  mockBinary,
-		profile:       profile,
-		resticCommand: "",
+		binary:  mockBinary,
+		profile: profile,
+		command: "",
 	}
 	wrapper := newResticWrapper(ctx)
 	err := wrapper.runRetention()
@@ -637,10 +637,10 @@ func TestRetentionNoError(t *testing.T) {
 func TestRetentionWithError(t *testing.T) {
 	profile := config.NewProfile(nil, "name")
 	ctx := &Context{
-		resticBinary:  mockBinary,
-		profile:       profile,
-		resticCommand: "",
-		arguments:     []string{"--exit", "10"},
+		binary:  mockBinary,
+		profile: profile,
+		command: "",
+		request: Request{arguments: []string{"--exit", "10"}},
 	}
 	wrapper := newResticWrapper(ctx)
 	err := wrapper.runRetention()
@@ -667,10 +667,10 @@ func TestBackupWithStreamSource(t *testing.T) {
 		profile.Backup = &config.BackupSection{}
 		signals := make(chan os.Signal, 1)
 		ctx := &Context{
-			resticBinary:  mockBinary,
-			profile:       profile,
-			resticCommand: "stdin-test",
-			sigChan:       signals,
+			binary:  mockBinary,
+			profile: profile,
+			command: "stdin-test",
+			sigChan: signals,
 		}
 		wrapper = newResticWrapper(ctx)
 		return
@@ -803,9 +803,9 @@ func TestBackupWithSuccess(t *testing.T) {
 	profile := config.NewProfile(nil, "name")
 	profile.Backup = &config.BackupSection{}
 	ctx := &Context{
-		resticBinary:  mockBinary,
-		profile:       profile,
-		resticCommand: "",
+		binary:  mockBinary,
+		profile: profile,
+		command: "",
 	}
 	wrapper := newResticWrapper(ctx)
 	err := wrapper.runCommand("backup")
@@ -816,10 +816,10 @@ func TestBackupWithError(t *testing.T) {
 	profile := config.NewProfile(nil, "name")
 	profile.Backup = &config.BackupSection{}
 	ctx := &Context{
-		resticBinary:  mockBinary,
-		profile:       profile,
-		resticCommand: "",
-		arguments:     []string{"--exit", "1"},
+		binary:  mockBinary,
+		profile: profile,
+		command: "",
+		request: Request{arguments: []string{"--exit", "1"}},
 	}
 	wrapper := newResticWrapper(ctx)
 	err := wrapper.runCommand("backup")
@@ -844,12 +844,12 @@ func TestBackupWithResticLockFailureRetried(t *testing.T) {
 	profile := config.NewProfile(nil, "name")
 	profile.Backup = &config.BackupSection{}
 	ctx := &Context{
-		global:        global,
-		resticBinary:  mockBinary,
-		profile:       profile,
-		resticCommand: "",
-		arguments:     []string{"--stderr", "@" + tempfile, "--exit", "1"},
-		sigChan:       sigChan,
+		global:  global,
+		binary:  mockBinary,
+		profile: profile,
+		command: "",
+		request: Request{arguments: []string{"--stderr", "@" + tempfile, "--exit", "1"}},
+		sigChan: sigChan,
 	}
 	wrapper := newResticWrapper(ctx)
 	wrapper.lockWait = &lockWait
@@ -878,12 +878,12 @@ func TestBackupWithResticLockFailureCancelled(t *testing.T) {
 	profile := config.NewProfile(nil, "name")
 	profile.Backup = &config.BackupSection{}
 	ctx := &Context{
-		global:        global,
-		resticBinary:  mockBinary,
-		profile:       profile,
-		resticCommand: "",
-		arguments:     []string{"--stderr", "@" + tempfile, "--exit", "1"},
-		sigChan:       sigChan,
+		global:  global,
+		binary:  mockBinary,
+		profile: profile,
+		command: "",
+		request: Request{arguments: []string{"--stderr", "@" + tempfile, "--exit", "1"}},
+		sigChan: sigChan,
 	}
 	wrapper := newResticWrapper(ctx)
 	wrapper.lockWait = &lockWait
@@ -901,10 +901,10 @@ func TestBackupWithResticLockFailureCancelled(t *testing.T) {
 func TestBackupWithNoConfiguration(t *testing.T) {
 	profile := config.NewProfile(nil, "name")
 	ctx := &Context{
-		resticBinary:  mockBinary,
-		profile:       profile,
-		resticCommand: "",
-		arguments:     []string{"--exit", "1"},
+		binary:  mockBinary,
+		profile: profile,
+		command: "",
+		request: Request{arguments: []string{"--exit", "1"}},
 	}
 	wrapper := newResticWrapper(ctx)
 	err := wrapper.runCommand("backup")
@@ -915,10 +915,10 @@ func TestBackupWithNoConfigurationButStatusFile(t *testing.T) {
 	profile := config.NewProfile(nil, "name")
 	profile.StatusFile = "status.json"
 	ctx := &Context{
-		resticBinary:  mockBinary,
-		profile:       profile,
-		resticCommand: "",
-		arguments:     []string{"--exit", "1"},
+		binary:  mockBinary,
+		profile: profile,
+		command: "",
+		request: Request{arguments: []string{"--exit", "1"}},
 	}
 	wrapper := newResticWrapper(ctx)
 	wrapper.addProgress(status.NewProgress(profile, status.NewStatus("status.json")))
@@ -930,10 +930,10 @@ func TestBackupWithWarningAsError(t *testing.T) {
 	profile := config.NewProfile(nil, "name")
 	profile.Backup = &config.BackupSection{}
 	ctx := &Context{
-		resticBinary:  mockBinary,
-		profile:       profile,
-		resticCommand: "",
-		arguments:     []string{"--exit", "3"},
+		binary:  mockBinary,
+		profile: profile,
+		command: "",
+		request: Request{arguments: []string{"--exit", "3"}},
 	}
 	wrapper := newResticWrapper(ctx)
 	err := wrapper.runCommand("backup")
@@ -944,10 +944,10 @@ func TestBackupWithSupressedWarnings(t *testing.T) {
 	profile := config.NewProfile(&config.Config{}, "name")
 	profile.Backup = &config.BackupSection{NoErrorOnWarning: true}
 	ctx := &Context{
-		resticBinary:  mockBinary,
-		profile:       profile,
-		resticCommand: "",
-		arguments:     []string{"--exit", "3"},
+		binary:  mockBinary,
+		profile: profile,
+		command: "",
+		request: Request{arguments: []string{"--exit", "3"}},
 	}
 	wrapper := newResticWrapper(ctx)
 	err := wrapper.runCommand("backup")
@@ -976,9 +976,9 @@ func TestRunShellCommands(t *testing.T) {
 		t.Run(fmt.Sprintf("run-before '%s'", command), func(t *testing.T) {
 			section.RunBefore = []string{"exit 2"}
 			ctx := &Context{
-				resticBinary:  mockBinary,
-				profile:       profile,
-				resticCommand: command,
+				binary:  mockBinary,
+				profile: profile,
+				command: command,
 			}
 			wrapper := newResticWrapper(ctx)
 			err := wrapper.runProfile()
@@ -994,9 +994,9 @@ func TestRunShellCommands(t *testing.T) {
 		t.Run(fmt.Sprintf("run-after '%s'", command), func(t *testing.T) {
 			section.RunAfter = []string{"exit 2"}
 			ctx := &Context{
-				resticBinary:  mockBinary,
-				profile:       profile,
-				resticCommand: command,
+				binary:  mockBinary,
+				profile: profile,
+				command: command,
 			}
 			wrapper := newResticWrapper(ctx)
 			err := wrapper.runProfile()
@@ -1021,10 +1021,10 @@ func TestRunStreamErrorHandler(t *testing.T) {
 	profile.Backup = &config.BackupSection{}
 	profile.StreamError = []config.StreamErrorSection{{Pattern: ".+error-line.+", Run: errorCommand}}
 	ctx := &Context{
-		resticBinary:  mockBinary,
-		profile:       profile,
-		resticCommand: "backup",
-		arguments:     []string{"--stderr", "--error-line--"},
+		binary:  mockBinary,
+		profile: profile,
+		command: "backup",
+		request: Request{arguments: []string{"--stderr", "--error-line--"}},
 	}
 	wrapper := newResticWrapper(ctx)
 
@@ -1038,10 +1038,10 @@ func TestRunStreamErrorHandlerDoesNotBreakCommand(t *testing.T) {
 	profile.Backup = &config.BackupSection{}
 	profile.StreamError = []config.StreamErrorSection{{Pattern: ".+error-line.+", Run: "exit 1"}}
 	ctx := &Context{
-		resticBinary:  mockBinary,
-		profile:       profile,
-		resticCommand: "backup",
-		arguments:     []string{"--stderr", "--error-line--"},
+		binary:  mockBinary,
+		profile: profile,
+		command: "backup",
+		request: Request{arguments: []string{"--stderr", "--error-line--"}},
 	}
 	wrapper := newResticWrapper(ctx)
 
@@ -1054,10 +1054,10 @@ func TestStreamErrorHandlerWithInvalidRegex(t *testing.T) {
 	profile.Backup = &config.BackupSection{}
 	profile.StreamError = []config.StreamErrorSection{{Pattern: "(", Run: "echo pass"}}
 	ctx := &Context{
-		resticBinary:  mockBinary,
-		profile:       profile,
-		resticCommand: "backup",
-		arguments:     []string{},
+		binary:  mockBinary,
+		profile: profile,
+		command: "backup",
+		request: Request{arguments: []string{}},
 	}
 	wrapper := newResticWrapper(ctx)
 
@@ -1068,9 +1068,9 @@ func TestStreamErrorHandlerWithInvalidRegex(t *testing.T) {
 func TestCanRetryAfterErrorDontFailWhenNoOutputAnalysis(t *testing.T) {
 	profile := config.NewProfile(&config.Config{}, "name")
 	ctx := &Context{
-		resticBinary:  mockBinary,
-		profile:       profile,
-		resticCommand: "backup",
+		binary:  mockBinary,
+		profile: profile,
+		command: "backup",
 	}
 	wrapper := newResticWrapper(ctx)
 	summary := monitor.Summary{}
@@ -1089,9 +1089,9 @@ func TestCanRetryAfterRemoteStaleLockFailure(t *testing.T) {
 	profile.Repository = config.NewConfidentialValue("my-repo")
 	profile.ForceLock = true
 	ctx := &Context{
-		resticBinary:  mockBinary,
-		profile:       profile,
-		resticCommand: "backup",
+		binary:  mockBinary,
+		profile: profile,
+		command: "backup",
 	}
 	wrapper := newResticWrapper(ctx)
 	wrapper.startTime = time.Now()
@@ -1146,9 +1146,9 @@ func TestCanRetryAfterRemoteLockFailure(t *testing.T) {
 	profile := config.NewProfile(&config.Config{}, "name")
 	profile.Repository = config.NewConfidentialValue("my-repo")
 	ctx := &Context{
-		resticBinary:  mockBinary,
-		profile:       profile,
-		resticCommand: "backup",
+		binary:  mockBinary,
+		profile: profile,
+		command: "backup",
 	}
 	wrapper := newResticWrapper(ctx)
 	wrapper.startTime = time.Now()
@@ -1197,10 +1197,10 @@ func TestCanUseResticLockRetry(t *testing.T) {
 
 	getWrapper := func() *resticWrapper {
 		wrapper := newResticWrapper(&Context{
-			flags:         commandLineFlags{dryRun: true},
-			resticBinary:  "restic",
-			profile:       profile,
-			resticCommand: constants.CommandBackup,
+			flags:   commandLineFlags{dryRun: true},
+			binary:  "restic",
+			profile: profile,
+			command: constants.CommandBackup,
 		})
 		wrapper.startTime = time.Now()
 		wrapper.global.ResticLockRetryAfter = 1 * time.Minute
@@ -1286,20 +1286,20 @@ func TestLocksAndLockWait(t *testing.T) {
 	term.SetOutput(os.Stdout)
 
 	ctx1 := &Context{
-		resticBinary:  mockBinary,
-		profile:       profile,
-		resticCommand: constants.CommandBackup,
-		arguments:     []string{"--sleep", "1500"},
+		binary:  mockBinary,
+		profile: profile,
+		command: constants.CommandBackup,
+		request: Request{arguments: []string{"--sleep", "1500"}},
 	}
 	ctx2 := &Context{
-		resticBinary:  mockBinary,
-		profile:       profile,
-		resticCommand: constants.CommandBackup,
+		binary:  mockBinary,
+		profile: profile,
+		command: constants.CommandBackup,
 	}
 	ctx3 := &Context{
-		resticBinary:  mockBinary,
-		profile:       profile,
-		resticCommand: constants.CommandBackup,
+		binary:  mockBinary,
+		profile: profile,
+		command: constants.CommandBackup,
 	}
 	w1 := newResticWrapper(ctx1)
 	w2 := newResticWrapper(ctx2)
@@ -1355,9 +1355,9 @@ func TestLocksAndLockWait(t *testing.T) {
 func TestGetContext(t *testing.T) {
 	profile := config.NewProfile(&config.Config{}, "TestProfile")
 	ctx := &Context{
-		resticBinary:  "",
-		profile:       profile,
-		resticCommand: "TestCommand",
+		binary:  "",
+		profile: profile,
+		command: "TestCommand",
 	}
 	wrapper := newResticWrapper(ctx)
 	require.NotNil(t, wrapper)
@@ -1373,9 +1373,9 @@ func TestGetContext(t *testing.T) {
 func TestGetContextWithError(t *testing.T) {
 	profile := config.NewProfile(&config.Config{}, "TestProfile")
 	ctx := &Context{
-		resticBinary:  "",
-		profile:       profile,
-		resticCommand: "TestCommand",
+		binary:  "",
+		profile: profile,
+		command: "TestCommand",
 	}
 	wrapper := newResticWrapper(ctx)
 	require.NotNil(t, wrapper)
@@ -1391,9 +1391,9 @@ func TestGetContextWithError(t *testing.T) {
 func TestGetErrorContext(t *testing.T) {
 	profile := config.NewProfile(&config.Config{}, "")
 	ctx := &Context{
-		resticBinary:  "",
-		profile:       profile,
-		resticCommand: "",
+		binary:  "",
+		profile: profile,
+		command: "",
 	}
 	wrapper := newResticWrapper(ctx)
 	require.NotNil(t, wrapper)
@@ -1407,9 +1407,9 @@ func TestGetErrorContext(t *testing.T) {
 func TestGetErrorContextWithStandardError(t *testing.T) {
 	profile := config.NewProfile(&config.Config{}, "")
 	ctx := &Context{
-		resticBinary:  "",
-		profile:       profile,
-		resticCommand: "",
+		binary:  "",
+		profile: profile,
+		command: "",
 	}
 	wrapper := newResticWrapper(ctx)
 	require.NotNil(t, wrapper)
@@ -1423,9 +1423,9 @@ func TestGetErrorContextWithStandardError(t *testing.T) {
 func TestGetErrorContextWithCommandError(t *testing.T) {
 	profile := config.NewProfile(&config.Config{}, "")
 	ctx := &Context{
-		resticBinary:  "",
-		profile:       profile,
-		resticCommand: "",
+		binary:  "",
+		profile: profile,
+		command: "",
 	}
 	wrapper := newResticWrapper(ctx)
 	require.NotNil(t, wrapper)
@@ -1445,9 +1445,9 @@ func TestGetErrorContextWithCommandError(t *testing.T) {
 func TestGetProfileEnvironment(t *testing.T) {
 	profile := config.NewProfile(&config.Config{}, "TestProfile")
 	ctx := &Context{
-		resticBinary:  "",
-		profile:       profile,
-		resticCommand: "TestCommand",
+		binary:  "",
+		profile: profile,
+		command: "TestCommand",
 	}
 	wrapper := newResticWrapper(ctx)
 	require.NotNil(t, wrapper)
@@ -1459,9 +1459,9 @@ func TestGetProfileEnvironment(t *testing.T) {
 func TestGetFailEnvironmentNoError(t *testing.T) {
 	profile := config.NewProfile(&config.Config{}, "")
 	ctx := &Context{
-		resticBinary:  "",
-		profile:       profile,
-		resticCommand: "",
+		binary:  "",
+		profile: profile,
+		command: "",
 	}
 	wrapper := newResticWrapper(ctx)
 	require.NotNil(t, wrapper)
@@ -1473,9 +1473,9 @@ func TestGetFailEnvironmentNoError(t *testing.T) {
 func TestGetFailEnvironmentWithStandardError(t *testing.T) {
 	profile := config.NewProfile(&config.Config{}, "")
 	ctx := &Context{
-		resticBinary:  "",
-		profile:       profile,
-		resticCommand: "",
+		binary:  "",
+		profile: profile,
+		command: "",
 	}
 	wrapper := newResticWrapper(ctx)
 	require.NotNil(t, wrapper)
@@ -1487,9 +1487,9 @@ func TestGetFailEnvironmentWithStandardError(t *testing.T) {
 func TestGetFailEnvironmentWithCommandError(t *testing.T) {
 	profile := config.NewProfile(&config.Config{}, "")
 	ctx := &Context{
-		resticBinary:  "",
-		profile:       profile,
-		resticCommand: "",
+		binary:  "",
+		profile: profile,
+		command: "",
 	}
 	wrapper := newResticWrapper(ctx)
 	require.NotNil(t, wrapper)
@@ -1570,11 +1570,11 @@ func TestRunInitCopyCommand(t *testing.T) {
 			defer clog.SetDefaultLogger(defaultLogger)
 
 			wrapper := newResticWrapper(&Context{
-				flags:         commandLineFlags{dryRun: true},
-				global:        config.NewGlobal(),
-				resticBinary:  "test",
-				profile:       testCase.profile,
-				resticCommand: "copy",
+				flags:   commandLineFlags{dryRun: true},
+				global:  config.NewGlobal(),
+				binary:  "test",
+				profile: testCase.profile,
+				command: "copy",
 			})
 			// 1. run init command with copy profile
 			err := wrapper.runInitializeCopy()


### PR DESCRIPTION
- introduction of a `Context` struct to pass context information around commands and profiles.
- own commands can return a specific error to exit main with an error code (will be used by `run-schedule`)
- extract bits of code into methods to simplify `main`
- add a `pre` field to `ownCommand` so commands can check the context before running

That will simplify future work like #259 and #146