### PR TITLE
fix bullet points from restic man page

### DIFF
--- a/restic/commands.json
+++ b/restic/commands.json
@@ -518,7 +518,7 @@
   },
   {
     "Name": "diff",
-    "Description": "The \"diff\" command shows differences from the first to the second snapshot. The\nfirst characters in each line display what has happened to a particular file or\ndirectory:\n\n+  The item was added\n-  The item was removed\nU  The metadata (access mode, timestamps, ...) for the item was updated\nM  The file's content was modified\nT  The type was changed, e.g. a file was made a symlink\n?  Bitrot detected: The file's content has changed but all metadata is the same\n\n\nMetadata comparison will likely not work if a backup was created using the\n\u0026'--ignore-inode' or '--ignore-ctime' option.\n\nTo only compare files in specific subfolders, you can use the\n\"snapshotID:subfolder\" syntax, where \"subfolder\" is a path within the\nsnapshot.",
+    "Description": "The \"diff\" command shows differences from the first to the second snapshot. The\nfirst characters in each line display what has happened to a particular file or\ndirectory:\n\n* `+` The item was added\n* `-` The item was removed\n* `U` The metadata (access mode, timestamps, ...) for the item was updated\n* `M` The file's content was modified\n* `T` The type was changed, e.g. a file was made a symlink\n* `?` Bitrot detected: The file's content has changed but all metadata is the same\n\n\nMetadata comparison will likely not work if a backup was created using the\n'--ignore-inode' or '--ignore-ctime' option.\n\nTo only compare files in specific subfolders, you can use the\n\"snapshotID:subfolder\" syntax, where \"subfolder\" is a path within the\nsnapshot.",
     "FromVersion": "",
     "RemovedInVersion": "",
     "Options": [
@@ -2238,7 +2238,7 @@
   },
   {
     "Name": "stats",
-    "Description": "The \"stats\" command walks one or multiple snapshots in a repository\nand accumulates statistics about the data stored therein. It reports\non the number of unique files and their sizes, according to one of\nthe counting modes as given by the --mode flag.\n\nIt operates on all snapshots matching the selection criteria or all\nsnapshots if nothing is specified. The special snapshot ID \"latest\"\nis also supported. Some modes make more sense over\njust a single snapshot, while others are useful across all snapshots,\ndepending on what you are trying to calculate.\n\nThe modes are:\n\nrestore-size: (default) Counts the size of the restored files.\nfiles-by-contents: Counts total size of unique files, where a file is\nconsidered unique if it has unique contents.\nraw-data: Counts the size of blobs in the repository, regardless of\nhow many files reference them.\nblobs-per-file: A combination of files-by-contents and raw-data.\n\n\nRefer to the online manual for more details about each mode.",
+    "Description": "The \"stats\" command walks one or multiple snapshots in a repository\nand accumulates statistics about the data stored therein. It reports\non the number of unique files and their sizes, according to one of\nthe counting modes as given by the --mode flag.\n\nIt operates on all snapshots matching the selection criteria or all\nsnapshots if nothing is specified. The special snapshot ID \"latest\"\nis also supported. Some modes make more sense over\njust a single snapshot, while others are useful across all snapshots,\ndepending on what you are trying to calculate.\n\nThe modes are:\n\n* restore-size: (default) Counts the size of the restored files.\n* files-by-contents: Counts total size of unique files, where a file is\nconsidered unique if it has unique contents.\n* raw-data: Counts the size of blobs in the repository, regardless of\nhow many files reference them.\n* blobs-per-file: A combination of files-by-contents and raw-data.\n\n\nRefer to the online manual for more details about each mode.",
     "FromVersion": "",
     "RemovedInVersion": "",
     "Options": [
@@ -2422,7 +2422,7 @@
         "Name": "cache-dir",
         "Alias": "",
         "Default": "\"\"",
-        "Description": "set the cache directory\u0026. (default: use system default cache directory)",
+        "Description": "set the cache directory. (default: use system default cache directory)",
         "Once": true,
         "FromVersion": "",
         "RemovedInVersion": ""

--- a/restic/commands_test.go
+++ b/restic/commands_test.go
@@ -103,6 +103,16 @@ Next paragraph
 		},
 
 		{
+			name: "parse description with dummy escape sequence",
+			source: `
+.SH DESCRIPTION
+.PP
+Metadata comparison will likely not work if a backup was created using the
+\&'--ignore-inode' or '--ignore-ctime' option.`,
+			validation: descriptionIs("Metadata comparison will likely not work if a backup was created using the\n'--ignore-inode' or '--ignore-ctime' option."),
+		},
+
+		{
 			name: "merge description sections",
 			source: `
 .SH DESCRIPTION
@@ -128,6 +138,28 @@ Second Line`,
 		},
 
 		{
+			name: "parse a list of flags for the diff command",
+			source: `
+.SH DESCRIPTION
+.RS
+.IP \(bu 2
++  added
+.IP \(bu 2
+-  removed
+.IP \(bu 2
+U  updated
+.IP \(bu 2
+M  modified
+.IP \(bu 2
+T  type changed
+.IP \(bu 2
+?  bitrot
+
+.RE`,
+			validation: descriptionIs("* `+` added\n* `-` removed\n* `U` updated\n* `M` modified\n* `T` type changed\n* `?` bitrot"),
+		},
+
+		{
 			name: "parse option",
 			source: `
 .SH DESCRIPTION
@@ -149,6 +181,30 @@ Desc 2
 					"copy-chunker-params",
 					"copy chunker parameters from the secondary repository (useful with the copy command)",
 					"false",
+					true,
+				),
+			),
+		},
+
+		{
+			name: "parse option with double backticks bug",
+			source: `
+.SH DESCRIPTION
+.PP
+Desc
+
+.SH OPTIONS
+.PP
+\fB-v\fP, \fB--verbose\fP[=0]
+	be verbose (specify multiple times or a level using --verbose=n` + "``" + `, max level/times is 2)
+
+`,
+			validation: all(
+				descriptionIs("Desc"),
+				optionIs(
+					"verbose",
+					"be verbose (specify multiple times or a level using --verbose=n, max level/times is 2)",
+					"0",
 					true,
 				),
 			),


### PR DESCRIPTION
The documentation parser was missing the groff sequence displaying bullet points.

Example on the `stats` command help:

before
```
The modes are:

restore-size: (default) Counts the size of the restored files. files-by-contents: Counts total size of unique files, where a file is considered unique if it has unique contents. raw-data: Counts the size of blobs in the repository, regardless of how many files reference them. blobs-per-file: A combination of files-by-contents and raw-data.
```

after
```
The modes are:

- restore-size: (default) Counts the size of the restored files.
- files-by-contents: Counts total size of unique files, where a file is considered unique if it has unique contents.
- raw-data: Counts the size of blobs in the repository, regardless of how many files reference them.
- blobs-per-file: A combination of files-by-contents and raw-data.
```
