### PR TITLE
restic: use repository-file if the repo flag contains a password

### DIFF
--- a/config/confidential_test.go
+++ b/config/confidential_test.go
@@ -4,8 +4,6 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"github.com/creativeprojects/resticprofile/util/templates"
-	"github.com/stretchr/testify/require"
 	"os"
 	"reflect"
 	"regexp"
@@ -13,8 +11,11 @@ import (
 	"testing"
 
 	"github.com/creativeprojects/resticprofile/constants"
+	"github.com/creativeprojects/resticprofile/platform"
 	"github.com/creativeprojects/resticprofile/shell"
+	"github.com/creativeprojects/resticprofile/util/templates"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 var (
@@ -284,6 +285,9 @@ func TestGetNonConfidentialArgs(t *testing.T) {
 }
 
 func TestGetAutoRepositoryFile(t *testing.T) {
+	require.NoError(t, os.Unsetenv("RESTIC_REPOSITORY"))
+	require.NoError(t, os.Unsetenv("RESTIC_REPOSITORY_FILE"))
+
 	tests := map[string]bool{
 		"/path/to/file":                      false,
 		"file:/path/to/file":                 false,
@@ -302,6 +306,10 @@ func TestGetAutoRepositoryFile(t *testing.T) {
 			require.NoError(t, err)
 			args := profile.GetCommandFlags(constants.CommandBackup)
 
+			if usesFile && platform.IsWindows() {
+				usesFile = false // Windows has no support for repository file right now (as temp files can't be forced to private with standard go API)
+			}
+
 			if usesFile {
 				file := templates.TempFile("my-profile-repo.txt")
 				expected := shell.NewArg(file, shell.ArgConfigEscape).String()
@@ -314,6 +322,55 @@ func TestGetAutoRepositoryFile(t *testing.T) {
 				expected := shell.NewArg(repo, shell.ArgConfigEscape).String()
 				assert.Equal(t, []string{"--repo=" + expected}, args.GetAll())
 			}
+		})
+	}
+}
+
+func TestGetAutoRepositoryFileDisabledWithEnv(t *testing.T) {
+	if platform.IsWindows() {
+		t.Skip()
+	}
+
+	tests := []string{
+		"RESTIC_REPOSITORY",
+		"RESTIC_REPOSITORY_FILE",
+	}
+
+	for _, envKey := range tests {
+		t.Run(envKey, func(t *testing.T) {
+			config := fmt.Sprintf(`
+				[my-profile]
+				repository = %q
+            `, defaultHttpUrl)
+
+			defer os.Unsetenv(envKey)
+			profile, err := getResolvedProfile("toml", config, "my-profile")
+			require.NoError(t, err)
+
+			hasRepoFlag := func() (found bool) {
+				_, found = profile.GetCommandFlags(constants.CommandBackup).Get("repo")
+				return
+			}
+
+			t.Run("no-env", func(t *testing.T) {
+				require.NoError(t, os.Unsetenv(envKey))
+				profile.Environment = nil
+				assert.False(t, hasRepoFlag())
+			})
+
+			t.Run("profile-env", func(t *testing.T) {
+				require.NoError(t, os.Unsetenv(envKey))
+				profile.Environment = map[string]ConfidentialValue{
+					envKey: NewConfidentialValue("1"),
+				}
+				assert.True(t, hasRepoFlag())
+			})
+
+			t.Run("os-env", func(t *testing.T) {
+				require.NoError(t, os.Setenv(envKey, "1"))
+				profile.Environment = nil
+				assert.True(t, hasRepoFlag())
+			})
 		})
 	}
 }

--- a/config/global.go
+++ b/config/global.go
@@ -4,6 +4,7 @@ import (
 	"time"
 
 	"github.com/creativeprojects/resticprofile/constants"
+	"github.com/creativeprojects/resticprofile/util/maybe"
 )
 
 // Global holds the configuration from the global section
@@ -15,7 +16,7 @@ type Global struct {
 	Priority             string              `mapstructure:"priority" default:"normal" enum:"idle;background;low;normal;high;highest" description:"Sets process priority class for resticprofile and child processes (on any OS)"`
 	DefaultCommand       string              `mapstructure:"default-command" default:"snapshots" description:"The restic or resticprofile command to use when no command was specified"`
 	Initialize           bool                `mapstructure:"initialize" default:"false" description:"Initialize a repository if missing"`
-	NoAutoRepositoryFile bool                `mapstructure:"prevent-auto-repository-file" default:"false" description:"Prevents using a repository file for repository definitions containing a password"`
+	NoAutoRepositoryFile maybe.Bool          `mapstructure:"prevent-auto-repository-file" default:"false" description:"Prevents using a repository file for repository definitions containing a password"`
 	ResticBinary         string              `mapstructure:"restic-binary" description:"Full path of the restic executable (detected if not set)"`
 	ResticVersion        string              // not configurable at the moment. To be set after ResticBinary is known.
 	FilterResticFlags    bool                `mapstructure:"restic-arguments-filter" default:"true" description:"Remove unknown flags instead of passing all configured flags to restic"`

--- a/config/global.go
+++ b/config/global.go
@@ -15,6 +15,7 @@ type Global struct {
 	Priority             string              `mapstructure:"priority" default:"normal" enum:"idle;background;low;normal;high;highest" description:"Sets process priority class for resticprofile and child processes (on any OS)"`
 	DefaultCommand       string              `mapstructure:"default-command" default:"snapshots" description:"The restic or resticprofile command to use when no command was specified"`
 	Initialize           bool                `mapstructure:"initialize" default:"false" description:"Initialize a repository if missing"`
+	NoAutoRepositoryFile bool                `mapstructure:"prevent-auto-repository-file" default:"false" description:"Prevents using a repository file for repository definitions containing a password"`
 	ResticBinary         string              `mapstructure:"restic-binary" description:"Full path of the restic executable (detected if not set)"`
 	ResticVersion        string              // not configurable at the moment. To be set after ResticBinary is known.
 	FilterResticFlags    bool                `mapstructure:"restic-arguments-filter" default:"true" description:"Remove unknown flags instead of passing all configured flags to restic"`

--- a/config/profile_test.go
+++ b/config/profile_test.go
@@ -306,8 +306,6 @@ func TestEnvironmentInProfileRepo(t *testing.T) {
 }
 
 func TestGetEnvironment(t *testing.T) {
-	t.Cleanup(util.ClearTempDir)
-
 	runForVersions(t, func(t *testing.T, version, prefix string) {
 		testConfig := version + `
 			[` + prefix + `profile]

--- a/examples/integration_test.hcl
+++ b/examples/integration_test.hcl
@@ -1,3 +1,7 @@
+global {
+    prevent-auto-repository-file = "true"
+}
+
 default {
     repository = "rest:http://user:password@localhost:8000/path"
     password-file = "key"

--- a/examples/integration_test.json
+++ b/examples/integration_test.json
@@ -1,4 +1,7 @@
 {
+    "global": {
+        "prevent-auto-repository-file": true
+    },
     "default": {
       "password-file": "key",
       "repository": "rest:http://user:password@localhost:8000/path"

--- a/examples/integration_test.toml
+++ b/examples/integration_test.toml
@@ -1,3 +1,6 @@
+[global]
+prevent-auto-repository-file = true
+
 [default]
 repository = "rest:http://user:password@localhost:8000/path"
 password-file = "key"

--- a/examples/integration_test.yaml
+++ b/examples/integration_test.yaml
@@ -1,4 +1,7 @@
 ---
+global:
+  prevent-auto-repository-file: true
+
 default:
   password-file: key
   repository: "rest:http://user:password@localhost:8000/path"

--- a/util/maybe/bool_test.go
+++ b/util/maybe/bool_test.go
@@ -1,6 +1,7 @@
 package maybe_test
 
 import (
+	"fmt"
 	"reflect"
 	"testing"
 
@@ -77,10 +78,10 @@ func TestBoolDecoder(t *testing.T) {
 		expected any
 	}{
 		{
-			from:     reflect.TypeOf(""),
+			from:     reflect.TypeOf(struct{}{}),
 			to:       reflect.TypeOf(maybe.Bool{}),
-			source:   true,
-			expected: true, // same value returned as the "from" type in unexpected
+			source:   struct{}{},
+			expected: struct{}{}, // same value returned as the "from" type in unexpected
 		},
 		{
 			from:     reflect.TypeOf(true),
@@ -89,10 +90,28 @@ func TestBoolDecoder(t *testing.T) {
 			expected: false, // same value returned as the "to" type in unexpected
 		},
 		{
-			from:     reflect.TypeOf(true),
+			from:     reflect.TypeOf(""),
 			to:       reflect.TypeOf(maybe.Bool{}),
 			source:   "",
 			expected: "", // same value returned as the original value in unexpected
+		},
+		{
+			from:     reflect.TypeOf(""),
+			to:       reflect.TypeOf(maybe.Bool{}),
+			source:   "true",
+			expected: maybe.True(),
+		},
+		{
+			from:     reflect.TypeOf(""),
+			to:       reflect.TypeOf(maybe.Bool{}),
+			source:   "t",
+			expected: maybe.True(),
+		},
+		{
+			from:     reflect.TypeOf(""),
+			to:       reflect.TypeOf(maybe.Bool{}),
+			source:   "f",
+			expected: maybe.False(),
 		},
 		{
 			from:     reflect.TypeOf(true),
@@ -107,8 +126,8 @@ func TestBoolDecoder(t *testing.T) {
 			expected: maybe.False(),
 		},
 	}
-	for _, fixture := range fixtures {
-		t.Run("", func(t *testing.T) {
+	for i, fixture := range fixtures {
+		t.Run(fmt.Sprintf("%d", i), func(t *testing.T) {
 			decoder := maybe.BoolDecoder()
 			decoded, err := decoder(fixture.from, fixture.to, fixture.source)
 			assert.NoError(t, err)

--- a/util/templates/functions.go
+++ b/util/templates/functions.go
@@ -155,7 +155,7 @@ func EnvFileFunc(receiverFunc EnvFileReceiverFunc) map[string]any {
 			if err != nil && !errors.Is(err, NotStrictlyPrivate) {
 				panic(fmt.Errorf("failed setting permissions for %s: %w", envFile, err))
 			}
-			//files[profile] = envFile
+			files[profile] = envFile
 		}
 		return
 	}


### PR DESCRIPTION
Experimental PR to replace `restic --repo https://user:password@host` with `restic --repository-file /tmp/profile-repo.txt` (with file mode `0600`)

Currently fails tests (as they don't expect replacement) and depends on some functions from other PRs to complete it.