### PR TITLE
read task info from list format instead of CSV

### DIFF
--- a/config/profile_test.go
+++ b/config/profile_test.go
@@ -825,7 +825,6 @@ func TestPathAndTagInRetention(t *testing.T) {
 
 		t.Run("ImplicitCopyPath", func(t *testing.T) {
 			profile := testProfile(t, Version01, ``)
-			t.Log(profile)
 			assert.Equal(t, expectedBackupSource, pathFlag(t, profile))
 		})
 

--- a/config/profile_test.go
+++ b/config/profile_test.go
@@ -708,6 +708,11 @@ func TestPathAndTagInRetention(t *testing.T) {
 	require.Greater(t, len(backupSource), 5)
 	require.NoError(t, err)
 
+	expectedBackupSource := make([]string, len(backupSource))
+	for index, value := range backupSource {
+		expectedBackupSource[index] = shell.NewArg(value, shell.ArgConfigEscape).String()
+	}
+
 	backupHost := ""
 	backupTags := []string{"one", "two"}
 	flatBackupTags := func() []string { return []string{strings.Join(backupTags, ",")} }
@@ -820,7 +825,8 @@ func TestPathAndTagInRetention(t *testing.T) {
 
 		t.Run("ImplicitCopyPath", func(t *testing.T) {
 			profile := testProfile(t, Version01, ``)
-			assert.Equal(t, backupSource, pathFlag(t, profile))
+			t.Log(profile)
+			assert.Equal(t, expectedBackupSource, pathFlag(t, profile))
 		})
 
 		t.Run("ExplicitCopyPath", func(t *testing.T) {
@@ -828,7 +834,7 @@ func TestPathAndTagInRetention(t *testing.T) {
 				`path (from source) "` + sourcePattern + `"`: backupSource,
 			}
 			profile := testProfile(t, Version01, `path = true`)
-			assert.Equal(t, backupSource, pathFlag(t, profile))
+			assert.Equal(t, expectedBackupSource, pathFlag(t, profile))
 			assert.Equal(t, expectedIssues, profile.config.issues.changedPaths)
 
 			profile.config.DisplayConfigurationIssues()

--- a/examples/other windows.yaml
+++ b/examples/other windows.yaml
@@ -1,0 +1,33 @@
+# yaml-language-server: $schema=https://creativeprojects.github.io/resticprofile/jsonschema/config.json
+
+version: "1"
+
+global:
+    priority: low
+    min-memory: 10
+    prevent-sleep: true
+
+
+default:
+    repository: "c:\\backup"
+    password-file: key
+    lock: "c:\\resticprofile-{{ .Profile.Name }}.lock"
+
+self:
+    inherit: default
+    verbose: true
+    force-inactive-lock: true
+    status-file: "c:\\backup\\status.json"
+    backup:
+        source: "."
+        exclude:
+            - "*.exe"
+            - "resticprofile_*"
+            - ".git"
+            - "examples\\private"
+        schedule:
+            at:
+                - "Mon..Fri *:00,15,30,45" # every 15 minutes on weekdays
+                - "Sat,Sun 0,12:00"        # twice a day on week-ends
+            permission: user_logged_on
+            log: "self-backup.log"

--- a/schtasks/list.go
+++ b/schtasks/list.go
@@ -1,0 +1,72 @@
+//go:build windows
+
+package schtasks
+
+import (
+	"bufio"
+	"errors"
+	"io"
+	"strings"
+)
+
+const (
+	commonListSeparator = ":  "
+	otherListSeparator  = ": "
+	listFolderKey       = "Folder"
+)
+
+func getTaskInfoFromList(input io.Reader) ([]map[string]string, error) {
+	currentFolder := ""
+	output := make([]map[string]string, 0, 10)
+	record := make(map[string]string, 30)
+	scanner := bufio.NewScanner(input)
+	for scanner.Scan() {
+		line := scanner.Text()
+		if len(line) == 0 {
+			if len(record) > 0 {
+				record[listFolderKey] = currentFolder
+				output = append(output, record)
+				record = make(map[string]string, 30)
+			}
+			continue
+		}
+		key, value, found := strings.Cut(line, commonListSeparator)
+		if !found {
+			// if the line doesn't contain a colon followed by 2 spaces, it means it's either "Folder:" or the longest key.
+			key, value, found = strings.Cut(line, otherListSeparator)
+			if !found {
+				return output, errors.New("invalid line format: " + line)
+			}
+		}
+		key = strings.TrimSpace(key)
+		value = strings.TrimSpace(value)
+		if len(key) == 0 || len(value) == 0 {
+			continue
+		}
+		if key == listFolderKey {
+			currentFolder = value
+			continue
+		}
+		if _, exists := record[key]; exists {
+			return output, errors.New("duplicate key found in task info: " + key)
+		}
+		record[key] = value
+	}
+	if err := scanner.Err(); err != nil {
+		return output, err
+	}
+	if len(record) > 0 {
+		record[listFolderKey] = currentFolder
+		output = append(output, record)
+	}
+	return output, nil
+}
+
+func getFirstField(data []map[string]string, fieldName string) string {
+	for _, record := range data {
+		if value, exists := record[fieldName]; exists {
+			return value
+		}
+	}
+	return ""
+}

--- a/schtasks/list_test.go
+++ b/schtasks/list_test.go
@@ -20,9 +20,9 @@ Logon Mode:                           Interactive only
 Last Run Time:                        04/08/2025 21:00:01
 Last Result:                          1
 Author:                               resticprofile
-Task To Run:                          G:\go\src\github.com\creativeprojects\resticprofile\resticprofile.exe --no-ansi --config "examples\othere windows.yaml" run-schedule backup@self
+Task To Run:                          G:\go\src\github.com\creativeprojects\resticprofile\resticprofile.exe --no-ansi --config "examples\other windows.yaml" run-schedule backup@self
 Start In:                             G:\go\src\github.com\creativeprojects\resticprofile
-Comment:                              resticprofile backup for profile self in examples\othere windows.yaml
+Comment:                              resticprofile backup for profile self in examples\other windows.yaml
 Scheduled Task State:                 Enabled
 Idle Time:                            Disabled
 Power Management:                     Stop On Battery Mode, No Start On Batteries
@@ -49,9 +49,9 @@ Logon Mode:                           Interactive only
 Last Run Time:                        04/08/2025 21:00:01
 Last Result:                          1
 Author:                               resticprofile
-Task To Run:                          G:\go\src\github.com\creativeprojects\resticprofile\resticprofile.exe --no-ansi --config "examples\othere windows.yaml" run-schedule backup@self
+Task To Run:                          G:\go\src\github.com\creativeprojects\resticprofile\resticprofile.exe --no-ansi --config "examples\other windows.yaml" run-schedule backup@self
 Start In:                             G:\go\src\github.com\creativeprojects\resticprofile
-Comment:                              resticprofile backup for profile self in examples\othere windows.yaml
+Comment:                              resticprofile backup for profile self in examples\other windows.yaml
 Scheduled Task State:                 Enabled
 Idle Time:                            Disabled
 Power Management:                     Stop On Battery Mode, No Start On Batteries
@@ -89,9 +89,9 @@ func TestReadingListOutput(t *testing.T) {
 			"Last Run Time":                        "04/08/2025 21:00:01",
 			"Last Result":                          "1",
 			"Author":                               "resticprofile",
-			"Task To Run":                          "G:\\go\\src\\github.com\\creativeprojects\\resticprofile\\resticprofile.exe --no-ansi --config \"examples\\othere windows.yaml\" run-schedule backup@self",
+			"Task To Run":                          "G:\\go\\src\\github.com\\creativeprojects\\resticprofile\\resticprofile.exe --no-ansi --config \"examples\\other windows.yaml\" run-schedule backup@self",
 			"Start In":                             "G:\\go\\src\\github.com\\creativeprojects\\resticprofile",
-			"Comment":                              "resticprofile backup for profile self in examples\\othere windows.yaml",
+			"Comment":                              "resticprofile backup for profile self in examples\\other windows.yaml",
 			"Scheduled Task State":                 "Enabled",
 			"Idle Time":                            "Disabled",
 			"Power Management":                     "Stop On Battery Mode, No Start On Batteries",
@@ -120,9 +120,9 @@ func TestReadingListOutput(t *testing.T) {
 			"Last Run Time":                        "04/08/2025 21:00:01",
 			"Last Result":                          "1",
 			"Author":                               "resticprofile",
-			"Task To Run":                          "G:\\go\\src\\github.com\\creativeprojects\\resticprofile\\resticprofile.exe --no-ansi --config \"examples\\othere windows.yaml\" run-schedule backup@self",
+			"Task To Run":                          "G:\\go\\src\\github.com\\creativeprojects\\resticprofile\\resticprofile.exe --no-ansi --config \"examples\\other windows.yaml\" run-schedule backup@self",
 			"Start In":                             "G:\\go\\src\\github.com\\creativeprojects\\resticprofile",
-			"Comment":                              "resticprofile backup for profile self in examples\\othere windows.yaml",
+			"Comment":                              "resticprofile backup for profile self in examples\\other windows.yaml",
 			"Scheduled Task State":                 "Enabled",
 			"Idle Time":                            "Disabled",
 			"Power Management":                     "Stop On Battery Mode, No Start On Batteries",

--- a/schtasks/list_test.go
+++ b/schtasks/list_test.go
@@ -146,3 +146,46 @@ func TestReadingListOutput(t *testing.T) {
 	}
 	assert.Equal(t, expected, output)
 }
+
+func TestReadingListOutputWithNoSeparator(t *testing.T) {
+	t.Parallel()
+
+	list := `
+Line with no separator
+`
+	_, err := getTaskInfoFromList(bytes.NewBufferString(list))
+	require.Error(t, err)
+}
+
+func TestReadingListOutputWithEmptyKey(t *testing.T) {
+	t.Parallel()
+
+	list := `
+: Value
+`
+	_, err := getTaskInfoFromList(bytes.NewBufferString(list))
+	require.NoError(t, err)
+}
+
+func TestReadingListOutputWithEmptyValue(t *testing.T) {
+	t.Parallel()
+
+	// keep the space after the colon
+	list := `
+Key: 
+`
+	_, err := getTaskInfoFromList(bytes.NewBufferString(list))
+	require.NoError(t, err)
+}
+
+func TestReadingListOutputWithDuplicateKey(t *testing.T) {
+	t.Parallel()
+
+	// keep the space after the colon
+	list := `
+Key: Value
+Key: Value
+`
+	_, err := getTaskInfoFromList(bytes.NewBufferString(list))
+	require.Error(t, err)
+}

--- a/schtasks/list_test.go
+++ b/schtasks/list_test.go
@@ -1,0 +1,146 @@
+//go:build windows
+
+package schtasks
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const listOutput = `
+Folder: \resticprofile backup
+HostName:                             WIN-5NMJF0VS8OR
+TaskName:                             \resticprofile backup\self backup
+Next Run Time:                        04/08/2025 21:15:00
+Status:                               Ready
+Logon Mode:                           Interactive only
+Last Run Time:                        04/08/2025 21:00:01
+Last Result:                          1
+Author:                               resticprofile
+Task To Run:                          G:\go\src\github.com\creativeprojects\resticprofile\resticprofile.exe --no-ansi --config "examples\othere windows.yaml" run-schedule backup@self
+Start In:                             G:\go\src\github.com\creativeprojects\resticprofile
+Comment:                              resticprofile backup for profile self in examples\othere windows.yaml
+Scheduled Task State:                 Enabled
+Idle Time:                            Disabled
+Power Management:                     Stop On Battery Mode, No Start On Batteries
+Run As User:                          Fred
+Delete Task If Not Rescheduled:       Disabled
+Stop Task If Runs X Hours and X Mins: Disabled
+Schedule:                             Scheduling data is not available in this format.
+Schedule Type:                        Weekly
+Start Time:                           20:15:00
+Start Date:                           04/08/2025
+End Date:                             N/A
+Days:                                 MON, TUE, WED, THU, FRI
+Months:                               Every 1 week(s)
+Repeat: Every:                        0 Hour(s), 15 Minute(s)
+Repeat: Until: Time:                  None
+Repeat: Until: Duration:              23 Hour(s), 45 Minute(s)
+Repeat: Stop If Still Running:        Disabled
+
+HostName:                             WIN-5NMJF0VS8OR
+TaskName:                             \resticprofile backup\self backup
+Next Run Time:                        04/08/2025 21:15:00
+Status:                               Ready
+Logon Mode:                           Interactive only
+Last Run Time:                        04/08/2025 21:00:01
+Last Result:                          1
+Author:                               resticprofile
+Task To Run:                          G:\go\src\github.com\creativeprojects\resticprofile\resticprofile.exe --no-ansi --config "examples\othere windows.yaml" run-schedule backup@self
+Start In:                             G:\go\src\github.com\creativeprojects\resticprofile
+Comment:                              resticprofile backup for profile self in examples\othere windows.yaml
+Scheduled Task State:                 Enabled
+Idle Time:                            Disabled
+Power Management:                     Stop On Battery Mode, No Start On Batteries
+Run As User:                          Fred
+Delete Task If Not Rescheduled:       Disabled
+Stop Task If Runs X Hours and X Mins: Disabled
+Schedule:                             Scheduling data is not available in this format.
+Schedule Type:                        Weekly
+Start Time:                           00:00:00
+Start Date:                           09/08/2025
+End Date:                             N/A
+Days:                                 SUN, SAT
+Months:                               Every 1 week(s)
+Repeat: Every:                        12 Hour(s), 0 Minute(s)
+Repeat: Until: Time:                  None
+Repeat: Until: Duration:              12 Hour(s), 0 Minute(s)
+Repeat: Stop If Still Running:        Disabled
+`
+
+func TestReadingListOutput(t *testing.T) {
+	t.Parallel()
+
+	output, err := getTaskInfoFromList(bytes.NewBufferString(listOutput))
+	require.NoError(t, err)
+	assert.NotNil(t, output)
+
+	expected := []map[string]string{
+		{
+			"Folder":                               "\\resticprofile backup",
+			"HostName":                             "WIN-5NMJF0VS8OR",
+			"TaskName":                             "\\resticprofile backup\\self backup",
+			"Next Run Time":                        "04/08/2025 21:15:00",
+			"Status":                               "Ready",
+			"Logon Mode":                           "Interactive only",
+			"Last Run Time":                        "04/08/2025 21:00:01",
+			"Last Result":                          "1",
+			"Author":                               "resticprofile",
+			"Task To Run":                          "G:\\go\\src\\github.com\\creativeprojects\\resticprofile\\resticprofile.exe --no-ansi --config \"examples\\othere windows.yaml\" run-schedule backup@self",
+			"Start In":                             "G:\\go\\src\\github.com\\creativeprojects\\resticprofile",
+			"Comment":                              "resticprofile backup for profile self in examples\\othere windows.yaml",
+			"Scheduled Task State":                 "Enabled",
+			"Idle Time":                            "Disabled",
+			"Power Management":                     "Stop On Battery Mode, No Start On Batteries",
+			"Run As User":                          "Fred",
+			"Delete Task If Not Rescheduled":       "Disabled",
+			"Stop Task If Runs X Hours and X Mins": "Disabled",
+			"Schedule":                             "Scheduling data is not available in this format.",
+			"Schedule Type":                        "Weekly",
+			"Start Time":                           "20:15:00",
+			"Start Date":                           "04/08/2025",
+			"End Date":                             "N/A",
+			"Days":                                 "MON, TUE, WED, THU, FRI",
+			"Months":                               "Every 1 week(s)",
+			"Repeat: Every":                        "0 Hour(s), 15 Minute(s)",
+			"Repeat: Until: Time":                  "None",
+			"Repeat: Until: Duration":              "23 Hour(s), 45 Minute(s)",
+			"Repeat: Stop If Still Running":        "Disabled",
+		},
+		{
+			"Folder":                               "\\resticprofile backup",
+			"HostName":                             "WIN-5NMJF0VS8OR",
+			"TaskName":                             "\\resticprofile backup\\self backup",
+			"Next Run Time":                        "04/08/2025 21:15:00",
+			"Status":                               "Ready",
+			"Logon Mode":                           "Interactive only",
+			"Last Run Time":                        "04/08/2025 21:00:01",
+			"Last Result":                          "1",
+			"Author":                               "resticprofile",
+			"Task To Run":                          "G:\\go\\src\\github.com\\creativeprojects\\resticprofile\\resticprofile.exe --no-ansi --config \"examples\\othere windows.yaml\" run-schedule backup@self",
+			"Start In":                             "G:\\go\\src\\github.com\\creativeprojects\\resticprofile",
+			"Comment":                              "resticprofile backup for profile self in examples\\othere windows.yaml",
+			"Scheduled Task State":                 "Enabled",
+			"Idle Time":                            "Disabled",
+			"Power Management":                     "Stop On Battery Mode, No Start On Batteries",
+			"Run As User":                          "Fred",
+			"Delete Task If Not Rescheduled":       "Disabled",
+			"Stop Task If Runs X Hours and X Mins": "Disabled",
+			"Schedule":                             "Scheduling data is not available in this format.",
+			"Schedule Type":                        "Weekly",
+			"Start Time":                           "00:00:00",
+			"Start Date":                           "09/08/2025",
+			"End Date":                             "N/A",
+			"Days":                                 "SUN, SAT",
+			"Months":                               "Every 1 week(s)",
+			"Repeat: Every":                        "12 Hour(s), 0 Minute(s)",
+			"Repeat: Until: Time":                  "None",
+			"Repeat: Until: Duration":              "12 Hour(s), 0 Minute(s)",
+			"Repeat: Stop If Still Running":        "Disabled",
+		},
+	}
+	assert.Equal(t, expected, output)
+}

--- a/schtasks/list_test.go
+++ b/schtasks/list_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+//nolint:misspell
 const listOutput = `
 Folder: \resticprofile backup
 HostName:                             WIN-5NMJF0VS8OR
@@ -78,6 +79,7 @@ func TestReadingListOutput(t *testing.T) {
 	require.NoError(t, err)
 	assert.NotNil(t, output)
 
+	//nolint:misspell
 	expected := []map[string]string{
 		{
 			"Folder":                               "\\resticprofile backup",

--- a/schtasks/schtasks.go
+++ b/schtasks/schtasks.go
@@ -18,7 +18,7 @@ func getRegisteredTasks() ([]string, error) {
 	if err != nil {
 		return nil, err
 	}
-	all, err := getCSV(bytes.NewBuffer(raw))
+	all, err := getTaskInfoFromCSV(bytes.NewBuffer(raw))
 	if err != nil {
 		return nil, err
 	}
@@ -33,20 +33,20 @@ func getRegisteredTasks() ([]string, error) {
 	return list, nil
 }
 
-func getTaskInfo(taskName string) ([][]string, error) {
+func getTaskInfo(taskName string) ([]map[string]string, error) {
 	buffer := &bytes.Buffer{}
 	err := readTaskInfo(taskName, buffer)
 	if err != nil {
 		return nil, err
 	}
-	output, err := getCSV(buffer)
+	output, err := getTaskInfoFromList(buffer)
 	if err != nil {
 		return nil, err
 	}
 	return output, nil
 }
 
-func getCSV(input io.Reader) ([][]string, error) {
+func getTaskInfoFromCSV(input io.Reader) ([][]string, error) {
 	reader := csv.NewReader(input)
 	return reader.ReadAll()
 }
@@ -124,14 +124,14 @@ func deleteTask(taskName string) (string, error) {
 	return stdout.String(), nil
 }
 
-// readTaskInfo returns the raw CSV output from querying the task name (via schtasks.exe)
+// readTaskInfo returns the raw output from querying the task name (via schtasks.exe)
 func readTaskInfo(taskName string, output io.Writer) error {
 	taskName, err := sanitizeTaskName(taskName)
 	if err != nil {
 		return err
 	}
 	stderr := &bytes.Buffer{}
-	cmd := exec.Command(binaryPath, "/query", "/fo", "csv", "/v", "/tn", taskName)
+	cmd := exec.Command(binaryPath, "/query", "/fo", "list", "/v", "/tn", taskName)
 	cmd.Stdout = output
 	cmd.Stderr = stderr
 	err = cmd.Run()

--- a/schtasks/schtasks_test.go
+++ b/schtasks/schtasks_test.go
@@ -18,13 +18,13 @@ const csvOutput = `"HostName","TaskName","Next Run Time","Status","Logon Mode","
 func TestReadingCSVOutput(t *testing.T) {
 	t.Parallel()
 
-	output, err := getCSV(bytes.NewBufferString(csvOutput))
+	output, err := getTaskInfoFromCSV(bytes.NewBufferString(csvOutput))
 	require.NoError(t, err)
 	assert.Len(t, output, 3)     // lines
 	assert.Len(t, output[0], 28) // fields
 }
 
-func TestReadTaskInfoError(t *testing.T) {
+func TestGetTaskInfoError(t *testing.T) {
 	t.Parallel()
 
 	testCases := []struct {
@@ -42,7 +42,7 @@ func TestReadTaskInfoError(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.taskname, func(t *testing.T) {
 			output := &bytes.Buffer{}
-			err := readTaskInfo(tc.taskname, output)
+			_, err := getTaskInfo(tc.taskname)
 			require.ErrorIs(t, err, tc.expected)
 			assert.Empty(t, output.Len())
 		})

--- a/schtasks/taskscheduler.go
+++ b/schtasks/taskscheduler.go
@@ -131,9 +131,10 @@ func Registered() ([]Config, error) {
 
 	configs := make([]Config, 0, len(list))
 	for _, taskPath := range list {
+		clog.Debugf("loading task %q", taskPath)
 		info, err := getTaskInfo(taskPath)
 		if err != nil {
-			clog.Errorf("loading task %q: %w", taskPath, err)
+			clog.Errorf("loading task %q: %s", taskPath, err)
 			continue
 		}
 		if len(info) < 2 {
@@ -176,12 +177,4 @@ func createTaskDefinition(config *Config, schedules []*calendar.Event) Task {
 	})
 	task.AddSchedules(schedules)
 	return task
-}
-
-func getFirstField(data [][]string, fieldName string) string {
-	index := slices.Index(data[0], fieldName)
-	if index < 0 {
-		return ""
-	}
-	return data[1][index]
 }

--- a/schtasks/taskscheduler.go
+++ b/schtasks/taskscheduler.go
@@ -137,9 +137,6 @@ func Registered() ([]Config, error) {
 			clog.Errorf("loading task %q: %s", taskPath, err)
 			continue
 		}
-		if len(info) < 2 {
-			continue
-		}
 		taskName := strings.TrimPrefix(taskPath, tasksPathPrefix)
 		parts := strings.Split(taskName, " ")
 		if len(parts) < 2 {


### PR DESCRIPTION
## Refactor Windows task scheduler to use list format instead of CSV

This PR refactors the Windows task scheduler implementation to read task information from the schtasks list format instead of CSV format.

**Key Changes:**
- **New parser**: Added `getTaskInfoFromList()` function to parse key-value pairs from list format output
- **Command change**: Modified schtasks command to use `/fo list` instead of `/fo csv`
- **Data structure**: Changed from `[][]string` (CSV rows) to `[]map[string]string` (key-value records)
- **Improved parsing**: Better handling of different separator formats (`:  ` and `: `)
- **Enhanced testing**: Added comprehensive tests for the new list format parser

**Benefits:**
- More robust parsing of task information
- Better handling of complex field values that may contain quotes
- Cleaner data structure for accessing task properties by name
- Improved error handling for malformed data

The change maintains backward compatibility while providing a more reliable way to extract Windows scheduled task information.

Fixes #545 