### PR TITLE
fix regression with temporary log file

### DIFF
--- a/dial/url.go
+++ b/dial/url.go
@@ -46,5 +46,5 @@ func IsSupportedURL(source string) bool {
 // IsURL is true if the provided source is a parsable URL and no file path
 func IsURL(source string) bool {
 	u, e := url.Parse(source)
-	return e == nil && len(u.Scheme) > 1
+	return e == nil && len(u.Scheme) > 1 && u.Scheme != "temp"
 }

--- a/dial/url_test.go
+++ b/dial/url_test.go
@@ -47,6 +47,7 @@ func TestGetDialAddr(t *testing.T) {
 		{"/file", "", "", false},
 		{"path/file", "", "", false},
 		{"/root/file", "", "", false},
+		{"temp:/t/backup.log", "", "", false},
 	}
 
 	for _, fixture := range fixtures {
@@ -66,5 +67,6 @@ func TestIsUrl(t *testing.T) {
 	assert.True(t, dial.IsURL("ftp://"))
 	assert.True(t, dial.IsURL("http://"))
 	assert.False(t, dial.IsURL("c://"))
+	assert.False(t, dial.IsURL("temp:/t/backup.log"))
 	assert.False(t, dial.IsURL(""))
 }

--- a/examples/linux.yaml
+++ b/examples/linux.yaml
@@ -1,9 +1,13 @@
+# yaml-language-server: $schema=https://creativeprojects.github.io/resticprofile/jsonschema/config-1.json
+
+version: "1"
+
 global:
     default-command: version
     initialize: false
     priority: low
     systemd-unit-template: sample.service
-    prevent-sleep: true
+    prevent-sleep: false
 
 default:
     password-file: key
@@ -60,6 +64,19 @@ test2:
         schedule: "*-*-2"
         schedule-permission: system
         schedule-log: check-test2.log
+
+test3:
+    inherit: default
+    initialize: true
+    verbose: true
+    backup:
+        source: ./
+        exclude: .git
+        schedule: "*:05,20,35,50"
+        schedule-permission: user
+        schedule-log: '{{ tempFile "backup.log" }}'
+        run-finally:
+            - 'grep --invert-match -E "^unchanged\\s" {{ tempFile "backup.log" }} > /tmp/backup-{{ .Profile.Name }}-{{ .Now.Format "2006-01-02_15-04" }}.log'
 
 longrun:
     inherit: default


### PR DESCRIPTION
Temporary session log file (starting with `temp:`) was incorrectly recognised as a URL and it was trying to redirect logs to a syslog handler.

Fixes #385 