### PR TITLE
HTTP hook Authorization header value is replaced in post requests

### DIFF
--- a/config/confidential.go
+++ b/config/confidential.go
@@ -14,10 +14,13 @@ type ConfidentialValue struct {
 	public, confidential string
 }
 
+// Value returns the unmasked original value
 func (c ConfidentialValue) Value() string {
 	return c.confidential
 }
 
+// String returns the masked representation of a value, if confidential
+// It returns the original value if not confidential
 func (c ConfidentialValue) String() string {
 	return c.public
 }


### PR DESCRIPTION
Fix for sending a masked value in the `Authorization` header.

The function `stringifyHeaders` used to display the debugging information was replacing the value with a masked one.
The masked value was then sent to the server in place of the original value

Fixes #326 
