### PR TITLE
add support for windows only flag exclude-cloud-files

### DIFF
--- a/restic/commands_test.go
+++ b/restic/commands_test.go
@@ -563,10 +563,21 @@ func TestBuiltInCommandsTable(t *testing.T) {
 		assert.GreaterOrEqual(t, len(GetDefaultOptions()), len(expectedOptions))
 	})
 
-	t.Run("windows specific option", func(t *testing.T) {
+	t.Run("windows specific option use-fs-snapshot", func(t *testing.T) {
 		cmd, _ := GetCommandForVersion("backup", "0.12", false)
 		require.NotNil(t, cmd)
 		option, found := cmd.Lookup("use-fs-snapshot")
+		require.True(t, found)
+
+		assert.False(t, option.AvailableInOS("linux"))
+		assert.False(t, option.AvailableInOS("darwin"))
+		assert.True(t, option.AvailableInOS("windows"))
+	})
+
+	t.Run("windows specific option exclude-cloud-files", func(t *testing.T) {
+		cmd, _ := GetCommandForVersion("backup", "0.18", false)
+		require.NotNil(t, cmd)
+		option, found := cmd.Lookup("exclude-cloud-files")
 		require.True(t, found)
 
 		assert.False(t, option.AvailableInOS("linux"))

--- a/restic/commands_windows.json
+++ b/restic/commands_windows.json
@@ -8,6 +8,15 @@
       "Once": true,
       "FromVersion": "0.12.0",
       "RemovedInVersion": ""
+    },
+    {
+      "Name": "exclude-cloud-files",
+      "Alias": "",
+      "Default": "false",
+      "Description": "excludes online-only cloud files (such as OneDrive Files On-Demand)",
+      "Once": true,
+      "FromVersion": "0.18.0",
+      "RemovedInVersion": ""
     }
   ]
 }


### PR DESCRIPTION
add support for windows only flag `exclude-cloud-files`

Fixes #499 