### PR TITLE
Fix typo in the `schedule-permission` field description

### DIFF
--- a/docs/content/schedules/configuration.md
+++ b/docs/content/schedules/configuration.md
@@ -79,7 +79,7 @@ profile:
 
 * `user_logged_on`: **Not for crond** - Provides the same permissions as `user`, but runs only when the user is logged on. On Windows, it does not ask for your user password.
 
-* *empty*: resticprofile will guess based on how it was started (with sudo or as a normal user). The fallback is `system` on Windows and `user_logged_in` on other platforms.
+* *empty*: resticprofile will guess based on how it was started (with sudo or as a normal user). The fallback is `system` on Windows and `user_logged_on` on other platforms.
 
 ### Changing schedule-permission
 


### PR DESCRIPTION
Fix the default value for the `schedule-permission` field to clarify what is going on when user doesn't provide any input.