### PR TITLE
Add `prometheus-push-format` to allow selecting text format

### DIFF
--- a/config/profile.go
+++ b/config/profile.go
@@ -94,6 +94,7 @@ type Profile struct {
 	PrometheusSaveToFile    string                            `mapstructure:"prometheus-save-to-file" description:"Path to the prometheus metrics file to update with a summary of the last restic command result"`
 	PrometheusPush          string                            `mapstructure:"prometheus-push" format:"uri" description:"URL of the prometheus push gateway to send the summary of the last restic command result to"`
 	PrometheusPushJob       string                            `mapstructure:"prometheus-push-job" description:"Prometheus push gateway job name. $command placeholder is replaced with restic command"`
+	PrometheusPushFormat    string                            `mapstructure:"prometheus-push-format" default:"protobuf" enum:"protobuf;text" description:"Prometheus push gateway request format"`
 	PrometheusLabels        map[string]string                 `mapstructure:"prometheus-labels" description:"Additional prometheus labels to set"`
 	SystemdDropInFiles      []string                          `mapstructure:"systemd-drop-in-files" default:"" description:"Files containing systemd drop-in (override) files - see https://creativeprojects.github.io/resticprofile/schedules/systemd/"`
 	Environment             map[string]ConfidentialValue      `mapstructure:"env" description:"Additional environment variables to set in any child process"`
@@ -482,6 +483,7 @@ func NewProfile(c *Config, name string) (p *Profile) {
 		Name:          name,
 		config:        c,
 		OtherSections: make(map[string]*GenericSection),
+		PrometheusPushFormat: constants.DefaultPrometheusPushFormat,
 	}
 
 	// create dynamic sections defined in any known restic version

--- a/config/profile.go
+++ b/config/profile.go
@@ -94,7 +94,7 @@ type Profile struct {
 	PrometheusSaveToFile    string                            `mapstructure:"prometheus-save-to-file" description:"Path to the prometheus metrics file to update with a summary of the last restic command result"`
 	PrometheusPush          string                            `mapstructure:"prometheus-push" format:"uri" description:"URL of the prometheus push gateway to send the summary of the last restic command result to"`
 	PrometheusPushJob       string                            `mapstructure:"prometheus-push-job" description:"Prometheus push gateway job name. $command placeholder is replaced with restic command"`
-	PrometheusPushFormat    string                            `mapstructure:"prometheus-push-format" default:"protobuf" enum:"protobuf;text" description:"Prometheus push gateway request format"`
+	PrometheusPushFormat    string                            `mapstructure:"prometheus-push-format" default:"text" enum:"text;protobuf" description:"Prometheus push gateway request format"`
 	PrometheusLabels        map[string]string                 `mapstructure:"prometheus-labels" description:"Additional prometheus labels to set"`
 	SystemdDropInFiles      []string                          `mapstructure:"systemd-drop-in-files" default:"" description:"Files containing systemd drop-in (override) files - see https://creativeprojects.github.io/resticprofile/schedules/systemd/"`
 	Environment             map[string]ConfidentialValue      `mapstructure:"env" description:"Additional environment variables to set in any child process"`

--- a/constants/default.go
+++ b/constants/default.go
@@ -19,7 +19,7 @@ const (
 	DefaultQuietFlag            = false
 	DefaultMinMemory            = 100
 	DefaultSenderTimeout        = 30 * time.Second
-	DefaultPrometheusPushFormat = "protobuf"
+	DefaultPrometheusPushFormat = "text"
 	BatteryFull                 = 100
 	LocalLockRetryDelay         = 5 * time.Second
 )

--- a/constants/default.go
+++ b/constants/default.go
@@ -19,6 +19,7 @@ const (
 	DefaultQuietFlag            = false
 	DefaultMinMemory            = 100
 	DefaultSenderTimeout        = 30 * time.Second
+	DefaultPrometheusPushFormat = "protobuf"
 	BatteryFull                 = 100
 	LocalLockRetryDelay         = 5 * time.Second
 )

--- a/docs/content/status/prometheus/index.md
+++ b/docs/content/status/prometheus/index.md
@@ -135,6 +135,8 @@ Prometheus Pushgateway uses the job label as a grouping key. All metrics with th
 
 If you need more control over the job label, you can use the `prometheus-push-job` property. This property can contain the `$command` placeholder, which is replaced with the name of the executed command.
 
+Additionally, the request format can be specified with `prometheus-push-format`. The default is `protobuf`, but it can also be set to `text` for compatibility with [more recent versions of Prometheus](https://prometheus.io/docs/instrumenting/exposition_formats/#exposition-formats).
+
 ## User defined labels
 
 You can add your own prometheus labels. Please note they will be applied to **all** the metrics.
@@ -227,5 +229,3 @@ root:
 
 
 which will add the `host` label to all your metrics.
-
-

--- a/docs/content/status/prometheus/index.md
+++ b/docs/content/status/prometheus/index.md
@@ -135,7 +135,7 @@ Prometheus Pushgateway uses the job label as a grouping key. All metrics with th
 
 If you need more control over the job label, you can use the `prometheus-push-job` property. This property can contain the `$command` placeholder, which is replaced with the name of the executed command.
 
-Additionally, the request format can be specified with `prometheus-push-format`. The default is `protobuf`, but it can also be set to `text` for compatibility with [more recent versions of Prometheus](https://prometheus.io/docs/instrumenting/exposition_formats/#exposition-formats).
+Additionally, the request format can be specified with `prometheus-push-format`. The default is `text`, but it can also be set to `protobuf` (see [compatibility with Prometheus](https://prometheus.io/docs/instrumenting/exposition_formats/#exposition-formats)).
 
 ## User defined labels
 

--- a/monitor/prom/metrics.go
+++ b/monitor/prom/metrics.go
@@ -7,6 +7,7 @@ import (
 	"github.com/creativeprojects/resticprofile/monitor"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/push"
+	"github.com/prometheus/common/expfmt"
 )
 
 const namespace = "resticprofile"
@@ -85,8 +86,17 @@ func (p *Metrics) SaveTo(filename string) error {
 	return prometheus.WriteToTextfile(filename, p.registry)
 }
 
-func (p *Metrics) Push(url, jobName string) error {
+func (p *Metrics) Push(url, format string, jobName string) error {
+	var expFmt expfmt.Format
+
+	if format == "protobuf" {
+		expFmt = expfmt.FmtProtoDelim
+	} else {
+		expFmt = expfmt.FmtText
+	}
+
 	return push.New(url, jobName).
+		Format(expFmt).
 		Gatherer(p.registry).
 		Add()
 }

--- a/monitor/prom/progress.go
+++ b/monitor/prom/progress.go
@@ -71,7 +71,7 @@ func (p *Progress) Summary(command string, summary monitor.Summary, stderr strin
 			}
 			return ""
 		})
-		err := p.metrics.Push(p.profile.PrometheusPush, jobName)
+		err := p.metrics.Push(p.profile.PrometheusPush, p.profile.PrometheusPushFormat, jobName)
 		if err != nil {
 			// not important enough to throw an error here
 			clog.Warningf("pushing prometheus metrics to %q: %v", p.profile.PrometheusPush, err)


### PR DESCRIPTION
The default golang client push format [is `FmtProtoDelim`](https://github.com/prometheus/client_golang/blob/f030c3d062e5180830979221733d46d286790bac/prometheus/push/push.go#L112C15-L112C35).

However, some implementations do not support protocol buffers, [including VictoriaMetrics](https://github.com/VictoriaMetrics/VictoriaMetrics/issues/3745).

This PR adds the ability to select a simple text format in such cases.

By default (protocol buffers):

![image](https://github.com/creativeprojects/resticprofile/assets/17737/09791475-293a-4249-ad5e-4f682a42d744)

With `prometheus-push-format: text`:

![image](https://github.com/creativeprojects/resticprofile/assets/17737/5b66db38-6871-4505-9e35-aa215c2ebeed)