### PR TITLE
Add copy from repository in configuration

### DIFF
--- a/config/profile.go
+++ b/config/profile.go
@@ -349,7 +349,7 @@ type CopySection struct {
 	GenericSectionWithSchedule  `mapstructure:",squash"`
 	Initialize                  bool              `mapstructure:"initialize" description:"Initialize the secondary repository if missing"`
 	InitializeCopyChunkerParams maybe.Bool        `mapstructure:"initialize-copy-chunker-params" default:"true" description:"Copy chunker parameters when initializing the secondary repository"`
-	FromRepository              ConfidentialValue `mapstructure:"from-repo" argument:"from-repo" description:"Source repository to copy snapshots from"`
+	FromRepository              ConfidentialValue `mapstructure:"from-repository" argument:"from-repo" description:"Source repository to copy snapshots from"`
 	FromRepositoryFile          string            `mapstructure:"from-repository-file" argument:"from-repository-file" description:"File from which to read the source repository location to copy snapshots from"`
 	FromPasswordFile            string            `mapstructure:"from-password-file" argument:"from-password-file" description:"File to read the source repository password from"`
 	FromPasswordCommand         string            `mapstructure:"from-password-command" argument:"from-password-command" description:"Shell command to obtain the source repository password from"`

--- a/wrapper_test.go
+++ b/wrapper_test.go
@@ -1630,8 +1630,8 @@ func TestRunInitCopyCommand(t *testing.T) {
 			PasswordFile: "password_origin",
 			Copy: &config.CopySection{
 				InitializeCopyChunkerParams: copyChunkerParams,
-				Repository:                  config.NewConfidentialValue("repo_copy"),
-				PasswordFile:                "password_copy",
+				ToRepository:                config.NewConfidentialValue("repo_copy"),
+				ToPasswordFile:              "password_copy",
 			},
 		}
 		require.NoError(t, p.SetResticVersion(resticVersion))


### PR DESCRIPTION
Fix the copy command so that `from-repository` and `from-repository-file` works like they work with restic alone. That means
```yaml
version: 2
profile:
  repository: r1
  ...
  copy:
    from-repository: r2
    ...
```
copies from repository `r2` to `r1` and not in the opposite direction, like it does now. That means the repository mentioned directly below `profile` (`r1`) is the destination similar to `backup`. The special case without the "from"-prefix mention in the docs works like before.

As a bonus the retention section can allow  `before-copy` and `after-copy` analog to `before-backup` and `after-backup`. This will be reserved for a future PR.