### PR TITLE
update SonarCloud trigger condition to check for SONAR_TOKEN presence

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -74,7 +74,6 @@ jobs:
   sonarCloudTrigger:
     needs: build
     name: SonarCloud Trigger
-    if: github.repository == 'creativeprojects/resticprofile'
     runs-on: ubuntu-latest
     steps:
       - name: Clone Repository
@@ -91,6 +90,7 @@ jobs:
 
       - name: Analyze with SonarCloud
         uses: SonarSource/sonarqube-scan-action@v5
+        if: ${{ env.SONAR_TOKEN != '' }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}


### PR DESCRIPTION
Update SonarCloud trigger condition to check for SONAR_TOKEN presence to avoid failed step during a Pull Request from a fork.