### PR TITLE
refactor: update JSON schema tests to use go library

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -36,11 +36,6 @@ jobs:
           check-latest: true
           cache: true
 
-      - name: Set up Node.js LTS for running JSON schema tests (using ajv)
-        uses: actions/setup-node@v4
-        with:
-          node-version: "22"
-
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v8
         with:

--- a/config/jsonschema/v1.conf
+++ b/config/jsonschema/v1.conf
@@ -1,0 +1,2 @@
+version = "1"
+unknown_property = "value"

--- a/config/jsonschema/v1.yaml
+++ b/config/jsonschema/v1.yaml
@@ -1,0 +1,2 @@
+version: "1"
+unknown_property: "value"

--- a/config/jsonschema/v2.conf
+++ b/config/jsonschema/v2.conf
@@ -1,0 +1,2 @@
+version = "2"
+unknown_property = "value"

--- a/config/jsonschema/v2.yaml
+++ b/config/jsonschema/v2.yaml
@@ -1,0 +1,2 @@
+version: "2"
+unknown_property: "value"

--- a/go.mod
+++ b/go.mod
@@ -17,6 +17,7 @@ require (
 	github.com/prometheus/client_golang v1.22.0
 	github.com/prometheus/common v0.65.0
 	github.com/rickb777/period v1.0.12
+	github.com/santhosh-tekuri/jsonschema/v6 v6.0.2
 	github.com/shirou/gopsutil/v3 v3.24.5
 	github.com/spf13/afero v1.15.0
 	github.com/spf13/cast v1.10.0

--- a/go.sum
+++ b/go.sum
@@ -23,6 +23,8 @@ github.com/davidmz/go-pageant v1.0.2 h1:bPblRCh5jGU+Uptpz6LgMZGD5hJoOt7otgT454Wv
 github.com/davidmz/go-pageant v1.0.2/go.mod h1:P2EDDnMqIwG5Rrp05dTRITj9z2zpGcD9efWSkTNKLIE=
 github.com/distatus/battery v0.11.0 h1:KJk89gz90Iq/wJtbjjM9yUzBXV+ASV/EG2WOOL7N8lc=
 github.com/distatus/battery v0.11.0/go.mod h1:KmVkE8A8hpIX4T78QRdMktYpEp35QfOL8A8dwZBxq2k=
+github.com/dlclark/regexp2 v1.11.0 h1:G/nrcoOa7ZXlpoa/91N3X7mM3r8eIlMBBJZvsz/mxKI=
+github.com/dlclark/regexp2 v1.11.0/go.mod h1:DHkYz0B9wPfa6wondMfaivmHpzrQ3v9q8cnmRbL6yW8=
 github.com/fatih/color v1.18.0 h1:S8gINlzdQ840/4pfAwic/ZE0djQEH3wM94VfqLTZcOM=
 github.com/fatih/color v1.18.0/go.mod h1:4FelSpRwEGDpQ12mAdzqdOukCy4u8WUtOY6lkT/6HfU=
 github.com/frankban/quicktest v1.14.6 h1:7Xjx+VpznH+oBnejlPUj8oUpdxnVs4f8XU8WnHkI4W8=
@@ -104,6 +106,8 @@ github.com/sagikazarmark/locafero v0.9.0 h1:GbgQGNtTrEmddYDSAH9QLRyfAHY12md+8YFT
 github.com/sagikazarmark/locafero v0.9.0/go.mod h1:UBUyz37V+EdMS3hDF3QWIiVr/2dPrx49OMO0Bn0hJqk=
 github.com/sagikazarmark/slog-shim v0.1.0 h1:diDBnUNK9N/354PgrxMywXnAwEr1QZcOr6gto+ugjYE=
 github.com/sagikazarmark/slog-shim v0.1.0/go.mod h1:SrcSrq8aKtyuqEI1uvTDTK1arOWRIczQRv+GVI1AkeQ=
+github.com/santhosh-tekuri/jsonschema/v6 v6.0.2 h1:KRzFb2m7YtdldCEkzs6KqmJw4nqEVZGK7IN2kJkjTuQ=
+github.com/santhosh-tekuri/jsonschema/v6 v6.0.2/go.mod h1:JXeL+ps8p7/KNMjDQk3TCwPpBy0wYklyWTfbkIzdIFU=
 github.com/shirou/gopsutil/v3 v3.24.5 h1:i0t8kL+kQTvpAYToeuiVk3TgDeKOFioZO3Ztz/iZ9pI=
 github.com/shirou/gopsutil/v3 v3.24.5/go.mod h1:bsoOS1aStSs9ErQ1WWfxllSeS1K5D+U30r2NfcubMVk=
 github.com/shoenig/go-m1cpu v0.1.6 h1:nxdKQNcEB6vzgA2E2bvzKIYRuNj7XNJ4S/aRSwKzFtM=


### PR DESCRIPTION
## Refactor: Remove Node.js dependency from JSON schema validation tests

This PR removes the Node.js dependency previously required for JSON schema validation in tests and replaces it with a pure Go solution using the `github.com/santhosh-tekuri/jsonschema/v6` library.

### Changes:
- **Removed Node.js setup** from GitHub Actions workflow (build.yml)
- **Replaced npm/ajv-based validation** with Go-native JSON schema validation
- **Added Go dependency** `github.com/santhosh-tekuri/jsonschema/v6` for schema compilation and validation
- **Refactored test functions** to use Go-based schema validation instead of external npm commands
- **Added test files** with invalid configurations to verify schema validation works correctly
- **Improved test parallelization** and structure

### Benefits:
- Eliminates external Node.js dependency for CI/CD
- Faster test execution with native Go validation
- Simplified development environment setup
- Better test reliability without external tool dependencies

The functionality remains the same - all JSON schema validation tests continue to work as expected, but now run entirely within the Go ecosystem.