### PR TITLE
[Docs] Add ~/.config/resticprofile/ to macOS default paths

### DIFF
--- a/docs/content/configuration/path.md
+++ b/docs/content/configuration/path.md
@@ -119,6 +119,7 @@ If you set a filename with no extension instead, resticprofile will load the fir
 
 resticprofile will search for your configuration file in these folders:
 - _current directory_
+- ~/.config/resticprofile/
 - ~/Library/Preferences/resticprofile/
 - /Library/Preferences/resticprofile/
 - /usr/local/etc/


### PR DESCRIPTION
As added by #370