### PR TITLE
drop-ins: transparent timer drop-in support

### DIFF
--- a/schedule/handler_systemd.go
+++ b/schedule/handler_systemd.go
@@ -193,23 +193,22 @@ func (h *HandlerSystemd) RemoveJob(job *Config, permission string) error {
 		}
 	}
 
-	err = os.Remove(path.Join(systemdPath, timerFile))
-	if err != nil {
-		return nil
-	}
-
 	serviceFile := systemd.GetServiceFile(job.ProfileName, job.CommandName)
-	err = os.Remove(path.Join(systemdPath, serviceFile))
-	if err != nil {
-		return nil
-	}
-
 	dropInDir := systemd.GetServiceFileDropInDir(job.ProfileName, job.CommandName)
-	err = os.RemoveAll(path.Join(systemdPath, dropInDir))
-	if err != nil {
-		return nil
+	timerDropInDir := systemd.GetTimerFileDropInDir(job.ProfileName, job.CommandName)
+
+	obsoletes := []string{
+		path.Join(systemdPath, timerFile),
+		path.Join(systemdPath, serviceFile),
+		path.Join(systemdPath, timerDropInDir),
+		path.Join(systemdPath, dropInDir),
 	}
 
+	for _, pathToRemove := range obsoletes {
+		if err = os.RemoveAll(pathToRemove); err != nil {
+			clog.Errorf("failed removing %q, error: %s. Please remove this path", pathToRemove, err.Error())
+		}
+	}
 	return nil
 }
 

--- a/schedule_jobs.go
+++ b/schedule_jobs.go
@@ -150,5 +150,7 @@ func scheduleToConfig(sched *config.Schedule) *schedule.Config {
 		Flags:                   sched.Flags,
 		IgnoreOnBattery:         sched.IgnoreOnBattery.IsTrue(),
 		IgnoreOnBatteryLessThan: sched.IgnoreOnBatteryLessThan,
+		AfterNetworkOnline:      sched.AfterNetworkOnline.IsTrue(),
+		SystemdDropInFiles:      sched.SystemdDropInFiles,
 	}
 }

--- a/systemd/drop_ins.go
+++ b/systemd/drop_ins.go
@@ -20,7 +20,7 @@ var (
 
 func getOwnedName(basename string) string {
 	ext := filepath.Ext(basename)
-	return fmt.Sprintf("%s.resticprofile%s", strings.TrimSuffix(basename, ext), ext)
+	return fmt.Sprintf("%s.resticprofile.conf", strings.TrimSuffix(basename, ext))
 }
 
 func IsTimerDropIn(file string) bool {
@@ -74,10 +74,11 @@ func CreateDropIns(dir string, files []string) error {
 
 	for _, dropInFilePath := range files {
 		dropInFileBase := filepath.Base(dropInFilePath)
-		// change the extension to prepend `.resticprofile`
+		// change the extension to `.resticprofile.conf`
 		// to signify it wasn't created outside of resticprofile, i.e. we own it
 		dropInFileOwned := getOwnedName(dropInFileBase)
 		dstPath := filepath.Join(dir, dropInFileOwned)
+		clog.Infof("writing %v", dstPath)
 		dst, err := fs.Create(dstPath)
 		if err != nil {
 			return err
@@ -86,7 +87,6 @@ func CreateDropIns(dir string, files []string) error {
 		if err != nil {
 			return err
 		}
-		clog.Infof("writing %v", dstPath)
 		if _, err := io.Copy(dst, src); err != nil {
 			return err
 		}


### PR DESCRIPTION
PR for #217 (and other systemd specific configs for timers), tested in unit and manual tests.

Note: This also contains a fix for run-schedule not transferring `AfterNetworkOnline` & `SystemdDropInFiles` and a weakness of the drop-in support not detecting the own files when the sources use an extension other than `.conf`.