### PR TITLE
fix: select latest release tag for Docker rebuild workflow

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -26,7 +26,11 @@ jobs:
 
       - name: Checkout latest tag
         run: |
-          export LATEST_TAG=`git describe --tags --abbrev=0`
+          export LATEST_TAG=$(git tag --list 'v*' --sort=-version:refname | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' | head -n 1)
+          if [ -z "$LATEST_TAG" ]; then
+            echo "No release tag found"
+            exit 1
+          fi
           git checkout $LATEST_TAG
 
       - name: Set up Go ${{ steps.dotenv.outputs.go_version }}


### PR DESCRIPTION
The latest [Rebuild docker image workflow run](https://github.com/creativeprojects/resticprofile/actions/runs/25274124014/job/74101169474) tagged `v0.33.0` as `latest` on Docker Hub instead of `v0.33.1`.

This happened because the workflow used `git describe --tags --abbrev=0`, which selects the nearest tag reachable from `master`. In this case, the `v0.33.1` tag points to a commit outside `master`, so the workflow fell back to `v0.33.0`.

This PR fixes the workflow by selecting the highest stable release tag directly, regardless of which branch contains the tagged commit.