### PR TITLE
[Docs] Correct configuration search paths on Windows

### DIFF
--- a/docs/content/configuration/path.md
+++ b/docs/content/configuration/path.md
@@ -153,8 +153,12 @@ resticprofile will search for your configuration file in these folders:
 
 resticprofile will search for your configuration file in these folders:
 - _current directory_
-- %USERPROFILE%\AppData\Local\
-- c:\ProgramData\
+- %USERPROFILE%\AppData\Local\resticprofile
+- %USERPROFILE%\AppData\Roaming\resticprofile
+- c:\ProgramData\resticprofile
 - c:\restic\
 - c:\resticprofile\
-- %USERPROFILE%\
+- %USERPROFILE%\resticprofile
+
+These paths may be overridden by setting the `XDG_CONFIG_HOME` or `XDG_CONFIG_DIRS`
+environment variables.


### PR DESCRIPTION
Append `resticprofile` to the AppData and ProgramData paths on Windows.

See https://github.com/creativeprojects/resticprofile/blob/ac3b810f2f735642d0a0cea8ec46c585b80904bc/filesearch/filesearch.go#L224, resticprofile adds its AppName to the config dir paths.

Also add `%USERPROFILE%\AppData\Roaming\resticprofile`, which should be included in the paths returned by `xdg.ConfigDirs` (see https://github.com/adrg/xdg/blob/d8917aeea69ad0645ce98b2a1e3edb5cab67199a/paths_windows.go#L22).

Finally, I added a note to clarify that these paths can be overridden if the XDG environment variables are set.