### PR TITLE
fix: preserve empty command-line arguments

### DIFF
--- a/shell/arg.go
+++ b/shell/arg.go
@@ -41,7 +41,7 @@ func NewArg(value string, argType ArgType, options ...ArgOption) Arg {
 	arg := Arg{
 		value:              value,
 		argType:            argType,
-		empty:              false,
+		empty:              value == "" && argType == ArgCommandLineEscape,
 		confidentialFilter: nil,
 	}
 	for _, option := range options {

--- a/shell/arg_test.go
+++ b/shell/arg_test.go
@@ -25,6 +25,12 @@ func TestEmptyArgValue(t *testing.T) {
 	}
 }
 
+func TestCommandLineEmptyArgValue(t *testing.T) {
+	t.Parallel()
+
+	assert.Equal(t, `""`, NewArg("", ArgCommandLineEscape).String())
+}
+
 func TestArgClone(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary

- preserve explicit empty values passed on the command line
- allow invocations such as `resticprofile snapshots -H ""` to reach restic unchanged
- add a regression test covering empty command-line arguments

## Root cause

An empty argv element was converted to a `shell.Arg` indistinguishable from a flag with no value. Its rendered value was therefore empty, and it disappeared when the shell command was composed.

## Validation

- confirmed the regression test failed before the fix: expected `""`, got an empty rendered argument
- `go test ./shell -count=1`
- `git diff --check`

The repository-wide test run was also attempted. Unrelated environment-dependent tests failed because `RESTIC_HOST` is set on the host, `crontab` is unavailable, and the host does not expose the expected I/O-priority behaviour.

Fixes #648
