### PR TITLE
feat: add --output=json to the profiles command

### DIFF
--- a/commands.go
+++ b/commands.go
@@ -89,6 +89,9 @@ func getOwnCommands() []ownCommand {
 			longDescription:   "The \"profiles\" command prints brief information on all profiles and groups that are declared in the configuration file",
 			action:            displayProfilesCommand,
 			needConfiguration: true,
+			flags: map[string]string{
+				"--output=<format>": "output format: plain (default) or json",
+			},
 		},
 		{
 			name:              "show",

--- a/commands_display.go
+++ b/commands_display.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"bytes"
+	"encoding/json"
 	"fmt"
 	"io"
 	"regexp"
@@ -20,6 +21,24 @@ import (
 	"github.com/creativeprojects/resticprofile/util/ansi"
 	"github.com/creativeprojects/resticprofile/util/collect"
 )
+
+// profilesOutput is the top-level JSON payload of `profiles --output=json`.
+type profilesOutput struct {
+	Profiles []profileEntry `json:"profiles"`
+	Groups   []groupEntry   `json:"groups"`
+}
+
+type profileEntry struct {
+	Name        string   `json:"name"`
+	Description string   `json:"description,omitempty"`
+	Sections    []string `json:"sections"`
+}
+
+type groupEntry struct {
+	Name        string   `json:"name"`
+	Description string   `json:"description,omitempty"`
+	Profiles    []string `json:"profiles"`
+}
 
 func displayWriter(terminal *term.Terminal) (out func(args ...any) io.Writer, closer func()) {
 	output := terminal.Stdout()
@@ -286,9 +305,18 @@ func displayVersion(ctx commandContext) error {
 }
 
 func displayProfilesCommand(ctx commandContext) error {
-	displayProfiles(ctx)
-	displayGroups(ctx)
-	return nil
+	switch format := parseOutputFormat(ctx.request.arguments); format {
+	case "plain":
+		displayProfiles(ctx)
+		displayGroups(ctx)
+		return nil
+
+	case "json":
+		return displayProfilesJSON(ctx)
+
+	default:
+		return fmt.Errorf("unknown output format %q", format)
+	}
 }
 
 func displayProfiles(ctx commandContext) {
@@ -327,6 +355,50 @@ func displayGroups(ctx commandContext) {
 		out("\t%s:\t[%s]\t%s\n", name, ansi.Cyan(strings.Join(groupList.Profiles, ", ")), groupList.Description)
 	}
 	out("\n")
+}
+
+func displayProfilesJSON(ctx commandContext) error {
+	profiles := ctx.config.GetProfiles()
+	groups := ctx.config.GetProfileGroups()
+
+	out := profilesOutput{
+		Profiles: make([]profileEntry, len(profiles)),
+		Groups:   make([]groupEntry, len(groups)),
+	}
+
+	for i, name := range sortedProfileKeys(profiles) {
+		sections := profiles[name].DefinedCommands()
+		sort.Strings(sections)
+		if sections == nil {
+			sections = []string{}
+		}
+		out.Profiles[i] = profileEntry{
+			Name:        name,
+			Description: profiles[name].Description,
+			Sections:    sections,
+		}
+	}
+
+	groupKeys := make([]string, 0, len(groups))
+	for name := range groups {
+		groupKeys = append(groupKeys, name)
+	}
+	sort.Strings(groupKeys)
+	for i, name := range groupKeys {
+		profilesList := groups[name].Profiles
+		if profilesList == nil {
+			profilesList = []string{}
+		}
+		out.Groups[i] = groupEntry{
+			Name:        name,
+			Description: groups[name].Description,
+			Profiles:    profilesList,
+		}
+	}
+
+	encoder := json.NewEncoder(ctx.terminal.Stdout())
+	encoder.SetIndent("", "  ")
+	return encoder.Encode(out)
 }
 
 func sortedProfileKeys(data map[string]*config.Profile) []string {

--- a/commands_display.go
+++ b/commands_display.go
@@ -315,7 +315,7 @@ func displayProfilesCommand(ctx commandContext) error {
 		return displayProfilesJSON(ctx)
 
 	default:
-		return fmt.Errorf("unknown output format %q", format)
+		return fmt.Errorf("unknown output format %q: must be one of plain, json", format)
 	}
 }
 

--- a/commands_display_test.go
+++ b/commands_display_test.go
@@ -90,42 +90,6 @@ func TestDisplayVersionVerbose2(t *testing.T) {
 	assert.True(t, strings.Contains(buffer.String(), runtime.GOOS))
 }
 
-const profilesTestConfig = `version: "2"
-
-groups:
-  full-backup:
-    description: All hosts
-    profiles:
-      - alpha
-      - beta
-
-profiles:
-  alpha:
-    description: First profile
-    backup:
-      source: /srv/alpha
-    check:
-      read-data: true
-  beta:
-    description: Second profile
-`
-
-func newProfilesTestContext(t *testing.T, args []string) (commandContext, *bytes.Buffer) {
-	t.Helper()
-	cfg, err := config.Load(bytes.NewBufferString(profilesTestConfig), config.FormatYAML)
-	require.NoError(t, err)
-
-	buffer := &bytes.Buffer{}
-	terminal := term.NewTerminal(term.WithStdout(buffer), term.WithColors(false))
-	return commandContext{
-		Context: Context{
-			config:   cfg,
-			terminal: terminal,
-			request:  Request{arguments: args},
-		},
-	}, buffer
-}
-
 func TestDisplayProfilesCommand_Plain(t *testing.T) {
 	ctx, buffer := newProfilesTestContext(t, []string{"profiles"})
 
@@ -196,7 +160,7 @@ func TestDisplayProfilesCommand_JSONEmptyConfig(t *testing.T) {
 
 	require.NoError(t, displayProfilesCommand(ctx))
 
-	// Empty slices must serialise as [] rather than null so scripts can
+	// Empty slices must serialize as [] rather than null so scripts can
 	// rely on the keys always being arrays.
 	assert.Contains(t, buffer.String(), `"profiles": []`)
 	assert.Contains(t, buffer.String(), `"groups": []`)
@@ -210,10 +174,47 @@ func TestDisplayProfilesCommand_JSONEmptyConfig(t *testing.T) {
 }
 
 func TestDisplayProfilesCommand_InvalidFormat(t *testing.T) {
-	ctx, buffer := newProfilesTestContext(t, []string{"profiles", "--output=xml"})
+	ctx, buffer := newProfilesTestContext(t, []string{"profiles", "--output=foo"})
 
 	err := displayProfilesCommand(ctx)
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "xml")
+	assert.EqualError(t, err, `unknown output format "foo": must be one of plain, json`)
 	assert.Empty(t, buffer.String())
+}
+
+func newProfilesTestContext(t *testing.T, args []string) (commandContext, *bytes.Buffer) {
+	t.Helper()
+
+	conf := strings.NewReader(`version: "2"
+
+groups:
+  full-backup:
+    description: All hosts
+    profiles:
+      - alpha
+      - beta
+
+profiles:
+  alpha:
+    description: First profile
+    backup:
+      source: /srv/alpha
+    check:
+      read-data: true
+  beta:
+    description: Second profile
+`)
+
+	cfg, err := config.Load(conf, config.FormatYAML)
+	require.NoError(t, err)
+
+	buffer := &bytes.Buffer{}
+	terminal := term.NewTerminal(term.WithStdout(buffer), term.WithColors(false))
+	return commandContext{
+		Context: Context{
+			config:   cfg,
+			terminal: terminal,
+			request:  Request{arguments: args},
+		},
+	}, buffer
 }

--- a/commands_display_test.go
+++ b/commands_display_test.go
@@ -180,6 +180,35 @@ func TestDisplayProfilesCommand_JSONSpaceSeparated(t *testing.T) {
 	assert.NotEmpty(t, got.Profiles)
 }
 
+func TestDisplayProfilesCommand_JSONEmptyConfig(t *testing.T) {
+	cfg, err := config.Load(bytes.NewBufferString("version: \"2\"\n"), config.FormatYAML)
+	require.NoError(t, err)
+
+	buffer := &bytes.Buffer{}
+	terminal := term.NewTerminal(term.WithStdout(buffer), term.WithColors(false))
+	ctx := commandContext{
+		Context: Context{
+			config:   cfg,
+			terminal: terminal,
+			request:  Request{arguments: []string{"profiles", "--output=json"}},
+		},
+	}
+
+	require.NoError(t, displayProfilesCommand(ctx))
+
+	// Empty slices must serialise as [] rather than null so scripts can
+	// rely on the keys always being arrays.
+	assert.Contains(t, buffer.String(), `"profiles": []`)
+	assert.Contains(t, buffer.String(), `"groups": []`)
+
+	var got profilesOutput
+	require.NoError(t, json.Unmarshal(buffer.Bytes(), &got))
+	assert.NotNil(t, got.Profiles)
+	assert.NotNil(t, got.Groups)
+	assert.Empty(t, got.Profiles)
+	assert.Empty(t, got.Groups)
+}
+
 func TestDisplayProfilesCommand_InvalidFormat(t *testing.T) {
 	ctx, buffer := newProfilesTestContext(t, []string{"profiles", "--output=xml"})
 

--- a/commands_display_test.go
+++ b/commands_display_test.go
@@ -2,10 +2,12 @@ package main
 
 import (
 	"bytes"
+	"encoding/json"
 	"runtime"
 	"strings"
 	"testing"
 
+	"github.com/creativeprojects/resticprofile/config"
 	"github.com/creativeprojects/resticprofile/term"
 	"github.com/fatih/color"
 	"github.com/stretchr/testify/assert"
@@ -86,4 +88,103 @@ func TestDisplayVersionVerbose2(t *testing.T) {
 	err := displayVersion(commandContext{Context: Context{terminal: term.NewTerminal(term.WithStdout(buffer)), request: Request{arguments: []string{"-v"}}}})
 	require.NoError(t, err)
 	assert.True(t, strings.Contains(buffer.String(), runtime.GOOS))
+}
+
+const profilesTestConfig = `version: "2"
+
+groups:
+  full-backup:
+    description: All hosts
+    profiles:
+      - alpha
+      - beta
+
+profiles:
+  alpha:
+    description: First profile
+    backup:
+      source: /srv/alpha
+    check:
+      read-data: true
+  beta:
+    description: Second profile
+`
+
+func newProfilesTestContext(t *testing.T, args []string) (commandContext, *bytes.Buffer) {
+	t.Helper()
+	cfg, err := config.Load(bytes.NewBufferString(profilesTestConfig), config.FormatYAML)
+	require.NoError(t, err)
+
+	buffer := &bytes.Buffer{}
+	terminal := term.NewTerminal(term.WithStdout(buffer), term.WithColors(false))
+	return commandContext{
+		Context: Context{
+			config:   cfg,
+			terminal: terminal,
+			request:  Request{arguments: args},
+		},
+	}, buffer
+}
+
+func TestDisplayProfilesCommand_Plain(t *testing.T) {
+	ctx, buffer := newProfilesTestContext(t, []string{"profiles"})
+
+	require.NoError(t, displayProfilesCommand(ctx))
+	out := buffer.String()
+
+	assert.Contains(t, out, "Profiles available")
+	assert.Contains(t, out, "alpha")
+	assert.Contains(t, out, "beta")
+	assert.Contains(t, out, "First profile")
+	assert.Contains(t, out, "Second profile")
+	assert.Contains(t, out, "backup, check")
+	assert.Contains(t, out, "Groups available")
+	assert.Contains(t, out, "full-backup")
+	assert.Contains(t, out, "All hosts")
+}
+
+func TestDisplayProfilesCommand_JSON(t *testing.T) {
+	ctx, buffer := newProfilesTestContext(t, []string{"profiles", "--output=json"})
+
+	require.NoError(t, displayProfilesCommand(ctx))
+
+	var got profilesOutput
+	require.NoError(t, json.Unmarshal(buffer.Bytes(), &got))
+
+	require.Len(t, got.Profiles, 2)
+	assert.Equal(t, profileEntry{
+		Name:        "alpha",
+		Description: "First profile",
+		Sections:    []string{"backup", "check"},
+	}, got.Profiles[0])
+	assert.Equal(t, profileEntry{
+		Name:        "beta",
+		Description: "Second profile",
+		Sections:    []string{},
+	}, got.Profiles[1])
+	require.Len(t, got.Groups, 1)
+	assert.Equal(t, groupEntry{
+		Name:        "full-backup",
+		Description: "All hosts",
+		Profiles:    []string{"alpha", "beta"},
+	}, got.Groups[0])
+}
+
+func TestDisplayProfilesCommand_JSONSpaceSeparated(t *testing.T) {
+	ctx, buffer := newProfilesTestContext(t, []string{"profiles", "--output", "json"})
+
+	require.NoError(t, displayProfilesCommand(ctx))
+
+	var got profilesOutput
+	require.NoError(t, json.Unmarshal(buffer.Bytes(), &got))
+	assert.NotEmpty(t, got.Profiles)
+}
+
+func TestDisplayProfilesCommand_InvalidFormat(t *testing.T) {
+	ctx, buffer := newProfilesTestContext(t, []string{"profiles", "--output=xml"})
+
+	err := displayProfilesCommand(ctx)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "xml")
+	assert.Empty(t, buffer.String())
 }

--- a/commands_output.go
+++ b/commands_output.go
@@ -7,9 +7,8 @@ import (
 // wantsStructuredOutput reports whether args request a machine-readable
 // output format via --output=<format> (anything other than plain). Used to
 // route diagnostic logs to stderr so stdout stays parseable for tools like
-// jq. Format validation is left to parseOutputFormat; an unrecognised value
-// is still treated as "structured" here so logs do not leak before the
-// command errors out.
+// jq. An unrecognised value is still treated as structured so logs do not
+// leak before the command rejects the value.
 func wantsStructuredOutput(args []string) bool {
 	value, ok := findOutputValue(args)
 	if !ok {
@@ -18,6 +17,9 @@ func wantsStructuredOutput(args []string) bool {
 	return value != "" && value != "plain"
 }
 
+// parseOutputFormat returns the --output=<format> value from args, or
+// "plain" when the flag is absent. The flag accepts both --output=<value>
+// and --output <value> forms. Callers validate the returned format.
 func parseOutputFormat(args []string) string {
 	format, found := findOutputValue(args)
 	if !found {

--- a/commands_output.go
+++ b/commands_output.go
@@ -1,0 +1,43 @@
+package main
+
+import (
+	"strings"
+)
+
+// wantsStructuredOutput reports whether args request a machine-readable
+// output format via --output=<format> (anything other than plain). Used to
+// route diagnostic logs to stderr so stdout stays parseable for tools like
+// jq. Format validation is left to parseOutputFormat; an unrecognised value
+// is still treated as "structured" here so logs do not leak before the
+// command errors out.
+func wantsStructuredOutput(args []string) bool {
+	value, ok := findOutputValue(args)
+	if !ok {
+		return false
+	}
+	return value != "" && value != "plain"
+}
+
+func parseOutputFormat(args []string) string {
+	format, found := findOutputValue(args)
+	if !found {
+		return "plain"
+	}
+	return format
+}
+
+func findOutputValue(args []string) (string, bool) {
+	const outputFlag = "--output"
+	value := ""
+	found := false
+	for i, arg := range args {
+		if v, ok := strings.CutPrefix(arg, outputFlag+"="); ok {
+			value, found = v, true
+			continue
+		}
+		if arg == outputFlag && i+1 < len(args) {
+			value, found = args[i+1], true
+		}
+	}
+	return value, found
+}

--- a/commands_output_test.go
+++ b/commands_output_test.go
@@ -1,0 +1,53 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestParseOutputFormat(t *testing.T) {
+	tests := []struct {
+		name string
+		args []string
+		want string
+	}{
+		{name: "absent returns plain", args: []string{"profiles"}, want: "plain"},
+		{name: "equals form", args: []string{"profiles", "--output=json"}, want: "json"},
+		{name: "space form", args: []string{"profiles", "--output", "json"}, want: "json"},
+		{name: "explicit plain", args: []string{"--output=plain"}, want: "plain"},
+		{name: "unknown value returned as-is", args: []string{"--output=yaml"}, want: "yaml"},
+		{name: "unrelated args ignored", args: []string{"--no-start", "--all", "--reload"}, want: "plain"},
+		{name: "last occurrence wins", args: []string{"--output=plain", "--output=json"}, want: "json"},
+		{name: "trailing --output without value treated as absent", args: []string{"--output"}, want: "plain"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, parseOutputFormat(tc.args))
+		})
+	}
+}
+
+func TestWantsStructuredOutput(t *testing.T) {
+	tests := []struct {
+		name string
+		args []string
+		want bool
+	}{
+		{name: "no args", args: nil, want: false},
+		{name: "no output flag", args: []string{"profiles", "--all"}, want: false},
+		{name: "plain is not structured", args: []string{"--output=plain"}, want: false},
+		{name: "json is structured", args: []string{"--output=json"}, want: true},
+		{name: "space-separated json", args: []string{"--output", "json"}, want: true},
+		{name: "unknown value is treated as structured", args: []string{"--output=yaml"}, want: true},
+		{name: "empty value is not structured", args: []string{"--output="}, want: false},
+		{name: "trailing --output without value", args: []string{"--output"}, want: false},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, wantsStructuredOutput(tc.args))
+		})
+	}
+}

--- a/docs/content/usage/_index.md
+++ b/docs/content/usage/_index.md
@@ -28,6 +28,12 @@ Groups available (name, profiles, description):
 
 ```
 
+For scripting, the same information is available as JSON via `--output=json`. Diagnostic log lines are routed to stderr in this mode, so stdout stays valid for parsers such as `jq`:
+
+```shell
+resticprofile profiles --output=json | jq '.profiles[].name'
+```
+
 Backup root & src profiles (using _full-backup_ group shown earlier)
 
 ```shell

--- a/logger.go
+++ b/logger.go
@@ -26,6 +26,14 @@ type LogCloser interface {
 	Close() error
 }
 
+// routeLogsToStderr redirects subsequently-constructed log handlers to
+// stderr. Used when the active command produces structured output on stdout
+// (e.g. --output=json) so log lines do not contaminate the data stream.
+// Must be called before any clog console handler is constructed.
+func routeLogsToStderr() {
+	color.Output = color.Error
+}
+
 func setupConsoleLogger(flags commandLineFlags) {
 	if flags.stderr {
 		out := color.Output

--- a/main.go
+++ b/main.go
@@ -76,6 +76,12 @@ func main() {
 		terminal = term.Set(term.NewTerminal(terminalOptions...))
 	}
 
+	// Route diagnostic logs to stderr when a command requests a structured
+	// stdout format (e.g. --output=json), so the data stream stays parseable.
+	if wantsStructuredOutput(flags.resticArgs) {
+		routeLogsToStderr()
+	}
+
 	if flags.wait {
 		// keep the console running at the end of the program
 		// so we can see what's going on


### PR DESCRIPTION
## Description

I want to be able to retrieve all defined profiles and then run some scripts on them. Currently, I parse profile names using `resticprofile profiles | awk ...`, but I would like a more flexible, robust approach that supports structured output such as JSON and pipes the result into `jq`.

## Summary

_Disclaimer: The code was originally written by Claude and then I polished it myself until I was happy with the result. :robot:_

- Add `--output=<format>` to the `profiles` command (`plain` default, `json` available) so callers can pipe profile/group metadata into `jq` and friends.
- JSON shape mirrors today's text output: each profile has `name`, `description`, `sections`; each group has `name`, `description`, `profiles`. Top-level object so it can grow non-breakingly later.
- When a structured format is requested, diagnostic logs (e.g. "using configuration file: …") are routed to stderr so stdout stays valid JSON.

## Test plan

- [x] `go test -count=1 -short .` passes
- [x] `golangci-lint run ./...` clean
- [x] `resticprofile profiles` output is unchanged (plain text path is byte-identical)
- [x] `resticprofile profiles --output=json | jq '.profiles[].name'` works end-to-end
- [x] `resticprofile profiles --output json` (space form) works
- [x] `resticprofile profiles --output=yaml` errors with `unknown output format "yaml"`
- [x] `resticprofile help profiles` lists the new flag