### PR TITLE
add version of restic to the Prometheus metrics

### DIFF
--- a/monitor/prom/metrics_test.go
+++ b/monitor/prom/metrics_test.go
@@ -10,7 +10,7 @@ import (
 )
 
 func TestSaveSingleBackup(t *testing.T) {
-	p := NewMetrics("test", "", "", nil)
+	p := NewMetrics("test", "", "", "", nil)
 	p.BackupResults(StatusSuccess, monitor.Summary{
 		Duration:   11 * time.Second,
 		BytesAdded: 100,
@@ -21,7 +21,7 @@ func TestSaveSingleBackup(t *testing.T) {
 }
 
 func TestSaveSingleBackupWithConfigLabel(t *testing.T) {
-	p := NewMetrics("test", "", "", map[string]string{"test_label": "test_value"})
+	p := NewMetrics("test", "", "", "", map[string]string{"test_label": "test_value"})
 	p.BackupResults(StatusSuccess, monitor.Summary{
 		Duration:   11 * time.Second,
 		BytesAdded: 100,
@@ -32,7 +32,7 @@ func TestSaveSingleBackupWithConfigLabel(t *testing.T) {
 }
 
 func TestSaveBackupGroup(t *testing.T) {
-	p := NewMetrics("test", "group", "", nil)
+	p := NewMetrics("test", "group", "", "", nil)
 	p.BackupResults(StatusSuccess, monitor.Summary{
 		Duration:   11 * time.Second,
 		BytesAdded: 100,

--- a/run_profile.go
+++ b/run_profile.go
@@ -193,7 +193,7 @@ func runProfile(ctx *Context) error {
 		wrapper.addProgress(status.NewProgress(profile, status.NewStatus(profile.StatusFile)))
 	}
 	if profile.PrometheusPush != "" || profile.PrometheusSaveToFile != "" {
-		wrapper.addProgress(prom.NewProgress(profile, prom.NewMetrics(profile.Name, ctx.request.group, version, profile.PrometheusLabels)))
+		wrapper.addProgress(prom.NewProgress(profile, prom.NewMetrics(profile.Name, ctx.request.group, version, ctx.global.ResticVersion, profile.PrometheusLabels)))
 	}
 
 	err = wrapper.runProfile()


### PR DESCRIPTION
Add the restic version as a new label to the existing metric `resticprofile_build_info`.

This allows tracking the versions of both restic and resticprofile: PromQL can be used to identify outdated installations.

I'm not an experienced developer in Go, so there might be better ways to solve this.

Adding the new metric `restic_build_info` failed for unknown reasons (the metric didn't show up in the output file).

refs #485