### PR TITLE
build: exclude the sbom asset when fetching golangci-lint

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -104,7 +104,7 @@ $(GOBIN)/mockery: verify $(GOBIN)/eget
 
 $(GOBIN)/golangci-lint-v2: verify $(GOBIN)/eget
 	@echo "[*] $@"
-	"$(GOBIN)/eget" golangci/golangci-lint --tag v2.12.2 --asset=tar.gz --upgrade-only --to '$(GOBIN)/golangci-lint-v2'
+	"$(GOBIN)/eget" golangci/golangci-lint --tag v2.12.2 --asset=tar.gz --asset=^sbom --upgrade-only --to '$(GOBIN)/golangci-lint-v2'
 
 $(GOBIN)/hugo: $(GOBIN)/eget
 	@echo "[*] $@"


### PR DESCRIPTION
## Problem

`make lint` fails on any machine that does not already have the pinned linter, whenever stdin is not a TTY (CI step, container, editor task, agent shell):

```
[*] /home/user/go/bin/golangci-lint-v2
"/home/user/go/bin/eget" golangci/golangci-lint --tag v2.12.2 --asset=tar.gz --upgrade-only --to '/home/user/go/bin/golangci-lint-v2'
2 candidates found for asset chain: please select manually
(1) golangci-lint-2.12.2-linux-amd64.tar.gz
(2) golangci-lint-2.12.2-linux-amd64.tar.gz.sbom.json
Enter selection number: Error reading selection
make: *** [Makefile:107: /home/user/go/bin/golangci-lint-v2] Error 1
```

The golangci-lint release publishes `…-linux-amd64.tar.gz.sbom.json` next to `…-linux-amd64.tar.gz`. `--asset=tar.gz` is a substring match, so it matches both and eget prompts for a choice. With no TTY to answer, the target fails and takes `make lint` with it.

It works once the binary is present, because `--upgrade-only` then skips the fetch — so this only bites on a fresh checkout or a new machine, which is exactly when a contributor is least equipped to debug it.

## Fix

Add eget's `^` exclusion prefix so the match is unambiguous.

## Verification

Removed the installed binary to force a re-fetch, then ran `make lint` with stdin not a TTY:

```
[*] /home/user/go/bin/golangci-lint-v2
"…/eget" golangci/golangci-lint --tag v2.12.2 --asset=tar.gz --asset=^sbom --upgrade-only --to '…/golangci-lint-v2'
https://github.com/golangci/golangci-lint/releases/download/v2.12.2/golangci-lint-2.12.2-linux-amd64.tar.gz
Extracted `golangci-lint-2.12.2-linux-amd64/golangci-lint` to `…/golangci-lint-v2`
[*] lint
GOOS=darwin  …/golangci-lint-v2 run → 0 issues.
GOOS=linux   …/golangci-lint-v2 run → 0 issues.
GOOS=windows …/golangci-lint-v2 run → 0 issues.
```

## Note

Only the golangci-lint target needs this today — the `mockery` and `hugo` releases don't currently publish a colliding asset, so I left those lines alone. The same one-word fix would apply if they ever do.

🤖 Generated with [Claude Code](https://claude.com/claude-code)