### PR TITLE
fix: report the real error when the log target cannot be opened

### DIFF
--- a/main.go
+++ b/main.go
@@ -137,7 +137,8 @@ func main() {
 			}
 		}
 		if logTarget != "" && logTarget != "-" {
-			if closer, options, err := setupTargetLogger(flags, terminal, logTarget, commandOutput); err == nil {
+			closer, options, err := setupTargetLogger(flags, terminal, logTarget, commandOutput)
+			if err == nil {
 				logCloser = func() { _ = closer.Close() }
 				terminalOptions = append(terminalOptions, options...)
 				return


### PR DESCRIPTION
## Problem

When a `log` target cannot be opened, the error message discards the actual reason:

```
cannot open log target: %!s(<nil>)
```

I hit this with a scheduled profile whose `log` pointed into a directory that did not exist. The message gave me nothing to go on, and the real cause (`no such file or directory`) was never printed.

## Cause

In `main.go`, `err` is declared in the `if` statement's init:

```go
if closer, options, err := setupTargetLogger(flags, terminal, logTarget, commandOutput); err == nil {
    ...
    return
}
// fallback to a console logger
setupConsoleLogger(flags)
clog.Errorf("cannot open log target: %s", err)
```

Go scopes that `err` to the `if` statement, so it is out of scope by the time `clog.Errorf` runs. The call therefore resolves to `main()`'s outer `var err error` (main.go:39), which is still `nil` at that point — hence `%!s(<nil>)`. It compiles precisely because that outer variable exists.

## Fix

Hoist the call out of the `if` init so the error is in scope where it is logged. Two lines, no behaviour change beyond the message.

## Verification

Same command, before and after:

```
# before
$ resticprofile --log /nonexistent-dir/test.log -n profile show
cannot open log target: %!s(<nil>)

# after
$ resticprofile --log /nonexistent-dir/test.log -n profile show
cannot open log target: open /nonexistent-dir/test.log: no such file or directory
```

`make build` and `make lint` pass (0 issues on darwin, linux and windows). `make test` shows no new failures.

I did not add a unit test: the affected code is a closure inside `main()`, so covering it would require refactoring `setupLogging` out of `main` — happy to do that in this PR if you would prefer it.