### PR TITLE
feat: add link checking functionality to documentation workflows

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -48,7 +48,7 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v6
+      uses: actions/checkout@v7
 
     - name: Dotenv Action
       id: dotenv

--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -69,6 +69,10 @@ jobs:
           pages_path: ./public/
           cmd_params: '--exclude="(linux\.die\.net|scoop\.sh|stackoverflow\.com|commit)" --buffer-size=8192 --max-connections-per-host=8 --rate-limit=20 --color=always --skip-tls-verification --header="User-Agent: Muffet/2.10.8" --timeout=20'
 
+      - name: Check documentation links from code
+        run: go run ./checklinks -target=https://${{ steps.build_hugo.outputs.branch_name }}.resticprofile.pages.dev
+        shell: bash
+
       - name: Publish to pages.dev
         continue-on-error: true # secrets are not set for PRs from forks
         uses: cloudflare/wrangler-action@v3

--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -70,7 +70,7 @@ jobs:
           cmd_params: '--exclude="(linux\.die\.net|scoop\.sh|stackoverflow\.com|commit)" --buffer-size=8192 --max-connections-per-host=8 --rate-limit=20 --color=always --skip-tls-verification --header="User-Agent: Muffet/2.10.8" --timeout=20'
 
       - name: Check documentation links from code
-        run: go run ./checklinks -target=https://${{ steps.build_hugo.outputs.branch_name }}.resticprofile.pages.dev
+        run: go run ./checklinks -v -dir=./public/
         shell: bash
 
       - name: Publish to pages.dev

--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -7,11 +7,19 @@ on:
       - master
     paths:
       - "docs/**"
+      - ".github/workflows/doc.yml"
+      - "Makefile"
+      - "config/checkdoc/**"
+      - "checklinks/**"
 
   pull_request:
     types: [opened, synchronize, reopened]
     paths:
-      - 'docs/**'
+      - "docs/**"
+      - ".github/workflows/doc.yml"
+      - "Makefile"
+      - "config/checkdoc/**"
+      - "checklinks/**"
   
 jobs:
   build:
@@ -66,16 +74,16 @@ jobs:
           sed -i "s/canonifyURLs = true/canonifyURLs = false/g" hugo.toml
           hugo --minify --baseURL "https://${{ steps.branch_name.outputs.branch_name }}.resticprofile.pages.dev/"
 
+      - name: Check documentation links from code
+        run: go run ./checklinks -v -dir=./public/
+        shell: bash
+
       - name: Check broken links
         uses: ruzickap/action-my-broken-link-checker@v3
         with:
           url: "https://${{ steps.branch_name.outputs.branch_name }}.resticprofile.pages.dev/"
           pages_path: ./public/
-          cmd_params: '--exclude="(linux\.die\.net|scoop\.sh|stackoverflow\.com|commit)" --buffer-size=8192 --max-connections-per-host=8 --rate-limit=20 --color=always --skip-tls-verification --header="User-Agent: Muffet/2.10.8" --timeout=20'
-
-      - name: Check documentation links from code
-        run: go run ./checklinks -v -dir=./public/
-        shell: bash
+          cmd_params: '--exclude="(linux\.die\.net|scoop\.sh|stackoverflow\.com|commit)" --buffer-size=8192 --max-connections-per-host=8 --rate-limit=20 --color=always --skip-tls-verification --header="User-Agent: Muffet/2.10.8" --timeout=20 --accepted-status-codes=200..300,403,418'
 
       - name: Publish to pages.dev
         continue-on-error: true # secrets are not set for PRs from forks

--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -37,14 +37,22 @@ jobs:
           check-latest: true
           cache: true
 
-      - name: Check configuration snippets in documentation
-        run: go run ./config/checkdoc -r docs/content -i changelog.md
-        shell: bash
+      - name: Set branch name for pages.dev
+        id: branch_name
+        run: |
+          export BRANCH_NAME=$(echo ${GITHUB_REF_NAME} | tr / -)
+          echo "BRANCH_NAME=${BRANCH_NAME}" >> "$GITHUB_ENV"
+          echo "branch_name=${BRANCH_NAME}" >> "$GITHUB_OUTPUT"
         
       - name: Build JSON schema & config reference
         run: make generate-jsonschema generate-config-reference
         env:
+          WEB_BASE_URL: "https://${{ steps.branch_name.outputs.branch_name }}.resticprofile.pages.dev/"
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Check configuration snippets in documentation
+        run: go run ./config/checkdoc -r docs/content -i changelog.md
+        shell: bash
 
       - name: Setup Hugo
         uses: peaceiris/actions-hugo@v3
@@ -53,19 +61,15 @@ jobs:
           extended: true
 
       - name: Build
-        id: build_hugo
         run: |
           cd docs
           sed -i "s/canonifyURLs = true/canonifyURLs = false/g" hugo.toml
-          export BRANCH_NAME=$(echo ${GITHUB_REF_NAME} | tr / -)
-          echo "BRANCH_NAME=${BRANCH_NAME}" >> "$GITHUB_ENV"
-          echo "branch_name=${BRANCH_NAME}" >> "$GITHUB_OUTPUT"
-          hugo --minify --baseURL https://${BRANCH_NAME}.resticprofile.pages.dev/
+          hugo --minify --baseURL "https://${{ steps.branch_name.outputs.branch_name }}.resticprofile.pages.dev/"
 
       - name: Check broken links
         uses: ruzickap/action-my-broken-link-checker@v3
         with:
-          url: "https://${{ steps.build_hugo.outputs.branch_name }}.resticprofile.pages.dev/"
+          url: "https://${{ steps.branch_name.outputs.branch_name }}.resticprofile.pages.dev/"
           pages_path: ./public/
           cmd_params: '--exclude="(linux\.die\.net|scoop\.sh|stackoverflow\.com|commit)" --buffer-size=8192 --max-connections-per-host=8 --rate-limit=20 --color=always --skip-tls-verification --header="User-Agent: Muffet/2.10.8" --timeout=20'
 

--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -26,7 +26,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
 
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
         with:
           submodules: true  # Fetch Hugo themes (true OR recursive)
           fetch-depth: 0    # Fetch all history for .GitInfo and .Lastmod

--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -87,7 +87,7 @@ jobs:
 
       - name: Publish to pages.dev
         continue-on-error: true # secrets are not set for PRs from forks
-        uses: cloudflare/wrangler-action@v3
+        uses: cloudflare/wrangler-action@v4
         with:
           apiToken: ${{ secrets.CF_API_TOKEN }}
           accountId: ${{ secrets.CF_ACCOUNT_ID }}

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
           fetch-tags: true

--- a/.github/workflows/release-doc.yml
+++ b/.github/workflows/release-doc.yml
@@ -61,7 +61,7 @@ jobs:
           cmd_params: '--exclude="(linux\.die\.net|scoop\.sh|stackoverflow\.com|commit)" --buffer-size=8192 --max-connections-per-host=8 --rate-limit=20 --timeout=20 --header="User-Agent: Muffet/2.10.8" --skip-tls-verification'
 
       - name: Check documentation links from code
-        run: go run ./checklinks -target=https://creativeprojects.github.io/resticprofile
+        run: go run ./checklinks -v -dir=./www/resticprofile/
         shell: bash
 
       - name: Deploy to GitHub Pages

--- a/.github/workflows/release-doc.yml
+++ b/.github/workflows/release-doc.yml
@@ -60,6 +60,10 @@ jobs:
           pages_path: ./www/
           cmd_params: '--exclude="(linux\.die\.net|scoop\.sh|stackoverflow\.com|commit)" --buffer-size=8192 --max-connections-per-host=8 --rate-limit=20 --timeout=20 --header="User-Agent: Muffet/2.10.8" --skip-tls-verification'
 
+      - name: Check documentation links from code
+        run: go run ./checklinks -target=https://creativeprojects.github.io/resticprofile
+        shell: bash
+
       - name: Deploy to GitHub Pages
         uses: peaceiris/actions-gh-pages@v4
         # if: github.ref == 'refs/heads/main'

--- a/.github/workflows/release-doc.yml
+++ b/.github/workflows/release-doc.yml
@@ -33,17 +33,18 @@ jobs:
       - name: Check configuration snippets in documentation
         run: go run ./config/checkdoc -r docs/content -i changelog.md
         shell: bash
-        
-      - name: Build JSON schema & config reference
-        run: make generate-jsonschema generate-config-reference
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Setup Hugo
         uses: peaceiris/actions-hugo@v3
         with:
           hugo-version: '0.150.1'
           extended: true
+        
+      - name: Build JSON schema & config reference for GH Pages
+        run: make generate-jsonschema generate-config-reference
+        env:
+          WEB_BASE_URL: "https://creativeprojects.github.io/resticprofile"
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build for GitHub Pages
         run: cd docs && hugo --minify --baseURL https://creativeprojects.github.io/resticprofile/
@@ -53,16 +54,16 @@ jobs:
           mkdir -p ./www
           cp -r ./public ./www/resticprofile
 
+      - name: Check documentation links from code
+        run: go run ./checklinks -v -dir=./www/resticprofile/
+        shell: bash
+
       - name: Check broken links
         uses: ruzickap/action-my-broken-link-checker@v3
         with:
           url: https://creativeprojects.github.io/resticprofile/
           pages_path: ./www/
           cmd_params: '--exclude="(linux\.die\.net|scoop\.sh|stackoverflow\.com|commit)" --buffer-size=8192 --max-connections-per-host=8 --rate-limit=20 --timeout=20 --header="User-Agent: Muffet/2.10.8" --skip-tls-verification'
-
-      - name: Check documentation links from code
-        run: go run ./checklinks -v -dir=./www/resticprofile/
-        shell: bash
 
       - name: Deploy to GitHub Pages
         uses: peaceiris/actions-gh-pages@v4
@@ -71,6 +72,12 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_branch: gh-docs
           publish_dir: ./public
+        
+      - name: Build JSON schema & config reference for pages.dev
+        run: make generate-jsonschema generate-config-reference
+        env:
+          WEB_BASE_URL: "https://resticprofile.creativeprojects.tech"
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build for pages.dev
         run: |

--- a/.github/workflows/release-doc.yml
+++ b/.github/workflows/release-doc.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
 
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
         with:
           submodules: true  # Fetch Hugo themes (true OR recursive)
           fetch-depth: 0    # Fetch all history for .GitInfo and .Lastmod

--- a/.github/workflows/release-doc.yml
+++ b/.github/workflows/release-doc.yml
@@ -86,7 +86,7 @@ jobs:
           hugo --minify --baseURL https://resticprofile.creativeprojects.tech/
 
       - name: Publish to pages.dev
-        uses: cloudflare/wrangler-action@v3
+        uses: cloudflare/wrangler-action@v4
         with:
           apiToken: ${{ secrets.CF_API_TOKEN }}
           accountId: ${{ secrets.CF_ACCOUNT_ID }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Unshallow
         run: git fetch --prune --unshallow

--- a/.github/workflows/run-tests-os.yml
+++ b/.github/workflows/run-tests-os.yml
@@ -14,7 +14,7 @@ jobs:
 
     steps:
       - name: Check out code into the Go module directory
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Dotenv Action
         id: dotenv

--- a/.github/workflows/run-tests-vm.yml
+++ b/.github/workflows/run-tests-vm.yml
@@ -15,7 +15,7 @@ jobs:
     name: Run tests
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
       - name: Dotenv Action
         id: dotenv

--- a/.github/workflows/snapshot.yml
+++ b/.github/workflows/snapshot.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
           fetch-tags: true

--- a/.github/workflows/ssh.yml
+++ b/.github/workflows/ssh.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out code into the Go module directory
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Dotenv Action
         id: dotenv

--- a/checklinks/README.md
+++ b/checklinks/README.md
@@ -1,0 +1,74 @@
+# checklinks
+
+`checklinks` is a small Go program that validates every link found in the
+resticprofile source tree that starts with the documentation base URL.
+
+## What it does
+
+1. **Discovery** – walks all files under the current directory (skipping `.git`,
+   `.github`, `.vscode`, `build`, `dist`, `public`, and `docs`) and extracts
+   every URL that begins with the configured source base URL using a regular
+   expression.
+2. **Deduplication** – each unique URL is checked only once, and a small
+   built-in exclusion list (e.g. JSON-schema endpoints) is skipped.
+3. **Checking** – each URL is fetched with an HTTP GET request.  A response
+   with a 2xx or 3xx status code is considered successful.
+4. **Fragment validation** – when a URL contains a fragment (`#anchor`), the
+   response body is scanned for `id="anchor"` so that broken anchors are
+   caught as well.
+
+## Modes of operation
+
+### Local mode (default)
+
+When no `-target` flag is provided, the tool starts an in-process TLS server
+that serves the compiled HTML documentation from a local directory.  All
+discovered links are rewritten to point at that local server so no network
+access is required.
+
+```
+checklinks -dir ./public
+```
+
+### Remote mode
+
+When a `-target` URL is supplied, all requests are redirected from the source
+host to the target host at the TCP dial level.  This is useful for
+smoke-testing a staging deployment without modifying source files.
+
+```
+checklinks -source https://creativeprojects.github.io/resticprofile \
+           -target  https://staging.example.com
+```
+
+## Usage
+
+```
+checklinks [-v] [-source <url>] [-target <url>] [-dir <path>]
+```
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `-v` | `false` | Print each link as it is discovered (verbose). |
+| `-source` | `https://creativeprojects.github.io/resticprofile` | Base URL whose occurrences are searched for in files. |
+| `-target` | *(empty)* | Alternative base URL to send requests to. When omitted, a local server is started and `-dir` is required. |
+| `-dir` | *(empty)* | Directory containing the compiled HTML documentation. Required when `-target` is not given. |
+
+## Exit codes
+
+| Code | Meaning |
+|------|---------|
+| `0` | All links are valid. |
+| `1` | One or more links could not be verified, or the tool encountered a fatal configuration error. |
+
+## Building
+
+```sh
+go build ./checklinks
+```
+
+Or run directly without building:
+
+```sh
+go run ./checklinks -dir ./public
+```

--- a/checklinks/README.md
+++ b/checklinks/README.md
@@ -5,10 +5,9 @@ resticprofile source tree that starts with the documentation base URL.
 
 ## What it does
 
-1. **Discovery** – walks all files under the current directory (skipping `.git`,
-   `.github`, `.vscode`, `build`, `dist`, `public`, and `docs`) and extracts
-   every URL that begins with the configured source base URL using a regular
-   expression.
+1. **Discovery** – walks all files under the current directory (skipping directories
+   containing binaries) and extracts every URL that begins with the 
+   configured source base URL using a regular expression.
 2. **Deduplication** – each unique URL is checked only once, and a small
    built-in exclusion list (e.g. JSON-schema endpoints) is skipped.
 3. **Checking** – each URL is fetched with an HTTP GET request.  A response

--- a/checklinks/main.go
+++ b/checklinks/main.go
@@ -53,7 +53,7 @@ import (
 )
 
 var (
-	excludeDirs = []string{".git", ".github", ".vscode", "build", "dist", "public", "docs"}
+	excludeDirs = []string{".git", ".github", ".vscode", "build", "dist", "public", "docs", "checklinks"}
 	excludeURLs = []string{
 		"%s/jsonschema",
 		"%s/jsonschema/",

--- a/checklinks/main.go
+++ b/checklinks/main.go
@@ -1,9 +1,8 @@
 // checklinks is a link-checking tool for the resticprofile documentation.
 //
 // It scans all files in the current directory tree (skipping common non-doc
-// directories such as .git, build, and dist) for URLs that begin with the
-// configured source base URL, then verifies that every discovered URL returns
-// a successful HTTP response.
+// directories) for URLs that begin with the configured source base URL,
+// then verifies that every discovered URL returns a successful HTTP response.
 //
 // When checking links, the tool can operate in two modes:
 //
@@ -107,6 +106,11 @@ func checklinks() error {
 			}
 			return nil
 		}
+		// avoid reading binary files by skipping files with execution bits set
+		if fileInfo, err := d.Info(); err == nil && fileInfo.Mode()&0111 != 0 {
+			return nil
+		}
+
 		links, err := findPatternInFile(linkPattern, path)
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "error reading %s: %v\n", path, err)

--- a/checklinks/main.go
+++ b/checklinks/main.go
@@ -1,3 +1,37 @@
+// checklinks is a link-checking tool for the resticprofile documentation.
+//
+// It scans all files in the current directory tree (skipping common non-doc
+// directories such as .git, build, and dist) for URLs that begin with the
+// configured source base URL, then verifies that every discovered URL returns
+// a successful HTTP response.
+//
+// When checking links, the tool can operate in two modes:
+//
+//  1. Local mode (default): starts an in-process HTTPS server that serves the
+//     compiled documentation from a local directory, then checks all links
+//     against that server.  Use -dir to point at the directory.
+//
+//  2. Remote mode: redirects all requests to an alternative base URL supplied
+//     via -target.  Useful for smoke-testing a staging deployment without
+//     rewriting every link in the source files.
+//
+// In addition to checking HTTP status codes, the tool validates URL fragments
+// (e.g. /page#section) by searching the response body for the corresponding
+// id="…" attribute, so broken anchors are caught as well.
+//
+// Usage:
+//
+//	checklinks [-v] [-source <url>] [-target <url>] [-dir <path>]
+//
+// Flags:
+//
+//	-v          Print each link as it is discovered (verbose output).
+//	-source     Base URL whose occurrences are searched for in files.
+//	            Defaults to https://creativeprojects.github.io/resticprofile.
+//	-target     Alternative base URL to send requests to.  When omitted, a
+//	            local server is started and -dir must be provided.
+//	-dir        Directory containing the compiled HTML documentation.
+//	            Required when -target is not specified.
 package main
 
 import (
@@ -8,10 +42,12 @@ import (
 	"io/fs"
 	"net"
 	"net/http"
+	"net/http/httptest"
 	"net/url"
 	"os"
 	"os/signal"
 	"regexp"
+	"slices"
 	"strings"
 	"time"
 )
@@ -37,10 +73,12 @@ func checklinks() error {
 		verboseFlag   bool
 		sourceURLFlag string
 		targetURLFlag string
+		dirFlag       string
 	)
 	flag.BoolVar(&verboseFlag, "v", false, "display more information")
 	flag.StringVar(&sourceURLFlag, "source", "https://creativeprojects.github.io/resticprofile", "base URL to find links from")
 	flag.StringVar(&targetURLFlag, "target", "", "base URL to check links against (leave empty to check against source URL)")
+	flag.StringVar(&dirFlag, "dir", "", "directory with HTML documentation")
 	flag.Parse()
 
 	if sourceURLFlag == "" {
@@ -64,7 +102,7 @@ func checklinks() error {
 			return nil
 		}
 		if d.IsDir() {
-			if contains(excludeDirs, d.Name()) {
+			if slices.Contains(excludeDirs, d.Name()) {
 				return fs.SkipDir
 			}
 			return nil
@@ -75,7 +113,7 @@ func checklinks() error {
 			return nil
 		}
 		for _, link := range links {
-			if !contains(allLinks, link) && !contains(excludeURLs, link) {
+			if !slices.Contains(allLinks, link) && !slices.Contains(excludeURLs, link) {
 				allLinks = append(allLinks, link)
 			}
 			if verboseFlag {
@@ -102,7 +140,25 @@ func checklinks() error {
 			return fmt.Errorf("parsing target URL: %w", err)
 		}
 	}
-	httpClient := newHTTPClient(source, target)
+
+	var transport *http.Transport
+	if target == "" {
+		// Start a local server to serve the documentation if no target URL is provided
+		if dirFlag == "" {
+			return fmt.Errorf("directory must be specified when no target URL is provided")
+		}
+		server := startServer(dirFlag)
+		defer server.Close()
+
+		targetURLFlag = server.URL
+		target, err = hostname(targetURLFlag)
+		if err != nil {
+			return fmt.Errorf("parsing local server URL: %w", err)
+		}
+		fmt.Printf("Started local server at %s serving directory %s\n", targetURLFlag, dirFlag)
+		transport = server.Client().Transport.(*http.Transport)
+	}
+	httpClient := newHTTPClient(source, target, transport)
 
 	hasErrors := false
 	fmt.Printf("Checking %d links\n", len(allLinks))
@@ -136,15 +192,6 @@ func findPatternInFile(pattern *regexp.Regexp, path string) ([]string, error) {
 	return pattern.FindAllString(string(rawBytes), -1), nil
 }
 
-func contains(slice []string, item string) bool {
-	for _, s := range slice {
-		if s == item {
-			return true
-		}
-	}
-	return false
-}
-
 func checkLink(ctx context.Context, client *http.Client, link string) error {
 	request, err := http.NewRequestWithContext(ctx, http.MethodGet, link, http.NoBody)
 	if err != nil {
@@ -172,8 +219,11 @@ func checkLink(ctx context.Context, client *http.Client, link string) error {
 	return nil
 }
 
-func newHTTPClient(source, target string) *http.Client {
-	transport := http.DefaultTransport.(*http.Transport).Clone()
+func newHTTPClient(source, target string, transport *http.Transport) *http.Client {
+	if transport == nil {
+		transport = http.DefaultTransport.(*http.Transport)
+	}
+	transport = transport.Clone()
 
 	if target != "" {
 		fmt.Printf("Redirecting requests from %s to %s\n", source, target)
@@ -208,4 +258,8 @@ func hostname(rawURL string) (string, error) {
 		}
 	}
 	return fmt.Sprintf("%s:%s", parts.Hostname(), port), nil
+}
+
+func startServer(root string) *httptest.Server {
+	return httptest.NewTLSServer(http.FileServer(http.Dir(root)))
 }

--- a/checklinks/main.go
+++ b/checklinks/main.go
@@ -1,0 +1,122 @@
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"io"
+	"io/fs"
+	"net/http"
+	"os"
+	"regexp"
+	"strings"
+)
+
+var (
+	excludeDirs = []string{".git", ".github", ".vscode", "build", "dist", "public", "docs"}
+	linkPattern = regexp.MustCompile(`https?://creativeprojects\.github\.io/resticprofile[^\s"\)>]*`)
+	verbose     = false
+	sourceURL   = "https://creativeprojects.github.io/resticprofile"
+	targetURL   = ""
+	excludeURLs = []string{
+		"https://creativeprojects.github.io/resticprofile/jsonschema",
+		"https://creativeprojects.github.io/resticprofile/jsonschema/",
+	}
+)
+
+func main() {
+	flag.BoolVar(&verbose, "v", false, "display more information")
+	flag.StringVar(&targetURL, "target", "http://127.0.0.1:1313/resticprofile", "base URL to check links against")
+	flag.Parse()
+
+	allLinks := make([]string, 0)
+	_ = fs.WalkDir(os.DirFS("."), ".", func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Error opening %s: %v\n", path, err)
+			return err
+		}
+		if d.IsDir() {
+			if contains(excludeDirs, d.Name()) {
+				return fs.SkipDir
+			}
+			return nil
+		}
+		links, err := findLinks(path)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Error reading %s: %v\n", path, err)
+			return nil
+		}
+		for _, link := range links {
+			if !contains(allLinks, link) && !contains(excludeURLs, link) {
+				allLinks = append(allLinks, link)
+			}
+			if verbose {
+				fmt.Printf("%s: %s\n", path, link)
+			}
+		}
+		return nil
+	})
+
+	hasErrors := false
+	fmt.Printf("Checking %d links\n", len(allLinks))
+	for _, link := range allLinks {
+		targetLink := strings.Replace(link, sourceURL, targetURL, 1)
+		err := checkLink(context.Background(), targetLink)
+		if err != nil {
+			fmt.Printf("[ Error ] %s => %v\n", targetLink, err)
+			hasErrors = true
+			continue
+		}
+		fmt.Printf("[  OK   ] %s\n", targetLink)
+	}
+	if hasErrors {
+		os.Exit(1)
+	}
+}
+
+func findLinks(path string) ([]string, error) {
+	rawBytes, err := os.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+
+	links := linkPattern.FindAllString(string(rawBytes), -1)
+
+	return links, nil
+}
+
+func contains(slice []string, item string) bool {
+	for _, s := range slice {
+		if s == item {
+			return true
+		}
+	}
+	return false
+}
+
+func checkLink(ctx context.Context, link string) error {
+	request, err := http.NewRequestWithContext(ctx, http.MethodGet, link, http.NoBody)
+	if err != nil {
+		return err
+	}
+	response, err := http.DefaultClient.Do(request)
+	if err != nil {
+		return err
+	}
+	defer response.Body.Close()
+
+	if response.StatusCode < 200 || response.StatusCode >= 400 {
+		return fmt.Errorf("HTTP %d", response.StatusCode)
+	}
+
+	content, err := io.ReadAll(response.Body)
+	if err != nil {
+		return err
+	}
+	if _, id, found := strings.Cut(link, "#"); found {
+		if !strings.Contains(string(content), `id="`+id+`"`) {
+			return fmt.Errorf("fragment %q not found in page", id)
+		}
+	}
+	return nil
+}

--- a/checklinks/main.go
+++ b/checklinks/main.go
@@ -88,7 +88,7 @@ func checklinks() error {
 		return nil
 	})
 	if err != nil {
-		return fmt.Errorf("walking directory: %w\n", err)
+		return fmt.Errorf("walking directory: %w", err)
 	}
 
 	source, err := hostname(sourceURLFlag)

--- a/checklinks/main.go
+++ b/checklinks/main.go
@@ -6,34 +6,62 @@ import (
 	"fmt"
 	"io"
 	"io/fs"
+	"net"
 	"net/http"
+	"net/url"
 	"os"
+	"os/signal"
 	"regexp"
 	"strings"
+	"time"
 )
 
 var (
 	excludeDirs = []string{".git", ".github", ".vscode", "build", "dist", "public", "docs"}
-	linkPattern = regexp.MustCompile(`https?://creativeprojects\.github\.io/resticprofile[^\s"\)>]*`)
-	verbose     = false
-	sourceURL   = "https://creativeprojects.github.io/resticprofile"
-	targetURL   = ""
 	excludeURLs = []string{
-		"https://creativeprojects.github.io/resticprofile/jsonschema",
-		"https://creativeprojects.github.io/resticprofile/jsonschema/",
+		"%s/jsonschema",
+		"%s/jsonschema/",
 	}
 )
 
 func main() {
-	flag.BoolVar(&verbose, "v", false, "display more information")
-	flag.StringVar(&targetURL, "target", "http://127.0.0.1:1313/resticprofile", "base URL to check links against")
+	err := checklinks()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "error: %v\n", err)
+		os.Exit(1)
+	}
+}
+
+func checklinks() error {
+	var (
+		verboseFlag   bool
+		sourceURLFlag string
+		targetURLFlag string
+	)
+	flag.BoolVar(&verboseFlag, "v", false, "display more information")
+	flag.StringVar(&sourceURLFlag, "source", "https://creativeprojects.github.io/resticprofile", "base URL to find links from")
+	flag.StringVar(&targetURLFlag, "target", "", "base URL to check links against (leave empty to check against source URL)")
 	flag.Parse()
 
+	if sourceURLFlag == "" {
+		return fmt.Errorf("source URL must be specified")
+	}
+	linkPattern, err := regexp.Compile(regexp.QuoteMeta(sourceURLFlag) + `[^\s"\)>]*`)
+	if err != nil {
+		return fmt.Errorf("compiling regex: %w", err)
+	}
+	for i, url := range excludeURLs {
+		excludeURLs[i] = fmt.Sprintf(url, sourceURLFlag)
+	}
+
+	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt)
+	defer stop()
+
 	allLinks := make([]string, 0)
-	_ = fs.WalkDir(os.DirFS("."), ".", func(path string, d fs.DirEntry, err error) error {
+	err = fs.WalkDir(os.DirFS("."), ".", func(path string, d fs.DirEntry, err error) error {
 		if err != nil {
-			fmt.Fprintf(os.Stderr, "Error opening %s: %v\n", path, err)
-			return err
+			fmt.Fprintf(os.Stderr, "error opening %s: %v\n", path, err)
+			return nil
 		}
 		if d.IsDir() {
 			if contains(excludeDirs, d.Name()) {
@@ -41,27 +69,52 @@ func main() {
 			}
 			return nil
 		}
-		links, err := findLinks(path)
+		links, err := findPatternInFile(linkPattern, path)
 		if err != nil {
-			fmt.Fprintf(os.Stderr, "Error reading %s: %v\n", path, err)
+			fmt.Fprintf(os.Stderr, "error reading %s: %v\n", path, err)
 			return nil
 		}
 		for _, link := range links {
 			if !contains(allLinks, link) && !contains(excludeURLs, link) {
 				allLinks = append(allLinks, link)
 			}
-			if verbose {
+			if verboseFlag {
 				fmt.Printf("%s: %s\n", path, link)
 			}
 		}
+		if ctx.Err() != nil {
+			return ctx.Err()
+		}
 		return nil
 	})
+	if err != nil {
+		return fmt.Errorf("walking directory: %w\n", err)
+	}
+
+	source, err := hostname(sourceURLFlag)
+	if err != nil {
+		return fmt.Errorf("parsing source URL: %w", err)
+	}
+	target := ""
+	if targetURLFlag != "" {
+		target, err = hostname(targetURLFlag)
+		if err != nil {
+			return fmt.Errorf("parsing target URL: %w", err)
+		}
+	}
+	httpClient := newHTTPClient(source, target)
 
 	hasErrors := false
 	fmt.Printf("Checking %d links\n", len(allLinks))
 	for _, link := range allLinks {
-		targetLink := strings.Replace(link, sourceURL, targetURL, 1)
-		err := checkLink(context.Background(), targetLink)
+		if ctx.Err() != nil {
+			return ctx.Err()
+		}
+		targetLink := link
+		if targetURLFlag != "" {
+			targetLink = strings.Replace(link, sourceURLFlag, targetURLFlag, 1)
+		}
+		err := checkLink(ctx, httpClient, targetLink)
 		if err != nil {
 			fmt.Printf("[ Error ] %s => %v\n", targetLink, err)
 			hasErrors = true
@@ -70,19 +123,17 @@ func main() {
 		fmt.Printf("[  OK   ] %s\n", targetLink)
 	}
 	if hasErrors {
-		os.Exit(1)
+		return fmt.Errorf("some links failed to check")
 	}
+	return nil
 }
 
-func findLinks(path string) ([]string, error) {
+func findPatternInFile(pattern *regexp.Regexp, path string) ([]string, error) {
 	rawBytes, err := os.ReadFile(path)
 	if err != nil {
 		return nil, err
 	}
-
-	links := linkPattern.FindAllString(string(rawBytes), -1)
-
-	return links, nil
+	return pattern.FindAllString(string(rawBytes), -1), nil
 }
 
 func contains(slice []string, item string) bool {
@@ -94,12 +145,12 @@ func contains(slice []string, item string) bool {
 	return false
 }
 
-func checkLink(ctx context.Context, link string) error {
+func checkLink(ctx context.Context, client *http.Client, link string) error {
 	request, err := http.NewRequestWithContext(ctx, http.MethodGet, link, http.NoBody)
 	if err != nil {
 		return err
 	}
-	response, err := http.DefaultClient.Do(request)
+	response, err := client.Do(request)
 	if err != nil {
 		return err
 	}
@@ -119,4 +170,42 @@ func checkLink(ctx context.Context, link string) error {
 		}
 	}
 	return nil
+}
+
+func newHTTPClient(source, target string) *http.Client {
+	transport := http.DefaultTransport.(*http.Transport).Clone()
+
+	if target != "" {
+		fmt.Printf("Redirecting requests from %s to %s\n", source, target)
+		dialer := &net.Dialer{
+			Timeout:   30 * time.Second,
+			KeepAlive: 30 * time.Second,
+		}
+		transport.DialContext = func(ctx context.Context, network, addr string) (net.Conn, error) {
+			if addr == source {
+				addr = target
+			}
+			fmt.Printf("Dialing %s\n", addr)
+			return dialer.DialContext(ctx, network, addr)
+		}
+	}
+
+	httpClient := &http.Client{Transport: transport, Timeout: 30 * time.Second}
+	return httpClient
+}
+
+func hostname(rawURL string) (string, error) {
+	parts, err := url.Parse(rawURL)
+	if err != nil {
+		return "", fmt.Errorf("parsing URL: %w", err)
+	}
+	port := parts.Port()
+	if port == "" {
+		if parts.Scheme == "https" {
+			port = "443"
+		} else {
+			port = "80"
+		}
+	}
+	return fmt.Sprintf("%s:%s", parts.Hostname(), port), nil
 }

--- a/checklinks/main.go
+++ b/checklinks/main.go
@@ -218,9 +218,11 @@ func checkLink(ctx context.Context, client *http.Client, link string) error {
 		return err
 	}
 	if _, id, found := strings.Cut(link, "#"); found {
-		if !strings.Contains(string(content), `id="`+id+`"`) {
+		if !strings.Contains(string(content), `id="`+id+`"`) &&
+			!strings.Contains(string(content), `id=`+id+` `) &&
+			!strings.Contains(string(content), `id=`+id+`>`) {
 			if verboseFlag {
-				return fmt.Errorf("fragment %q not found in page: %s", id, string(content))
+				return fmt.Errorf("fragment %q not found in page\n::group::{page content}\n%s\n::endgroup::\n", id, string(content))
 			}
 			return fmt.Errorf("fragment %q not found in page", id)
 		}

--- a/checklinks/main.go
+++ b/checklinks/main.go
@@ -222,7 +222,7 @@ func checkLink(ctx context.Context, client *http.Client, link string) error {
 			!strings.Contains(string(content), `id=`+id+` `) &&
 			!strings.Contains(string(content), `id=`+id+`>`) {
 			if verboseFlag {
-				return fmt.Errorf("fragment %q not found in page\n::group::{page content}\n%s\n::endgroup::\n", id, string(content))
+				fmt.Printf("\n::group::{page content}\n%s\n::endgroup::\n", string(content))
 			}
 			return fmt.Errorf("fragment %q not found in page", id)
 		}

--- a/checklinks/main.go
+++ b/checklinks/main.go
@@ -57,6 +57,7 @@ var (
 		"%s/jsonschema",
 		"%s/jsonschema/",
 	}
+	verboseFlag bool
 )
 
 func main() {
@@ -69,7 +70,6 @@ func main() {
 
 func checklinks() error {
 	var (
-		verboseFlag   bool
 		sourceURLFlag string
 		targetURLFlag string
 		dirFlag       string
@@ -201,6 +201,8 @@ func checkLink(ctx context.Context, client *http.Client, link string) error {
 	if err != nil {
 		return err
 	}
+	request.Header.Add("Accept", "*/*")
+
 	response, err := client.Do(request)
 	if err != nil {
 		return err
@@ -217,6 +219,9 @@ func checkLink(ctx context.Context, client *http.Client, link string) error {
 	}
 	if _, id, found := strings.Cut(link, "#"); found {
 		if !strings.Contains(string(content), `id="`+id+`"`) {
+			if verboseFlag {
+				return fmt.Errorf("fragment %q not found in page: %s", id, string(content))
+			}
 			return fmt.Errorf("fragment %q not found in page", id)
 		}
 	}

--- a/codecov.yml
+++ b/codecov.yml
@@ -13,6 +13,8 @@ ignore:
   - qemu/
   - "**/mocks/*.go"
   - testhelpers/
+  - config/checkdoc/
+  - checklinks/
 
 codecov:
   notify:

--- a/config/checkdoc/main.go
+++ b/config/checkdoc/main.go
@@ -23,7 +23,6 @@ const (
 
 var (
 	urlPattern = regexp.MustCompile(`{{< [^>}]+config(-\d)?\.json"[^>}]+ >}}`)
-	_          = regexp.MustCompile(`{{< [^>}]+config(-\d)?\.json"[^>}]+ >}}`) // Remove this when VS Code fixed the syntax highlighting issues
 )
 
 var (


### PR DESCRIPTION
# checklinks

`checklinks` is a small Go program that validates every link found in the
resticprofile source tree that starts with the documentation base URL.

## What it does

1. **Discovery** – walks all files under the current directory and extracts
   every URL that begins with the configured source base URL using a regular
   expression.
2. **Deduplication** – each unique URL is checked only once, and a small
   built-in exclusion list (e.g. JSON-schema endpoints) is skipped.
3. **Checking** – each URL is fetched with an HTTP GET request.  A response
   with a 2xx or 3xx status code is considered successful.
4. **Fragment validation** – when a URL contains a fragment (`#anchor`), the
   response body is scanned for `id="anchor"` so that broken anchors are
   caught as well.

## Modes of operation

### Local mode (default)

When no `-target` flag is provided, the tool starts an in-process TLS server
that serves the compiled HTML documentation from a local directory.  All
discovered links are rewritten to point at that local server so no network
access is required.

```
checklinks -dir ./public
```

### Remote mode

When a `-target` URL is supplied, all requests are redirected from the source
host to the target host at the TCP dial level.  This is useful for
smoke-testing a staging deployment without modifying source files.

```
checklinks -source https://creativeprojects.github.io/resticprofile \
           -target  https://staging.example.com
```

## Usage

```
checklinks [-v] [-source <url>] [-target <url>] [-dir <path>]
```

| Flag | Default | Description |
|------|---------|-------------|
| `-v` | `false` | Print each link as it is discovered (verbose). |
| `-source` | `https://creativeprojects.github.io/resticprofile` | Base URL whose occurrences are searched for in files. |
| `-target` | *(empty)* | Alternative base URL to send requests to. When omitted, a local server is started and `-dir` is required. |
| `-dir` | *(empty)* | Directory containing the compiled HTML documentation. Required when `-target` is not given. |

## Exit codes

| Code | Meaning |
|------|---------|
| `0` | All links are valid. |
| `1` | One or more links could not be verified, or the tool encountered a fatal configuration error. |

## Building

```sh
go build ./checklinks
```

Or run directly without building:

```sh
go run ./checklinks -dir ./public
```
