### PR TITLE
Add option to set working directory for restic backup

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -338,7 +338,7 @@ func (c *Config) DisplayConfigurationIssues() {
 		msg = append([]string{
 			"the configuration contains relative \"path\" items which may lead to unstable results in restic " +
 				"commands that select snapshots. Consider using absolute paths in \"path\" (and \"source\"), " +
-				"set \"base-dir\" in the profile or use \"tag\" instead of \"path\" (path = false) to select " +
+				"set \"base-dir\" or \"source-base\" in the profile or use \"tag\" instead of \"path\" (path = false) to select " +
 				"snapshots for restic commands.",
 			"Affected paths are:",
 		}, msg...)

--- a/config/profile.go
+++ b/config/profile.go
@@ -654,7 +654,7 @@ func (p *Profile) resolveSourcePath(sourceBase string, sourcePaths ...string) []
 
 	sourceBase = fixPath(sourceBase, expandEnv, expandUserHome)
 	// When "source-relative" is set, the source paths are relative to the "source-base"
-	if !p.Backup.SourceRelative {
+	if p.Backup == nil || !p.Backup.SourceRelative {
 		// Backup source is NOT relative to the configuration, but to PWD or sourceBase (if not empty)
 		// Applying "sourceBase" if set
 		if sourceBase = strings.TrimSpace(sourceBase); sourceBase != "" {

--- a/config/profile.go
+++ b/config/profile.go
@@ -172,6 +172,7 @@ type BackupSection struct {
 	CheckAfter                       bool     `mapstructure:"check-after" description:"Check the repository after the backup command succeeded"`
 	UseStdin                         bool     `mapstructure:"stdin" argument:"stdin"`
 	StdinCommand                     []string `mapstructure:"stdin-command" description:"Shell command(s) that generate content to redirect into the stdin of restic. When set, the flag \"stdin\" is always set to \"true\"."`
+	ChangeWorkingDir                 bool     `mapstructure:"change-working-dir" description:"Change the restic backup command's working directory to \"source-base\". When set, the \"source\" does not expand to absolute paths"`
 	SourceBase                       string   `mapstructure:"source-base" examples:"/;$PWD;C:\\;%cd%" description:"The base path to resolve relative backup paths against. Defaults to current directory if unset or empty (see also \"base-dir\" in profile)"`
 	Source                           []string `mapstructure:"source" examples:"/opt/;/home/user/;C:\\Users\\User\\Documents" description:"The paths to backup"`
 	Exclude                          []string `mapstructure:"exclude" argument:"exclude" argument-type:"no-glob"`
@@ -651,15 +652,19 @@ func (p *Profile) SetRootPath(rootPath string) {
 func (p *Profile) resolveSourcePath(sourceBase string, sourcePaths ...string) []string {
 	var applySourceBase, applyBaseDir pathFix
 
-	// Backup source is NOT relative to the configuration, but to PWD or sourceBase (if not empty)
-	// Applying "sourceBase" if set
-	if sourceBase = strings.TrimSpace(sourceBase); sourceBase != "" {
-		sourceBase = fixPath(sourceBase, expandEnv, expandUserHome)
-		applySourceBase = absolutePrefix(sourceBase)
-	}
-	// Applying a custom PWD eagerly so that own commands (e.g. "show") display correct paths
-	if p.BaseDir != "" {
-		applyBaseDir = absolutePrefix(p.BaseDir)
+	sourceBase = fixPath(sourceBase, expandEnv, expandUserHome)
+	// When "change-working-dir" is set, the source paths are relative to the "source-base"
+	if !p.Backup.ChangeWorkingDir {
+		// Backup source is NOT relative to the configuration, but to PWD or sourceBase (if not empty)
+		// Applying "sourceBase" if set
+		if sourceBase = strings.TrimSpace(sourceBase); sourceBase != "" {
+			applySourceBase = absolutePrefix(sourceBase)
+		}
+		// Applying a custom PWD eagerly so that own commands (e.g. "show") display correct paths
+		if p.BaseDir != "" {
+			applyBaseDir = absolutePrefix(p.BaseDir)
+		}
+
 	}
 
 	// prefix paths starting with "-" with a "./" to distinguish a source path from a flag

--- a/config/profile.go
+++ b/config/profile.go
@@ -172,7 +172,7 @@ type BackupSection struct {
 	CheckAfter                       bool     `mapstructure:"check-after" description:"Check the repository after the backup command succeeded"`
 	UseStdin                         bool     `mapstructure:"stdin" argument:"stdin"`
 	StdinCommand                     []string `mapstructure:"stdin-command" description:"Shell command(s) that generate content to redirect into the stdin of restic. When set, the flag \"stdin\" is always set to \"true\"."`
-	ChangeWorkingDir                 bool     `mapstructure:"change-working-dir" description:"Change the restic backup command's working directory to \"source-base\". When set, the \"source\" does not expand to absolute paths"`
+	SourceRelative                   bool     `mapstructure:"source-relative" description:"Enable backup with relative source paths. This will change the working directory of the \"restic backup\" command to \"source-base\", and will not expand \"source\" to an absolute path."`
 	SourceBase                       string   `mapstructure:"source-base" examples:"/;$PWD;C:\\;%cd%" description:"The base path to resolve relative backup paths against. Defaults to current directory if unset or empty (see also \"base-dir\" in profile)"`
 	Source                           []string `mapstructure:"source" examples:"/opt/;/home/user/;C:\\Users\\User\\Documents" description:"The paths to backup"`
 	Exclude                          []string `mapstructure:"exclude" argument:"exclude" argument-type:"no-glob"`
@@ -653,8 +653,8 @@ func (p *Profile) resolveSourcePath(sourceBase string, sourcePaths ...string) []
 	var applySourceBase, applyBaseDir pathFix
 
 	sourceBase = fixPath(sourceBase, expandEnv, expandUserHome)
-	// When "change-working-dir" is set, the source paths are relative to the "source-base"
-	if !p.Backup.ChangeWorkingDir {
+	// When "source-relative" is set, the source paths are relative to the "source-base"
+	if !p.Backup.SourceRelative {
 		// Backup source is NOT relative to the configuration, but to PWD or sourceBase (if not empty)
 		// Applying "sourceBase" if set
 		if sourceBase = strings.TrimSpace(sourceBase); sourceBase != "" {

--- a/config/profile_test.go
+++ b/config/profile_test.go
@@ -639,7 +639,7 @@ func TestResolveSourcesAgainstBase(t *testing.T) {
 	backupSource := func(base, source string, changeWorkingDir bool) []string {
 		config := `
 			[profile.backup]
-			change-working-dir = ` + strconv.FormatBool(changeWorkingDir) + `
+			source-relative = ` + strconv.FormatBool(changeWorkingDir) + `
 			source-base = "` + filepath.ToSlash(base) + `"
 			source = "` + filepath.ToSlash(source) + `"
 		`

--- a/config/profile_test.go
+++ b/config/profile_test.go
@@ -636,9 +636,10 @@ func TestResolveSourcesWithFlagPrefixInBackup(t *testing.T) {
 }
 
 func TestResolveSourcesAgainstBase(t *testing.T) {
-	backupSource := func(base, source string) []string {
+	backupSource := func(base, source string, changeWorkingDir bool) []string {
 		config := `
 			[profile.backup]
+			change-working-dir = ` + strconv.FormatBool(changeWorkingDir) + `
 			source-base = "` + filepath.ToSlash(base) + `"
 			source = "` + filepath.ToSlash(source) + `"
 		`
@@ -653,18 +654,27 @@ func TestResolveSourcesAgainstBase(t *testing.T) {
 	assert.NoError(t, err)
 
 	t.Run("no-base", func(t *testing.T) {
-		assert.Equal(t, []string{"src"}, backupSource("", "src"))
+		assert.Equal(t, []string{"src"}, backupSource("", "src", false))
 	})
 	t.Run("relative-base", func(t *testing.T) {
-		assert.Equal(t, []string{filepath.Join("rel", "src")}, backupSource("rel", "src"))
+		assert.Equal(t, []string{filepath.Join("rel", "src")}, backupSource("rel", "src", false))
 	})
 	t.Run("absolute-base", func(t *testing.T) {
-		assert.Equal(t, []string{filepath.Join(cwd, "src")}, backupSource(cwd, "src"))
+		assert.Equal(t, []string{filepath.Join(cwd, "src")}, backupSource(cwd, "src", false))
 	})
 	t.Run("env-var-base", func(t *testing.T) {
 		assert.NoError(t, os.Setenv("RP_TEST_CWD", cwd))
 		defer os.Unsetenv("RP_TEST_CWD")
-		assert.Equal(t, []string{filepath.Join(cwd, "path", "src")}, backupSource("${RP_TEST_CWD}/path", "src"))
+		assert.Equal(t, []string{filepath.Join(cwd, "path", "src")}, backupSource("${RP_TEST_CWD}/path", "src", false))
+	})
+	t.Run("change-relative-working-dir", func(t *testing.T) {
+		assert.Equal(t, []string{"."}, backupSource("path", ".", true))
+		assert.Equal(t, []string{filepath.Join("path", ".")}, backupSource("path", ".", false))
+	})
+	t.Run("change-env-var-working-dir", func(t *testing.T) {
+		assert.NoError(t, os.Setenv("RP_TEST_ENV", "."))
+		defer os.Unsetenv("RP_TEST_ENV")
+		assert.Equal(t, []string{"."}, backupSource("path", "${RP_TEST_ENV}", true))
 	})
 }
 

--- a/docs/content/configuration/path.md
+++ b/docs/content/configuration/path.md
@@ -101,7 +101,7 @@ default {
 {{% notice hint %}}
 Set `base-dir` to an absolute path to resolve `files` and `local:backup` relative to it.
 Set `source-base` if you need a separate base path for backup sources.
-To set the working directory for the `local:backup` command, use `change-working-dir`. Doing so means that the `source` will not be resolved to an absolute path in this context.
+When you want to use relative source paths for backup, set the `source-relative` option. This will change the working directory of the `restic backup` command to `source-base` and will not expand `source` to an absolute path.
 {{% /notice %}}
 
 ## How the configuration file is resolved

--- a/docs/content/configuration/path.md
+++ b/docs/content/configuration/path.md
@@ -101,6 +101,7 @@ default {
 {{% notice hint %}}
 Set `base-dir` to an absolute path to resolve `files` and `local:backup` relative to it.
 Set `source-base` if you need a separate base path for backup sources.
+To set the working directory for the `local:backup` command, use `change-working-dir`. Doing so means that the `source` will not be resolved to an absolute path in this context.
 {{% /notice %}}
 
 ## How the configuration file is resolved

--- a/shell/command.go
+++ b/shell/command.go
@@ -114,6 +114,8 @@ func (c *Command) Run() (monitor.Summary, string, error) {
 		cmd.Env = append(cmd.Env, c.Environ...)
 	}
 
+	cmd.Dir = c.Dir
+
 	start := time.Now()
 
 	// spawn the child process

--- a/shell/command_test.go
+++ b/shell/command_test.go
@@ -285,6 +285,23 @@ func TestSelectCustomShell(t *testing.T) {
 	assert.Empty(t, shell)
 }
 
+func TestRunShellWorkingDir(t *testing.T) {
+	buffer := &bytes.Buffer{}
+	cmd := NewCommand("pwd", nil)
+	cmd.Stdout = buffer
+	cmd.Dir = "/tmp"
+	_, _, err := cmd.Run()
+	if err != nil {
+		t.Fatal(err)
+	}
+	output, err := ioutil.ReadAll(buffer)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	assert.Contains(t, strings.TrimSpace(string(output)), "/tmp")
+}
+
 func TestRunShellEcho(t *testing.T) {
 	buffer := &bytes.Buffer{}
 	cmd := NewCommand("echo", []string{"TestRunShellEcho"})

--- a/shell/command_test.go
+++ b/shell/command_test.go
@@ -3,6 +3,7 @@ package shell
 import (
 	"bytes"
 	"fmt"
+	"github.com/creativeprojects/resticprofile/platform"
 	"io/ioutil"
 	"os"
 	"os/exec"
@@ -286,20 +287,23 @@ func TestSelectCustomShell(t *testing.T) {
 }
 
 func TestRunShellWorkingDir(t *testing.T) {
-	buffer := &bytes.Buffer{}
-	cmd := NewCommand("pwd", nil)
+	command := func() string {
+		if platform.IsWindows() {
+			return "(pwd).Path"
+		}
+		return "pwd"
+	}()
+	temp := t.TempDir()
+	buffer := new(strings.Builder)
+	cmd := NewCommand(command, nil)
 	cmd.Stdout = buffer
-	cmd.Dir = "/tmp"
+	cmd.Dir = temp
 	_, _, err := cmd.Run()
 	if err != nil {
 		t.Fatal(err)
 	}
-	output, err := ioutil.ReadAll(buffer)
-	if err != nil {
-		t.Fatal(err)
-	}
 
-	assert.Contains(t, strings.TrimSpace(string(output)), "/tmp")
+	assert.Contains(t, strings.TrimSpace(buffer.String()), temp)
 }
 
 func TestRunShellEcho(t *testing.T) {

--- a/shell/command_test.go
+++ b/shell/command_test.go
@@ -289,7 +289,7 @@ func TestSelectCustomShell(t *testing.T) {
 func TestRunShellWorkingDir(t *testing.T) {
 	command := func() string {
 		if platform.IsWindows() {
-			return "(pwd).Path"
+			return "@echo %CD%"
 		}
 		return "pwd"
 	}()

--- a/shell_command.go
+++ b/shell_command.go
@@ -18,6 +18,7 @@ type shellCommandDefinition struct {
 	publicArgs  []string
 	env         []string
 	shell       []string
+	dir         string
 	stdin       io.ReadCloser
 	stdout      io.Writer
 	stderr      io.Writer
@@ -84,6 +85,10 @@ func runShellCommand(command shellCommandDefinition) (summary monitor.Summary, s
 	if command.env != nil && len(command.env) > 0 {
 		shellCmd.Environ = append(shellCmd.Environ, command.env...)
 	}
+
+	// If Dir is the empty string, Run runs the command in the
+	// calling process's current directory.
+	shellCmd.Dir = command.dir
 
 	// scan output
 	if command.scanOutput != nil {

--- a/wrapper.go
+++ b/wrapper.go
@@ -366,8 +366,12 @@ func (r *resticWrapper) prepareCommand(command string, args *shell.Args, allowEx
 	args.AddArgs(moreArgs, shell.ArgCommandLineEscape)
 
 	// Special case for backup command
+	var dir string
 	if command == constants.CommandBackup {
 		args.AddArgs(r.profile.GetBackupSource(), shell.ArgConfigBackupSource)
+		if r.profile.Backup != nil {
+			dir = r.profile.Backup.SourceBase
+		}
 	}
 	// Special case for copy command
 	if command == constants.CommandCopy {
@@ -409,6 +413,7 @@ func (r *resticWrapper) prepareCommand(command string, args *shell.Args, allowEx
 	rCommand.stdout = term.GetOutput()
 	rCommand.stderr = term.GetErrorOutput()
 	rCommand.streamError = r.profile.StreamError
+	rCommand.dir = dir
 
 	return rCommand
 }

--- a/wrapper.go
+++ b/wrapper.go
@@ -369,7 +369,7 @@ func (r *resticWrapper) prepareCommand(command string, args *shell.Args, allowEx
 	var dir string
 	if command == constants.CommandBackup {
 		args.AddArgs(r.profile.GetBackupSource(), shell.ArgConfigBackupSource)
-		if r.profile.Backup != nil {
+		if r.profile.Backup != nil && r.profile.Backup.SourceRelative {
 			dir = r.profile.Backup.SourceBase
 		}
 	}


### PR DESCRIPTION
This PR introduces the `change-working-dir` option within the resticprofile configuration, enabling users to set a specific working directory for the restic backup command. This enhancement is particularly beneficial for users backing up Btrfs snapshots, where the ability to use relative paths is crucial. By utilizing relative paths, we can omit the snapshot path prefix in the restic repository, which significantly simplifies the restoration process from snapshots.

Prior to this change, resticprofile would always expand relative paths to absolute paths (e.g., converting `source: .` to its absolute path), and the `base-dir` setting was only modifiable at the profile level, affecting path resolution across different sections.

With the addition of the `change-working-dir` option, users now have the flexibility to ensure that the `source` paths are not expanded into absolute paths. This is achieved by changing the restic backup command's working directory to the one specified by `source-base`.

I'm relatively new to Golang, so if there's any aspect of my implementation that's incorrect or if I've overlooked anything, please do let me know. I appreciate your feedback and thank you in advance!