### PR TITLE
test(schedule): ignore pre-existing schedules in the final assertion

### DIFF
--- a/schedule/handler_systemd_test.go
+++ b/schedule/handler_systemd_test.go
@@ -111,16 +111,7 @@ func TestReadingSystemdScheduled(t *testing.T) {
 	scheduled, err := handler.Scheduled("")
 	require.NoError(t, err)
 
-	testScheduled := make([]Config, 0, len(scheduled))
-	for _, s := range scheduled {
-		if s.ConfigFile != "config file.yaml" && s.ConfigFile != "examples/dev.yaml" {
-			t.Logf("Ignoring config file %s", s.ConfigFile)
-			continue
-		}
-		testScheduled = append(testScheduled, s)
-	}
-
-	assert.ElementsMatch(t, expectedJobs, testScheduled)
+	assert.ElementsMatch(t, expectedJobs, onlyTestSchedules(t, scheduled))
 
 	// now delete all schedules
 	for _, testCase := range testCases {
@@ -130,7 +121,23 @@ func TestReadingSystemdScheduled(t *testing.T) {
 
 	scheduled, err = handler.Scheduled("")
 	require.NoError(t, err)
-	assert.Empty(t, scheduled)
+	assert.Empty(t, onlyTestSchedules(t, scheduled))
+}
+
+// onlyTestSchedules keeps the schedules created by this test and drops everything else.
+// Scheduled() reads the real user unit directory, so on a machine that actually uses
+// resticprofile it also returns the developer's own schedules.
+func onlyTestSchedules(t *testing.T, scheduled []Config) []Config {
+	t.Helper()
+	filtered := make([]Config, 0, len(scheduled))
+	for _, s := range scheduled {
+		if s.ConfigFile != "config file.yaml" && s.ConfigFile != "examples/dev.yaml" {
+			t.Logf("Ignoring config file %s", s.ConfigFile)
+			continue
+		}
+		filtered = append(filtered, s)
+	}
+	return filtered
 }
 
 func TestDetectPermissionSystemd(t *testing.T) {


### PR DESCRIPTION
## Problem

`TestReadingSystemdScheduled` fails on any machine that has a real resticprofile schedule installed:

```
    Error Trace:  schedule/handler_systemd_test.go:133
    Error:        Should be empty, but was [{dot-files backup [hourly] user_logged_on  /home/user/.config/resticprofile
                  /home/user/go/bin/resticprofile --no-ansi --config /home/user/.config/resticprofile/profiles.yaml
                  run-schedule backup@dot-files ...}]
    Test:         TestReadingSystemdScheduled
```

`Scheduled()` reads the user's real systemd unit directory, so it returns the developer's own schedules alongside the two the test creates.

The test already accounts for this when it builds the list it compares with `ElementsMatch` — it skips anything whose `ConfigFile` isn't one of its own fixtures. But the final `assert.Empty` check a few lines later uses the raw, unfiltered slice, so it sees whatever else happens to be installed on the machine.

Net effect: the suite passes on a clean CI runner and fails locally for anyone who actually uses resticprofile.

## Fix

Extract the filter the test already contains into a small helper and use it in both assertions. No production code touched.

## Verification

Before, on a machine with one real hourly schedule installed:

```
--- FAIL: TestReadingSystemdScheduled (1.32s)
```

After:

```
=== RUN   TestReadingSystemdScheduled
    handler_systemd_test.go:114: Ignoring config file /home/user/.config/resticprofile/profiles.yaml
    handler_systemd_test.go:124: Ignoring config file /home/user/.config/resticprofile/profiles.yaml
--- PASS: TestReadingSystemdScheduled (1.95s)
ok      github.com/creativeprojects/resticprofile/schedule
```

The two log lines are the same real schedule being skipped at each of the two filter points, which is exactly the case that was failing.

`make build` and `make lint` pass (0 issues on darwin, linux and windows), and the pre-existing schedule I had installed was still present and enabled afterwards.

🤖 Generated with [Claude Code](https://claude.com/claude-code)