### PR TITLE
linux: don't resolve symlink on executable

### DIFF
--- a/commands_display.go
+++ b/commands_display.go
@@ -16,6 +16,7 @@ import (
 	"github.com/creativeprojects/resticprofile/filesearch"
 	"github.com/creativeprojects/resticprofile/shell"
 	"github.com/creativeprojects/resticprofile/term"
+	"github.com/creativeprojects/resticprofile/util"
 	"github.com/creativeprojects/resticprofile/util/collect"
 	"github.com/fatih/color"
 	colorable "github.com/mattn/go-colorable"
@@ -258,7 +259,12 @@ func displayVersion(output io.Writer, ctx commandContext) error {
 	// allow for the general verbose flag, or specified after the command
 	arguments := ctx.request.arguments
 	if ctx.flags.verbose || (len(arguments) > 0 && (arguments[0] == "-v" || arguments[0] == "--verbose")) {
+		executablePath, err := util.Executable()
+		if err != nil {
+			executablePath = "unknown"
+		}
 		out("\n")
+		out("\t%s:\t%s\n", "executable", executablePath)
 		out("\t%s:\t%s\n", "home", "https://github.com/creativeprojects/resticprofile")
 		out("\t%s:\t%s\n", "version", version)
 		out("\t%s:\t%s\n", "commit", commit)

--- a/schedule_jobs.go
+++ b/schedule_jobs.go
@@ -8,6 +8,7 @@ import (
 	"github.com/creativeprojects/clog"
 	"github.com/creativeprojects/resticprofile/config"
 	"github.com/creativeprojects/resticprofile/schedule"
+	"github.com/creativeprojects/resticprofile/util"
 )
 
 func scheduleJobs(handler schedule.Handler, configs []*config.Schedule) error {
@@ -15,7 +16,7 @@ func scheduleJobs(handler schedule.Handler, configs []*config.Schedule) error {
 	if err != nil {
 		return err
 	}
-	binary, err := os.Executable()
+	binary, err := util.Executable()
 	if err != nil {
 		return err
 	}

--- a/util/executable.go
+++ b/util/executable.go
@@ -1,0 +1,12 @@
+//go:build !linux
+
+package util
+
+import "os"
+
+// Executable returns the path name for the executable that started the current process.
+// On non-Linux systems, it behaves like os.Executable.
+// On Linux, it returns the path to the executable as specified in the command line arguments.
+func Executable() (string, error) {
+	return os.Executable()
+}

--- a/util/executable_linux.go
+++ b/util/executable_linux.go
@@ -1,0 +1,28 @@
+//go:build linux
+
+package util
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+)
+
+// Executable returns the path name for the executable that started the current process.
+// On non-Linux systems, it behaves like os.Executable.
+// On Linux, it returns the path to the executable as specified in the command line arguments.
+func Executable() (string, error) {
+	executable := os.Args[0]
+	if len(executable) == 0 {
+		return "", errors.New("executable path is empty")
+	}
+	if executable[0] != '/' {
+		wd, err := os.Getwd()
+		if err != nil {
+			return "", err
+		}
+		// If the executable path is relative, prepend the current working directory to form an absolute path.
+		executable = filepath.Join(wd, executable)
+	}
+	return executable, nil
+}

--- a/util/executable_test.go
+++ b/util/executable_test.go
@@ -1,0 +1,17 @@
+package util
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestExecutableIsAbsolute(t *testing.T) {
+	executable, err := Executable()
+	require.NoError(t, err)
+	assert.NotEmpty(t, executable)
+
+	assert.True(t, filepath.IsAbs(executable))
+}


### PR DESCRIPTION
Linux fix only:
Don't resolve symlink on executable to keep a constant name (the physical path of the binary might change for each version)

Fixes #490 