### PR TITLE
Add "randInt" template function for random number

### DIFF
--- a/docs/content/configuration/templates.md
+++ b/docs/content/configuration/templates.md
@@ -600,6 +600,9 @@ resticprofile supports the following set of own functions in all templates:
 * `{{ tempDir }}` => `/tmp/resticprofile.../t` - unique OS specific existing temporary directory
 * `{{ tempFile "filename" }}` => `/tmp/resticprofile.../t/filename` - unique OS specific existing temporary file
 * `{{ env }}` => `/tmp/resticprofile.../t/profile.env` - unique OS specific existing temporary file that is added to the current profile env-files list
+* `{{ "seed" | randInt low high }}` => `123` -
+  Generate a random number greater than or equal to `low` and less than `high`,
+  using the value of `seed` for repeatable randomness.
 
 All `{{ temp* }}` functions guarantee that returned temporary directories and files are existing & writable. 
 When resticprofile ends, temporary directories and files are removed.

--- a/util/templates/functions_test.go
+++ b/util/templates/functions_test.go
@@ -59,6 +59,10 @@ func TestTemplateFuncs(t *testing.T) {
 		{template: `{{ "plain" | hex }}`, expected: "706c61696e"},
 		{template: `{{ "plain" | base64 }}`, expected: "cGxhaW4="},
 		{template: `{{ hello }}`, expected: `Hello World`},
+		{template: `{{ "" | randInt 0 1 }}`, expected: `0`},
+		{template: `{{ "hello" | randInt 5 6 }}`, expected: `5`},
+		{template: `{{ "" | randInt -1000 1000 }}`, expected: `419`},
+		{template: `{{ "ABC" | randInt -1000 1000 }}`, expected: `-272`},
 	}
 
 	extraFuncs := map[string]any{


### PR DESCRIPTION
The `randInt` function added by this change returns a pseudo-random number in a given range and using a seed for repeatable randomness. It can be used, for example, in cron schedules to pick a minute offset based on an environment variable (e.g. hostname).