### PR TITLE
lock: release lockfile when terminated by SIGINT or SIGTERM

### DIFF
--- a/lock.go
+++ b/lock.go
@@ -7,6 +7,8 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/creativeprojects/clog"
@@ -82,25 +84,40 @@ func lockRun(lockFile string, force bool, lockWait *time.Duration, sigChan <-cha
 	}
 
 	// Run locked.
-	// Also install a signal watcher: if the process is terminated via a signal
-	// while run() is executing, os.Exit() in main's deferred function bypasses
-	// defer runLock.Release() — so we release the lock from a goroutine first.
+	// Install a signal watcher: if the process is terminated via a signal while
+	// run() is executing, os.Exit() in main's deferred function bypasses normal
+	// defer chains, so the goroutine must release the lock first.
+	//
+	// Ownership rule: exactly one path calls Release() --
+	//   signal branch: goroutine calls it, sets signalReleased
+	//   normal branch: caller calls it after wg.Wait()
+	// sync.Once inside Lock.Release() is an extra safety layer.
+	var wg sync.WaitGroup
 	released := make(chan struct{})
+	var signalReleased atomic.Bool
+
 	if sigChan != nil {
+		wg.Add(1)
 		go func() {
+			defer wg.Done()
 			select {
 			case <-sigChan:
+				signalReleased.Store(true)
 				runLock.Release()
 			case <-released:
-				// normal exit — defer below handles cleanup
+				// normal exit -- caller owns Release()
 			}
 		}()
 	}
-	defer func() {
-		close(released)
+
+	err := run(runLock.SetPID)
+	close(released) // unblock goroutine if still waiting
+	wg.Wait()       // goroutine fully exited before we return
+
+	if !signalReleased.Load() {
 		runLock.Release()
-	}()
-	return run(runLock.SetPID)
+	}
+	return err
 }
 
 const logLockWaitEvery = 5 * time.Minute

--- a/lock.go
+++ b/lock.go
@@ -81,8 +81,25 @@ func lockRun(lockFile string, force bool, lockWait *time.Duration, sigChan <-cha
 		}
 	}
 
-	// Run locked
-	defer runLock.Release()
+	// Run locked.
+	// Also install a signal watcher: if the process is terminated via a signal
+	// while run() is executing, os.Exit() in main's deferred function bypasses
+	// defer runLock.Release() — so we release the lock from a goroutine first.
+	released := make(chan struct{})
+	if sigChan != nil {
+		go func() {
+			select {
+			case <-sigChan:
+				runLock.Release()
+			case <-released:
+				// normal exit — defer below handles cleanup
+			}
+		}()
+	}
+	defer func() {
+		close(released)
+		runLock.Release()
+	}()
 	return run(runLock.SetPID)
 }
 

--- a/lock/lock.go
+++ b/lock/lock.go
@@ -7,6 +7,7 @@ import (
 	"os/user"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/shirou/gopsutil/v3/process"
@@ -17,9 +18,10 @@ type SetPID func(pid int32)
 
 // Lock prevents code to run at the same time by using a lockfile
 type Lock struct {
-	Lockfile string
-	file     *os.File
-	locked   bool
+	Lockfile    string
+	file        *os.File
+	locked      bool
+	releaseOnce sync.Once
 }
 
 // NewLock creates a new lock
@@ -62,12 +64,16 @@ func (l *Lock) ForceAcquire() bool {
 	return l.lock()
 }
 
-// Release the lockfile
+// Release the lockfile. Safe to call concurrently or multiple times; only the
+// first call does work. This matters in lockRun, where a signal goroutine and
+// the normal defer can both call Release at the same time.
 func (l *Lock) Release() {
-	if l.file != nil {
-		_ = l.file.Close()
-	}
-	l.unlock()
+	l.releaseOnce.Do(func() {
+		if l.file != nil {
+			_ = l.file.Close()
+		}
+		l.unlock()
+	})
 }
 
 // Who owns the lock?

--- a/lock_test.go
+++ b/lock_test.go
@@ -120,29 +120,27 @@ func TestLockRunWithLockAndCancel(t *testing.T) {
 }
 
 func TestLockRunReleasesLockOnSignal(t *testing.T) {
-	// Verify that the lockfile is removed even when a signal fires during run(),
+	// Verify that the lockfile is removed when a signal fires during run(),
 	// simulating the os.Exit() path in main that bypasses defer chains.
+	// Also verifies lockRun does not return until the signal goroutine has fully
+	// exited (no goroutine leak).
 	lockfile := filepath.Join(t.TempDir(), "lockfile")
 	sigChan := make(chan os.Signal, 1)
 
 	started := make(chan struct{})
-	done := make(chan struct{})
 
+	// send signal while run() is blocking, then wait for lockRun to return
 	go func() {
-		defer close(done)
-		_ = lockRun(lockfile, false, nil, sigChan, func(setPID lock.SetPID) error {
-			close(started) // signal that we're inside run
-			// block until the signal goroutine has had time to fire
-			time.Sleep(200 * time.Millisecond)
-			return nil
-		})
+		<-started
+		sigChan <- os.Interrupt
 	}()
 
-	<-started
-	// send signal while run() is executing
-	sigChan <- os.Interrupt
-	<-done
+	_ = lockRun(lockfile, false, nil, sigChan, func(setPID lock.SetPID) error {
+		close(started)
+		time.Sleep(200 * time.Millisecond)
+		return nil
+	})
 
-	// Lock file must be gone regardless of which cleanup path ran
+	// Lock file must be gone -- signal goroutine released it
 	assert.NoFileExists(t, lockfile)
 }

--- a/lock_test.go
+++ b/lock_test.go
@@ -118,3 +118,31 @@ func TestLockRunWithLockAndCancel(t *testing.T) {
 	assert.Equal(t, 0, called)
 	assert.FileExists(t, lockfile)
 }
+
+func TestLockRunReleasesLockOnSignal(t *testing.T) {
+	// Verify that the lockfile is removed even when a signal fires during run(),
+	// simulating the os.Exit() path in main that bypasses defer chains.
+	lockfile := filepath.Join(t.TempDir(), "lockfile")
+	sigChan := make(chan os.Signal, 1)
+
+	started := make(chan struct{})
+	done := make(chan struct{})
+
+	go func() {
+		defer close(done)
+		_ = lockRun(lockfile, false, nil, sigChan, func(setPID lock.SetPID) error {
+			close(started) // signal that we're inside run
+			// block until the signal goroutine has had time to fire
+			time.Sleep(200 * time.Millisecond)
+			return nil
+		})
+	}()
+
+	<-started
+	// send signal while run() is executing
+	sigChan <- os.Interrupt
+	<-done
+
+	// Lock file must be gone regardless of which cleanup path ran
+	assert.NoFileExists(t, lockfile)
+}


### PR DESCRIPTION
## Summary

Fixes #548

When resticprofile is killed via SIGINT or SIGTERM, `main()` calls `os.Exit()` inside a deferred function. `os.Exit()` bypasses all remaining defer chains, so `defer runLock.Release()` in `lockRun` never executes and the lockfile is left on disk.

## Root cause

```go
// main.go
defer func() {
    if exitCode != 0 {
        os.Exit(exitCode) // bypasses all other defers up the stack
    }
}()
```

When a signal fires, the shell command propagates it to the child process, the child exits with a non-zero code, and `os.Exit` is called before `lockRun`'s `defer runLock.Release()` gets a chance to run.

## Fix

Start a goroutine inside `lockRun` that watches `sigChan` and calls `Release()` immediately when a signal fires. A `released` channel tells the goroutine to exit on the normal return path to avoid a double-release (`Release()` is idempotent via `os.Remove` but the goroutine exit is cleaner).

## Test

Added `TestLockRunReleasesLockOnSignal`: acquires a lock, sends a signal while `run()` is executing, and asserts the lockfile no longer exists after `lockRun` returns.