### PR TITLE
Change priority warning message

### DIFF
--- a/docs/content/configuration/priority/_index.md
+++ b/docs/content/configuration/priority/_index.md
@@ -1,0 +1,90 @@
+---
+title: "Priority"
+weight: 35
+---
+
+By default, restic is running with the default priority. It means it will get equal share of the resources with other processes.
+
+You can lower the priority of restic to avoid slowing down other processes. This is especially useful when you run restic on a production server.
+
+## Nice
+
+You can use these values for the `priority` parameter:
+
+| String value | "nice" equivalent on unixes |
+|-------|-------------------|
+| Idle       | 19 |
+| Background | 15 |
+| Low        | 10 |
+| Normal     | 0 |
+| High       | -10 |
+| Highest    | -20 |
+
+## IO Nice
+
+This setting is only available on Linux. It allows you to set the IO priority of restic.
+More information about ionice "class" and "level" can be found [here](https://linux.die.net/man/1/ionice).
+
+## Examples
+
+{{< tabs groupid="config-with-hcl" >}}
+{{% tab title="toml" %}}
+
+```toml
+version = "1"
+
+[global]
+  # priority is using priority class on windows, and "nice" on unixes
+  priority = "low"
+  # ionice is available on Linux only
+  ionice = true
+  ionice-class = 2
+  ionice-level = 6
+```
+
+{{% /tab %}}
+{{% tab title="yaml" %}}
+
+```yaml
+version: "1"
+
+global:
+  # priority is using priority class on windows, and "nice" on unixes
+  priority: low
+  # ionice is available on Linux only
+  ionice: true
+  ionice-class: 2
+  ionice-level: 6
+```
+
+{{% /tab %}}
+{{% tab title="hcl" %}}
+
+```hcl
+global {
+    # priority is using priority class on windows, and "nice" on unixes
+    priority = "low"
+    # ionice is available on Linux only
+    ionice = true
+    ionice-class = 2
+    ionice-level = 6
+}
+```
+
+{{% /tab %}}
+{{< /tabs >}}
+
+## Warnings
+
+In some cases, resticprofile will not be able to set the priority of restic.
+
+A warning message like this will be displayed:
+
+```
+cannot set process group priority, restic will run with the default priority: operation not permitted
+```
+
+This usually means:
+- resticprofile is running inside docker
+- you are using a tight security linux distribution which is launching every process inside a new container
+- resticprofile is running in WSL

--- a/priority/check/main_linux.go
+++ b/priority/check/main_linux.go
@@ -1,4 +1,4 @@
-//+build linux
+//go:build linux
 
 package main
 
@@ -11,10 +11,8 @@ import (
 
 // This is only displaying the priority of the current process (for testing)
 func main() {
-
 	getPriority()
 	getIOPriority()
-
 }
 
 func getPriority() {

--- a/priority/ioprio_test.go
+++ b/priority/ioprio_test.go
@@ -1,4 +1,4 @@
-//+build linux
+//go:build linux
 
 package priority
 

--- a/priority/linux.go
+++ b/priority/linux.go
@@ -1,4 +1,4 @@
-//+build linux
+//go:build linux
 
 package priority
 
@@ -53,13 +53,13 @@ func SetNice(priority int) error {
 	// group variants of Setpriority etc to affect all of our threads in one go
 	err = unix.Setpgid(pid, 0)
 	if err != nil {
-		return fmt.Errorf("error setting process group: %v", err)
+		return fmt.Errorf("cannot set process group priority, restic will run with the default priority: %w", err)
 	}
 
 	clog.Debugf("setting process priority to %d", priority)
 	err = unix.Setpriority(unix.PRIO_PROCESS, pid, priority)
 	if err != nil {
-		return fmt.Errorf("error setting process priority: %v", err)
+		return fmt.Errorf("cannot set process priority, restic will run with the default priority: %w", err)
 	}
 	return nil
 }

--- a/priority/prority_test.go
+++ b/priority/prority_test.go
@@ -2,7 +2,7 @@ package priority
 
 import (
 	"bytes"
-	"io/ioutil"
+	"io"
 	"os/exec"
 	"runtime"
 	"testing"
@@ -77,11 +77,10 @@ func runChildProcess() (string, error) {
 	buffer := &bytes.Buffer{}
 	cmd.Stdout = buffer
 	cmd.Stderr = buffer
-	err := cmd.Run()
-	if err != nil {
+	if err := cmd.Run(); err != nil {
 		return "", err
 	}
-	output, err := ioutil.ReadAll(buffer)
+	output, err := io.ReadAll(buffer)
 	if err != nil {
 		return "", err
 	}


### PR DESCRIPTION
- Make the warning more explicit when resticprofile cannot change the group process priority
- add documentation with most probable causes (container & WSL)

Fixes #296 