### PR TITLE
Relative source followup: Evaluate symlinks

### DIFF
--- a/config/path.go
+++ b/config/path.go
@@ -107,6 +107,21 @@ func absolutePath(value string) string {
 	return value
 }
 
+func evaluateSymlinks(value string) string {
+	suffix, name := "", "-"
+	for path := value; path != "" && name != ""; {
+		link := filepath.Clean(path)
+		path, name = filepath.Split(link)
+		if prefix, err := filepath.EvalSymlinks(link); err == nil {
+			return filepath.Join(prefix, suffix)
+		} else if !errors.Is(err, os.ErrNotExist) {
+			clog.Errorf("cannot evaluate symlinks for [%s]/%s: %s", link, suffix, err.Error())
+		}
+		suffix = filepath.Join(name, suffix)
+	}
+	return value
+}
+
 // resolveGlob evaluates glob expressions in a slice of paths and returns a resolved slice
 func resolveGlob(sources []string) (resolved []string) {
 	if len(sources) > 0 {

--- a/config/path_test.go
+++ b/config/path_test.go
@@ -7,12 +7,13 @@ import (
 	"runtime"
 	"testing"
 
+	"github.com/creativeprojects/resticprofile/platform"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
 func TestFixUnixPaths(t *testing.T) {
-	if runtime.GOOS == "windows" {
+	if platform.IsWindows() {
 		t.SkipNow()
 	}
 
@@ -95,4 +96,55 @@ func TestExpandEnv(t *testing.T) {
 	assert.Equal(t, "$PATH", expandEnv("$$PATH"))
 	assert.Equal(t, "", expandEnv("${__UNDEFINED_ENV_VAR__}"))
 	assert.Equal(t, "", expandEnv("$__UNDEFINED_ENV_VAR__"))
+}
+
+func TestEvalSymlinks(t *testing.T) {
+	if platform.IsWindows() {
+		t.SkipNow()
+	}
+
+	var rawDir, dir string
+	setup := func(t *testing.T) {
+		var err error
+		rawDir = t.TempDir()
+		dir, err = filepath.EvalSymlinks(rawDir)
+		require.NoError(t, err)
+	}
+
+	link := func(t *testing.T, path, linkname string) {
+		_ = os.Mkdir(filepath.Join(rawDir, path), 0700)
+		require.NoError(t, os.Symlink(filepath.Join(rawDir, path), filepath.Join(rawDir, linkname)))
+	}
+
+	t.Run("existing-target", func(t *testing.T) {
+		setup(t)
+		link(t, "a", "b")
+		assert.Equal(t, filepath.Join(dir, "a"), evaluateSymlinks(filepath.Join(rawDir, "b")))
+		assert.Equal(t, filepath.Join(dir, "a"), evaluateSymlinks(filepath.Join(rawDir, "a")))
+		assert.Equal(t, filepath.Join(dir, "a"), evaluateSymlinks(filepath.Join(dir, "a")))
+	})
+
+	t.Run("non-existing-target", func(t *testing.T) {
+		setup(t)
+		link(t, "a", "b")
+		assert.Equal(t, filepath.Join(dir, "a", "missing"), evaluateSymlinks(filepath.Join(rawDir, "b", "missing")))
+		assert.Equal(t, filepath.Join(dir, "missing/path"), evaluateSymlinks(filepath.Join(rawDir, "missing/path")))
+	})
+
+	t.Run("non-existing-targets", func(t *testing.T) {
+		setup(t)
+		link(t, "a", "b")
+		assert.Equal(t, filepath.Join(dir, "a/mis/s/ing"), evaluateSymlinks(filepath.Join(rawDir, "b/mis/s/ing")))
+	})
+
+	t.Run("nested", func(t *testing.T) {
+		setup(t)
+		link(t, "a", "b")
+		link(t, "d", "c")
+		link(t, "a/nested", "b/c")
+		link(t, "d", "b/c/toD")
+		assert.Equal(t, filepath.Join(dir, "a/nested"), evaluateSymlinks(filepath.Join(rawDir, "b/c")))
+		assert.Equal(t, filepath.Join(dir, "d"), evaluateSymlinks(filepath.Join(rawDir, "b/c/toD")))
+		assert.Equal(t, filepath.Join(dir, "d"), evaluateSymlinks(filepath.Join(rawDir, "a/nested/toD")))
+	})
 }

--- a/config/profile.go
+++ b/config/profile.go
@@ -707,7 +707,7 @@ func (p *Profile) SetTag(tags ...string) {
 
 // SetPath will replace any path value from a boolean to sourcePaths and change paths to absolute
 func (p *Profile) SetPath(basePath string, sourcePaths ...string) {
-	hasAbsoluteBase := len(p.BaseDir) > 0 && filepath.IsAbs(p.BaseDir) || basePath != "" && filepath.IsAbs(basePath)
+	hasAbsoluteBase := filepath.IsAbs(p.BaseDir) || filepath.IsAbs(basePath)
 
 	resolvePath := func(origin string, paths []string, revolver func(string) []string) (resolved []string) {
 		for _, path := range paths {

--- a/shell/command_test.go
+++ b/shell/command_test.go
@@ -3,7 +3,6 @@ package shell
 import (
 	"bytes"
 	"fmt"
-	"github.com/creativeprojects/resticprofile/platform"
 	"io/ioutil"
 	"os"
 	"os/exec"
@@ -16,6 +15,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/creativeprojects/resticprofile/platform"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )

--- a/wrapper.go
+++ b/wrapper.go
@@ -406,7 +406,14 @@ func (r *resticWrapper) prepareCommand(command string, args *shell.Args, allowEx
 	env := r.getEnvironment(true)
 	env = append(env, r.getProfileEnvironment()...)
 
-	clog.Debugf("starting command: %s %s", r.ctx.binary, strings.Join(publicArguments, " "))
+	clog.Debug(func() string {
+		wd := ""
+		if dir != "" {
+			wd = fmt.Sprintf(" (in %s)", dir)
+		}
+		return fmt.Sprintf("starting command: %s %s%s", r.ctx.binary, strings.Join(publicArguments, " "), wd)
+	})
+
 	rCommand := newShellCommand(r.ctx.binary, arguments, env, r.getShell(), r.dryRun, r.sigChan, r.setPID)
 	rCommand.publicArgs = publicArguments
 	// stdout are stderr are coming from the default terminal (in case they're redirected)


### PR DESCRIPTION
Followup for #354 (marked as draft since this PR depends on it and needs a rebase before it can be merged)

Explanation: restic resolves symlinks when it sees relative paths as backup source. Therefore resticprofile must behave the same so that `--path` arguments match the paths recorded in snapshots.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Added functionality to iteratively evaluate symlinks in paths, improving path resolution accuracy.
- **Bug Fixes**
	- Enhanced symlink evaluation logic for relative paths under specific conditions.
- **Refactor**
	- Updated import statements to use a more robust platform check.
	- Refactored conditions related to path setting for clarity and efficiency.
- **Tests**
	- Introduced tests for the new symlink evaluation functionality.
- **Documentation**
	- Improved logging of command starts with additional directory information, aiding in debugging and monitoring.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->