### PR TITLE
test: increase duration thresholds in command tests

### DIFF
--- a/shell/command_test.go
+++ b/shell/command_test.go
@@ -434,9 +434,9 @@ func TestSummaryDurationCommand(t *testing.T) {
 	require.NoError(t, err)
 
 	// make sure the command ran properly
-	assert.WithinDuration(t, time.Now(), start.Add(1*time.Second), 500*time.Millisecond)
+	assert.WithinDuration(t, time.Now(), start.Add(1*time.Second), 4*time.Second)
 	assert.GreaterOrEqual(t, summary.Duration.Milliseconds(), int64(1000))
-	assert.Less(t, summary.Duration.Milliseconds(), int64(1500))
+	assert.Less(t, summary.Duration.Milliseconds(), int64(5000))
 }
 
 func TestSummaryDurationSignalledCommand(t *testing.T) {
@@ -459,9 +459,9 @@ func TestSummaryDurationSignalledCommand(t *testing.T) {
 	require.NoError(t, err)
 
 	// make sure the command ran properly
-	assert.WithinDuration(t, time.Now(), start.Add(1*time.Second), 500*time.Millisecond)
+	assert.WithinDuration(t, time.Now(), start.Add(1*time.Second), 4*time.Second)
 	assert.GreaterOrEqual(t, summary.Duration.Milliseconds(), int64(1000))
-	assert.Less(t, summary.Duration.Milliseconds(), int64(1500))
+	assert.Less(t, summary.Duration.Milliseconds(), int64(5000))
 }
 
 func TestStderr(t *testing.T) {

--- a/shell/command_unix_test.go
+++ b/shell/command_unix_test.go
@@ -21,17 +21,17 @@ func TestInterruptShellCommand(t *testing.T) {
 	cmd := NewSignalledCommand(mockBinary, []string{"test", "--sleep", "3000"}, sigChan)
 	cmd.Stdout = buffer
 
-	// Will ask us to stop in 100ms
+	// Will ask us to stop in 500ms
 	go func() {
-		time.Sleep(100 * time.Millisecond)
+		time.Sleep(500 * time.Millisecond)
 		sigChan <- syscall.SIGINT
 	}()
 	start := time.Now()
 	_, _, err := cmd.Run()
 	require.Error(t, err)
 
-	// check it ran for more than 100ms (but less than a second - the build agent can be slow)
+	// check it ran for more than 500ms (but well under the 3000ms sleep - the build agent can be slow)
 	duration := time.Since(start)
-	assert.GreaterOrEqual(t, duration.Milliseconds(), int64(100))
-	assert.Less(t, duration.Milliseconds(), int64(1000))
+	assert.GreaterOrEqual(t, duration.Milliseconds(), int64(500))
+	assert.Less(t, duration.Milliseconds(), int64(3000))
 }


### PR DESCRIPTION
Fixes #645 