### PR TITLE
Remove rclone binary in make clean target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -171,6 +171,7 @@ clean:
 	       $(COVERAGE_FILE) \
 	       restic_*_linux_amd64* \
 	       ${BUILD}restic* \
+	       ${BUILD}rclone* \
 	       dist/*
 	find . -path "*/mocks/*" -exec rm {} \;
 	restic cache --cleanup


### PR DESCRIPTION
Looks like it may have been overlooked in https://github.com/creativeprojects/resticprofile/commit/35d07ee34f7f0175e38ac9c9dce688738f521694.