### PR TITLE
Update test to pass on Windows 11

### DIFF
--- a/docs/content/configuration/priority.md
+++ b/docs/content/configuration/priority.md
@@ -1,5 +1,6 @@
 ---
 title: "Priority"
+tags: ["v0.27.0"]
 weight: 35
 ---
 
@@ -11,18 +12,27 @@ You can lower the priority of restic to avoid slowing down other processes. This
 
 You can use these values for the `priority` parameter:
 
-| String value | "nice" equivalent on unixes |
-|-------|-------------------|
-| Idle       | 19 |
-| Background | 15 |
-| Low        | 10 |
-| Normal     | 0 |
-| High       | -10 |
-| Highest    | -20 |
+| String value | "nice" equivalent on unixes | Notes |
+|--------------|-----------------------------|------|
+| Idle         | 19 | |
+| Background [^background]   | 15 | **This mode is NOT recommended on Windows 11 [^background]** |
+| Low          | 10 | |
+| Normal       | 0 | Default priority when unspecified |
+| High         | -10 | |
+| Highest      | -20 | |
+
+[^background]: It seems that the implementation of the background mode is broken in Windows 11. Even though undocumented, it is widely reported that the process has a limit of 32MB of memory. Please use `Idle` or `Low` on Windows 11.
 
 ## IO Nice
 
-This setting is only available on Linux. It allows you to set the IO priority of restic.
+This setting is only available on Linux. It allows you to set the disks IO priority of restic.
+
+{{% notice style="info" %}}
+
+This setting is only affecting access to local disks. It has no effect on any network access.
+
+{{% /notice %}}
+
 More information about ionice "class" and "level" can be found [here](https://linux.die.net/man/1/ionice).
 
 ## Examples
@@ -76,7 +86,7 @@ global {
 
 ## Warnings
 
-In some cases, resticprofile will not be able to set the priority of restic.
+In some cases (mostly before version `v0.27.0`), resticprofile won't be able to set the priority of restic.
 
 A warning message like this will be displayed:
 
@@ -84,7 +94,8 @@ A warning message like this will be displayed:
 cannot set process group priority, restic will run with the default priority: operation not permitted
 ```
 
-This usually means:
+This either means:
 - resticprofile is running inside docker
 - you are using a tight security linux distribution which is launching every process inside a new container
 - resticprofile is running in WSL
+- you're running an older version of resticprofile (< `v0.27.0`)

--- a/priority/prority_test.go
+++ b/priority/prority_test.go
@@ -12,8 +12,6 @@ import (
 )
 
 func TestStartProcessWithPriority(t *testing.T) {
-
-	// Run these 3 tests inside one test, so we don't have any concurrency issue
 	t.Run("WithNormalPriority", func(t *testing.T) {
 		err := SetClass(Normal)
 		if err != nil {
@@ -52,8 +50,8 @@ func TestStartProcessWithPriority(t *testing.T) {
 	})
 	time.Sleep(30 * time.Millisecond)
 
-	t.Run("WithBackgroundPriority", func(t *testing.T) {
-		err := SetClass(Background)
+	t.Run("WithIdlePriority", func(t *testing.T) {
+		err := SetClass(Idle)
 		if err != nil {
 			t.Error(err)
 		}
@@ -66,7 +64,7 @@ func TestStartProcessWithPriority(t *testing.T) {
 		if platform.IsWindows() {
 			assert.Contains(t, output, "Priority class: IDLE")
 		} else {
-			assert.Contains(t, output, "Process Priority: 15")
+			assert.Contains(t, output, "Process Priority: 19")
 		}
 	})
 	time.Sleep(30 * time.Millisecond)


### PR DESCRIPTION
- Update test to pass on Windows 11
- Change documentation to discourage the use of background mode on Windows 11
