### PR TITLE
Restrict copy command to a list of snapshots

### DIFF
--- a/config/profile.go
+++ b/config/profile.go
@@ -322,6 +322,7 @@ type CopySection struct {
 	PasswordFile                     string            `mapstructure:"password-file" description:"File to read the destination repository password from"`
 	PasswordCommand                  string            `mapstructure:"password-command" description:"Shell command to obtain the destination repository password from"`
 	KeyHint                          string            `mapstructure:"key-hint" description:"Key ID of key to try decrypting the destination repository first"`
+	Snapshots                        []string          `mapstructure:"snapshot" description:"Snapshot IDs to copy (if empty, all snapshots are copied)"`
 }
 
 func (s *CopySection) IsEmpty() bool { return s == nil }
@@ -480,9 +481,9 @@ func (o *OtherFlagsSection) SetOtherFlag(name string, value any) {
 // NewProfile instantiates a new blank profile
 func NewProfile(c *Config, name string) (p *Profile) {
 	p = &Profile{
-		Name:          name,
-		config:        c,
-		OtherSections: make(map[string]*GenericSection),
+		Name:                 name,
+		config:               c,
+		OtherSections:        make(map[string]*GenericSection),
 		PrometheusPushFormat: constants.DefaultPrometheusPushFormat,
 	}
 
@@ -770,6 +771,14 @@ func (p *Profile) GetBackupSource() []string {
 		return nil
 	}
 	return p.Backup.Source
+}
+
+// GetCopySnapshotIDs returns the snapshot IDs to copy
+func (p *Profile) GetCopySnapshotIDs() []string {
+	if p.Copy == nil {
+		return nil
+	}
+	return p.Copy.Snapshots
 }
 
 // DefinedCommands returns all commands (also called sections) defined in the profile (backup, check, forget, etc.)

--- a/docs/content/configuration/copy/index.md
+++ b/docs/content/configuration/copy/index.md
@@ -1,12 +1,12 @@
 ---
 title: "Copy command"
-tags: ["v0.18.0"]
+tags: ["v0.18.0", "v0.25.0"]
 weight: 17
 ---
 
 
 
-## Special case for the `copy` command section
+## Special case for the **copy** command section
 
 The copy command needs two repositories (and quite likely 2 different set of keys). You can configure a `copy` section like this:
 
@@ -65,7 +65,7 @@ default {
 {{% /tab %}}
 {{< /tabs >}}
 
-You will note that the secondary repository doesn't need to have a `2` behind its flags (`repository2`, `password-file2`, etc.). It's because the flags are well separated in the configuration and there's no ambiguity.
+You will note that the secondary repository doesn't need to have a `2` behind its flags (`repository2`, `password-file2`, etc.) nor it is prefixed by a `from` for the more recent version of restic (`from-repo`, `from-password-file`, etc.). It's because the flags are well separated in the configuration and there's no ambiguity.
 
 ## Initialisation
 
@@ -122,6 +122,70 @@ profile {
         initialize-copy-chunker-params = true
         repository = "/backup/copy"
         password-file = "other_key"
+    }
+}
+```
+
+{{% /tab %}}
+{{< /tabs >}}
+
+## Copy only some snapshots
+
+You can restrict the copy to only some snapshots using the `snapshot` option.
+
+The `snapshot` parameter can be a snapshot ID  or the `latest` keyword. You can use an array if multiple values are needed.
+
+
+{{< tabs groupid="config-with-hcl" >}}
+{{% tab title="toml" %}}
+
+```toml
+version = "1"
+
+[profile]
+  repository = "/backup/original"
+  password-file = "key"
+
+  [profile.copy]
+    initialize = true
+    initialize-copy-chunker-params = true
+    repository = "/backup/copy"
+    password-file = "other_key"
+    snapshot = "latest"
+```
+
+{{% /tab %}}
+{{% tab title="yaml" %}}
+
+```yaml
+version: "1"
+
+profile:
+    repository: "/backup/original"
+    password-file: key
+    copy:
+        initialize: true
+        initialize-copy-chunker-params: true
+        repository: "/backup/copy"
+        password-file: other_key
+        snapshot: latest
+```
+
+{{% /tab %}}
+{{% tab title="hcl" %}}
+
+
+```hcl
+profile {
+    repository = "/backup/original"
+    password-file = "key"
+
+    copy = {
+        initialize = true
+        initialize-copy-chunker-params = true
+        repository = "/backup/copy"
+        password-file = "other_key"
+        snapshot = "latest"
     }
 }
 ```

--- a/docs/content/configuration/copy/index.md
+++ b/docs/content/configuration/copy/index.md
@@ -1,6 +1,6 @@
 ---
 title: "Copy command"
-tags: ["v0.18.0", "v0.25.0"]
+tags: ["v0.18.0", "v0.26.0"]
 weight: 17
 ---
 

--- a/examples/dev.yaml
+++ b/examples/dev.yaml
@@ -129,6 +129,7 @@ self:
         schedule-priority: standard
     copy:
         initialize: true
+        snapshot: latest
         schedule:
             - "*:45"
     snapshots:

--- a/wrapper.go
+++ b/wrapper.go
@@ -367,6 +367,10 @@ func (r *resticWrapper) prepareCommand(command string, args *shell.Args, allowEx
 	if command == constants.CommandBackup {
 		args.AddArgs(r.profile.GetBackupSource(), shell.ArgConfigBackupSource)
 	}
+	// Special case for copy command
+	if command == constants.CommandCopy {
+		args.AddArgs(r.profile.GetCopySnapshotIDs(), shell.ArgConfigEscape)
+	}
 
 	// Add retry-lock (supported from restic 0.16, depends on filter being enabled)
 	if lockRetryTime, enabled := r.remainingLockRetryTime(); enabled && filter != nil {

--- a/wrapper_test.go
+++ b/wrapper_test.go
@@ -1591,3 +1591,31 @@ func TestRunInitCopyCommand(t *testing.T) {
 		})
 	}
 }
+
+func TestCopyNoSnapshot(t *testing.T) {
+	profile := config.NewProfile(&config.Config{}, "name")
+	profile.Copy = &config.CopySection{}
+	ctx := &Context{
+		binary:  mockBinary,
+		profile: profile,
+		command: "",
+	}
+	wrapper := newResticWrapper(ctx)
+	args := shell.NewArgs()
+	cmd := wrapper.prepareCommand("copy", args, false)
+	assert.Equal(t, []string{"copy"}, cmd.args)
+}
+
+func TestCopySnapshot(t *testing.T) {
+	profile := config.NewProfile(&config.Config{}, "name")
+	profile.Copy = &config.CopySection{Snapshots: []string{"snapshot1", "snapshot2"}}
+	ctx := &Context{
+		binary:  mockBinary,
+		profile: profile,
+		command: "",
+	}
+	wrapper := newResticWrapper(ctx)
+	args := shell.NewArgs()
+	cmd := wrapper.prepareCommand("copy", args, false)
+	assert.Equal(t, []string{"copy", "snapshot1", "snapshot2"}, cmd.args)
+}


### PR DESCRIPTION
Fixes #263 

I called the new option `snapshot`: Would `snapshots` be more intuitive?

Progress:
- [x] Implementation
- [x] Tests
- [x] Documentation
- [x] Ready for review
