### PR TITLE
Document generated defaults in config reference

### DIFF
--- a/config/template.go
+++ b/config/template.go
@@ -6,6 +6,7 @@ import (
 	"path/filepath"
 	"slices"
 
+	"github.com/creativeprojects/resticprofile/constants"
 	"github.com/creativeprojects/resticprofile/restic"
 	"github.com/creativeprojects/resticprofile/util/collect"
 	"github.com/creativeprojects/resticprofile/util/templates"
@@ -60,6 +61,16 @@ type TemplateInfoData struct {
 	KnownResticVersions []string
 }
 
+type propertyTableData struct {
+	SectionName string
+	Properties  []PropertyInfo
+}
+
+type propertyRowData struct {
+	SectionName string
+	Property    PropertyInfo
+}
+
 // ProfileSections is a helper method for templates to list SectionInfo in ProfileInfo
 func (t *TemplateInfoData) ProfileSections() []SectionInfo {
 	return collect.From(t.Profile.Sections(), t.Profile.SectionInfo)
@@ -111,7 +122,35 @@ func (t *TemplateInfoData) GetFuncs() map[string]any {
 		"properties": func(set PropertySet) []PropertyInfo { return collect.From(set.Properties(), set.PropertyInfo) },
 		"own":        func(p []PropertyInfo) []PropertyInfo { return collect.All(p, collect.Not(PropertyInfo.IsOption)) },
 		"restic":     func(p []PropertyInfo) []PropertyInfo { return collect.All(p, PropertyInfo.IsOption) },
+		"propertyTable": func(sectionName string, properties []PropertyInfo) propertyTableData {
+			return propertyTableData{SectionName: sectionName, Properties: properties}
+		},
+		"propertyRow": func(sectionName string, property PropertyInfo) propertyRowData {
+			return propertyRowData{SectionName: sectionName, Property: property}
+		},
+		"referenceDefaults": referenceDefaults,
 	}
+}
+
+func referenceDefaults(sectionName string, property PropertyInfo) []string {
+	switch sectionName {
+	case constants.CommandBackup:
+		if property.Name() == constants.ParameterHost {
+			return []string{"true (config version 2)"}
+		}
+	case constants.SectionConfigurationRetention:
+		switch property.Name() {
+		case constants.ParameterPath:
+			return []string{"true"}
+		case constants.ParameterHost, constants.ParameterTag:
+			return []string{"true (config version 2)"}
+		}
+	}
+
+	if defaults := property.DefaultValue(); len(defaults) > 0 {
+		return defaults
+	}
+	return nil
 }
 
 // NewTemplateInfoData returns template data to render references for the specified resticVersion

--- a/config/template_test.go
+++ b/config/template_test.go
@@ -457,7 +457,7 @@ func TestInfoData(t *testing.T) {
 
 	funcs := data.GetFuncs()
 	props := collect.From(data.Profile.Properties(), data.Profile.PropertyInfo)
-	assert.Len(t, funcs, 3)
+	assert.Len(t, funcs, 6)
 	assert.NotEmpty(t, props)
 
 	t.Run("properties", func(t *testing.T) {
@@ -492,5 +492,15 @@ func TestInfoData(t *testing.T) {
 			assert.Contains(t, props, prop)
 			assert.True(t, prop.IsOption())
 		}
+	})
+
+	t.Run("referenceDefaults", func(t *testing.T) {
+		fn, ok := funcs["referenceDefaults"].(func(sectionName string, property PropertyInfo) []string)
+		require.True(t, ok)
+
+		retention := data.Profile.SectionInfo(constants.SectionConfigurationRetention)
+		require.NotNil(t, retention)
+		assert.Equal(t, []string{"true"}, fn(retention.Name(), retention.PropertyInfo(constants.ParameterPath)))
+		assert.Equal(t, []string{"true (config version 2)"}, fn(retention.Name(), retention.PropertyInfo(constants.ParameterTag)))
 	})
 }

--- a/contrib/templates/_config-reference.gomd
+++ b/contrib/templates/_config-reference.gomd
@@ -87,6 +87,16 @@
     {{- "\n\n" -}}
 {{ end }}
 
+{{ define "printSectionPropertyTable" -}}
+    {{- "| Name              | Type                    | Default  | Notes |\n" -}}
+    {{- "|:------------------|:------------------------|:---------|:------|\n" -}}
+    {{- $sectionName := .SectionName -}}
+    {{ range .Properties -}}
+        {{ template "printSectionPropertyRow" (propertyRow $sectionName .) }}
+    {{- end -}}
+    {{- "\n\n" -}}
+{{ end }}
+
 {{ define "printPropertyRow" -}}
     {{- /*gotype: github.com/creativeprojects/resticprofile/config.PropertyInfo*/ -}}
     {{- if .IsDeprecated -}}
@@ -97,6 +107,20 @@
     {{- template "printPropertyType" . }} |
     {{- template "printRange" .DefaultValue }} |
     {{- template "printDescription" . }} |
+{{ end }}
+
+{{ define "printSectionPropertyRow" -}}
+    {{- /*gotype: github.com/creativeprojects/resticprofile/config.propertyRowData*/ -}}
+    {{- $sectionName := .SectionName -}}
+    {{- $property := .Property -}}
+    {{- if $property.IsDeprecated -}}
+      | ~~{{ template "printCell" $property.Name }}~~ |
+    {{- else -}}
+      | **{{ template "printCell" $property.Name }}** |
+    {{- end -}}
+    {{- template "printPropertyType" $property }} |
+    {{- template "printRange" (referenceDefaults $sectionName $property) }} |
+    {{- template "printDescription" $property }} |
 {{ end }}
 
 {{ define "printDescription" -}}

--- a/contrib/templates/profile.sub-section.gomd
+++ b/contrib/templates/profile.sub-section.gomd
@@ -44,14 +44,14 @@ manual pages.
     {{- if . -}}
         {{ $layoutHeadings -}}
         {{- "#### Flags used by **resticprofile** only:\n\n" -}}
-        {{- template "printPropertyTable" . -}}
+        {{- template "printSectionPropertyTable" (propertyTable $.Section.Name .) -}}
     {{- end -}}
 {{- end }}
 {{ with . | properties | restic -}}
     {{- if . -}}
         {{ $layoutHeadings -}}
         {{- "#### Flags passed to the **restic** command line:\n\n" -}}
-        {{- template "printPropertyTable" . -}}
+        {{- template "printSectionPropertyTable" (propertyTable $.Section.Name .) -}}
     {{- end -}}
 {{- end }}
 
@@ -61,4 +61,3 @@ manual pages.
 Flags declared for the **restic** command line in section *[profile](../profile)*
 can be overridden in this section.
 {{ $layoutHintEnd }}
-


### PR DESCRIPTION
## Summary
- add generated-reference helpers for section-specific defaults
- show resticprofile defaults for retention `path`, retention `tag`, and related `host` rows
- cover the new reference default helper in template tests

Closes #200

## Verification
- `go test ./config`
- `go run . generate --config-reference --to /tmp/resticprofile-reference-fixed`
- `git diff --check`

Note: `go test ./...` was attempted first, but this local checkout is missing helper binaries under `build/` such as `test-shell`, `test-crontab`, and `test-args`.